### PR TITLE
Add ThemeProvider to support explicitly light/dark UI

### DIFF
--- a/src/design-system/components/Box/Box.tsx
+++ b/src/design-system/components/Box/Box.tsx
@@ -8,6 +8,7 @@ import {
   resetElements,
 } from '../../styles/core.css';
 import { backgroundColors, BackgroundColor } from '../../styles/designTokens';
+import { themeClasses } from '../../styles/themeClasses';
 import {
   ColorContextProvider,
   useAccentColorContext,
@@ -76,16 +77,16 @@ export const Box = forwardRef(
                   : backgroundColors[lightThemeBackgroundColor][
                       lightThemeColorContext
                     ].setColorContext) === 'light'
-                  ? 'lightTheme-lightContext'
-                  : 'lightTheme-darkContext',
+                  ? themeClasses.lightTheme.lightContext
+                  : themeClasses.lightTheme.darkContext,
 
                 (darkThemeBackgroundColor === 'accent'
                   ? accentColorContext
                   : backgroundColors[darkThemeBackgroundColor][
                       darkThemeColorContext
                     ].setColorContext) === 'light'
-                  ? 'darkTheme-lightContext'
-                  : 'darkTheme-darkContext',
+                  ? themeClasses.darkTheme.lightContext
+                  : themeClasses.darkTheme.darkContext,
               ]
             : null,
           className,

--- a/src/design-system/components/Box/ColorContext.tsx
+++ b/src/design-system/components/Box/ColorContext.tsx
@@ -13,6 +13,7 @@ import {
   ColorContext,
 } from '../../styles/designTokens';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { themeClasses } from '../../styles/themeClasses';
 
 export interface ColorContextValue {
   lightThemeColorContext: ColorContext;
@@ -106,5 +107,35 @@ export function AccentColorProvider({
         <div style={style}>{children}</div>
       )}
     </AccentColorContext.Provider>
+  );
+}
+
+interface ThemeProviderProps {
+  theme: ColorContext;
+  children: ReactNode | ((args: { className: string }) => ReactNode);
+}
+
+const lightContextClasses = `${themeClasses.lightTheme.lightContext} ${themeClasses.darkTheme.lightContext}`;
+const darkContextClasses = `${themeClasses.lightTheme.darkContext} ${themeClasses.darkTheme.darkContext}`;
+
+export function ThemeProvider({ theme, children }: ThemeProviderProps) {
+  const className = theme === 'dark' ? darkContextClasses : lightContextClasses;
+
+  return (
+    <ColorContext.Provider
+      value={useMemo(
+        () => ({
+          lightThemeColorContext: theme,
+          darkThemeColorContext: theme,
+        }),
+        [theme],
+      )}
+    >
+      {typeof children === 'function' ? (
+        children({ className })
+      ) : (
+        <div className={className}>{children}</div>
+      )}
+    </ColorContext.Provider>
   );
 }

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,4 +1,8 @@
-export { AccentColorProvider } from './components/Box/ColorContext';
+export { initTheming } from './styles/initTheming';
+export {
+  AccentColorProvider,
+  ThemeProvider,
+} from './components/Box/ColorContext';
 export { Box } from './components/Box/Box';
 export { boxStyles, textStyles } from './styles/core.css';
 export { Text } from './components/Text/Text';

--- a/src/design-system/styles/core.css.ts
+++ b/src/design-system/styles/core.css.ts
@@ -1,3 +1,4 @@
+import { themeClasses, rootThemeClasses } from './themeClasses';
 import {
   style,
   globalStyle,
@@ -96,20 +97,20 @@ const semanticColorVars = createThemeContract({
   foregroundColors: mapValues(foregroundColors, () => null),
 });
 
-globalStyle('html.lightTheme', {
+globalStyle(`html.${rootThemeClasses.lightTheme}`, {
   backgroundColor: backgroundColors.surfacePrimary.light.color,
   vars: { [accentColorVar]: backgroundColors.blue.light.color },
 });
 
-globalStyle('html.darkTheme', {
+globalStyle(`html.${rootThemeClasses.darkTheme}`, {
   backgroundColor: backgroundColors.surfacePrimary.dark.color,
   vars: { [accentColorVar]: backgroundColors.blue.dark.color },
 });
 
 globalStyle(
   [
-    'html.lightTheme .lightTheme-lightContext > *',
-    'html.darkTheme .darkTheme-lightContext > *',
+    `html.${rootThemeClasses.lightTheme} .${themeClasses.lightTheme.lightContext} > *`,
+    `html.${rootThemeClasses.darkTheme} .${themeClasses.darkTheme.lightContext} > *`,
   ].join(', '),
   {
     vars: assignVars(semanticColorVars, {
@@ -121,8 +122,8 @@ globalStyle(
 
 globalStyle(
   [
-    'html.darkTheme .darkTheme-darkContext > *',
-    'html.lightTheme .lightTheme-darkContext > *',
+    `html.${rootThemeClasses.lightTheme} .${themeClasses.lightTheme.darkContext} > *`,
+    `html.${rootThemeClasses.darkTheme} .${themeClasses.darkTheme.darkContext} > *`,
   ].join(', '),
   {
     vars: assignVars(semanticColorVars, {
@@ -173,8 +174,8 @@ const boxBaseProperties = defineProperties({
 
 const boxColorProperties = defineProperties({
   conditions: {
-    light: { selector: 'html.lightTheme &' },
-    dark: { selector: 'html.darkTheme &' },
+    light: { selector: `html.${rootThemeClasses.lightTheme} &` },
+    dark: { selector: `html.${rootThemeClasses.darkTheme} &` },
   },
   defaultCondition: ['light', 'dark'],
   properties: {

--- a/src/design-system/styles/initTheming.ts
+++ b/src/design-system/styles/initTheming.ts
@@ -1,0 +1,26 @@
+import { themeClasses, rootThemeClasses } from './themeClasses';
+
+export function initTheming() {
+  const setTheme = (theme: 'dark' | 'light') => {
+    document.documentElement.classList.remove(
+      ...Object.values(rootThemeClasses),
+    );
+    document.documentElement.classList.add(
+      rootThemeClasses[theme === 'dark' ? 'darkTheme' : 'lightTheme'],
+    );
+  };
+
+  const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  setTheme(darkModeMediaQuery.matches ? 'dark' : 'light');
+
+  // Update the theme if the user changes their OS preference
+  darkModeMediaQuery.addEventListener('change', ({ matches: isDark }) => {
+    setTheme(isDark ? 'dark' : 'light');
+  });
+
+  // Set the initial color contexts to match their respective themes
+  document.body.classList.add(
+    themeClasses.lightTheme.lightContext,
+    themeClasses.darkTheme.darkContext,
+  );
+}

--- a/src/design-system/styles/themeClasses.ts
+++ b/src/design-system/styles/themeClasses.ts
@@ -1,0 +1,15 @@
+export const rootThemeClasses = {
+  lightTheme: 'lt',
+  darkTheme: 'dt',
+};
+
+export const themeClasses = {
+  lightTheme: {
+    lightContext: 'lt-lc',
+    darkContext: 'lt-dc',
+  },
+  darkTheme: {
+    lightContext: 'dt-lc',
+    darkContext: 'dt-dc',
+  },
+};

--- a/src/entries/popup/index.ts
+++ b/src/entries/popup/index.ts
@@ -3,25 +3,10 @@ import './global.css';
 import { createElement } from 'react';
 import ReactDOM from 'react-dom';
 
+import { initTheming } from '~/design-system';
 import { App } from './App';
 
-const setTheme = (theme: 'dark' | 'light') => {
-  document.documentElement.classList.remove('lightTheme', 'darkTheme');
-  document.documentElement.classList.add(
-    theme === 'dark' ? 'darkTheme' : 'lightTheme',
-  );
-};
-
-const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-setTheme(darkModeMediaQuery.matches ? 'dark' : 'light');
-
-// Update the theme if the user changes their OS preference
-darkModeMediaQuery.addEventListener('change', ({ matches: isDark }) => {
-  setTheme(isDark ? 'dark' : 'light');
-});
-
-// Set the initial color contexts to match their respective themes
-document.body.classList.add('lightTheme-lightContext', 'darkTheme-darkContext');
+initTheming();
 
 const domContainer = document.querySelector('#app');
 ReactDOM.render(createElement(App), domContainer);

--- a/src/entries/popup/pages/index.tsx
+++ b/src/entries/popup/pages/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useBalance } from 'wagmi';
 import { useFirstTransactionTimestamp } from '~/core/resources/transactions';
 import { Storage } from '~/core/storage';
-import { AccentColorProvider, Box, Text } from '~/design-system';
+import { AccentColorProvider, ThemeProvider, Box, Text } from '~/design-system';
 
 export function Index() {
   const [status, setStatus] = useState(0);
@@ -67,6 +67,22 @@ export function Index() {
           </Text>
         </Box>
       </AccentColorProvider>
+      <Box display="flex" flexDirection="column" gap="16px">
+        <ThemeProvider theme="dark">
+          <Box padding="12px" background="surfacePrimary">
+            <Text size="17pt" weight="bold" color="label" align="center">
+              Dark theme via ThemeProvider
+            </Text>
+          </Box>
+        </ThemeProvider>
+        <ThemeProvider theme="light">
+          <Box padding="12px" background="surfacePrimary">
+            <Text size="17pt" weight="bold" color="label" align="center">
+              Light theme via ThemeProvider
+            </Text>
+          </Box>
+        </ThemeProvider>
+      </Box>
       <Box display="flex" flexDirection="row" gap="8px">
         <Text size="17pt" weight="bold" color="labelTertiary">
           Injecting?


### PR DESCRIPTION
Fixes BX-10

## What changed (plus any additional context for devs)

You can now explicitly set portions of the app to be dark or light, regardless of the theme of the surrounding app.

I've also refactored the code so the global theme classes are now referenced via a JS object so that we can guarantee they're correct.

## Screen recordings / screenshots

<img width="312" alt="Screen Shot 2022-10-14 at 2 29 34 pm" src="https://user-images.githubusercontent.com/696693/195755961-027f1f97-b4a5-4726-bc21-af4b385699d2.png">


## Final checklist

- [x] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [x] I have tested my changes in Chrome & Brave.
- [x] If your changes are visual, did you check both the light and dark themes?
