### PR TITLE
Migrate to standard web type scale, add letter spacing

### DIFF
--- a/src/design-system/styles/core.css.ts
+++ b/src/design-system/styles/core.css.ts
@@ -213,13 +213,20 @@ const fontMetrics = {
   unitsPerEm: 2048,
 };
 
-function fontSize(fontSize: number, lineHeight: number | `${number}%`) {
+function defineType(
+  fontSize: number,
+  lineHeight: number | `${number}%`,
+  letterSpacing: number,
+) {
   const leading =
     typeof lineHeight === 'number'
       ? lineHeight
       : (fontSize * parseInt(lineHeight)) / 100;
 
-  return capsize({ fontMetrics, fontSize, leading });
+  return {
+    ...capsize({ fontMetrics, fontSize, leading }),
+    letterSpacing,
+  };
 }
 
 const textProperties = defineProperties({
@@ -230,25 +237,20 @@ const textProperties = defineProperties({
     },
     fontFamily: { rounded: 'SFRounded' },
     fontSize: {
-      '11pt': fontSize(11, 14),
-      '12pt': fontSize(12, 16),
-      '13pt': fontSize(13, 18),
-      '13pt / 135%': fontSize(13, '135%'),
-      '13pt / 150%': fontSize(13, '150%'),
-      '15pt': fontSize(15, 20),
-      '15pt / 135%': fontSize(15, '135%'),
-      '15pt / 150%': fontSize(15, '150%'),
-      '17pt': fontSize(17, 22),
-      '17pt / 135%': fontSize(17, '135%'),
-      '17pt / 150%': fontSize(17, '150%'),
-      '20pt': fontSize(20, 24),
-      '20pt / 135%': fontSize(20, '135%'),
-      '20pt / 150%': fontSize(20, '150%'),
-      '22pt': fontSize(22, 28),
-      '26pt': fontSize(26, 32),
-      '30pt': fontSize(30, 37),
-      '34pt': fontSize(34, 41),
-      '44pt': fontSize(44, 52),
+      '11pt': defineType(11, 13, 0.56),
+      '12pt': defineType(12, 15, 0.52),
+      '14pt': defineType(14, 19, 0.48),
+      '14pt / 135%': defineType(14, '135%', 0.48),
+      '14pt / 155%': defineType(14, '150%', 0.48),
+      '16pt': defineType(16, 21, 0.35),
+      '16pt / 135%': defineType(16, '135%', 0.35),
+      '16pt / 155%': defineType(16, '150%', 0.35),
+      '20pt': defineType(20, 25, 0.36),
+      '20pt / 135%': defineType(20, '135%', 0.36),
+      '20pt / 150%': defineType(20, '150%', 0.36),
+      '23pt': defineType(23, 29, 0.35),
+      '26pt': defineType(26, 32, 0.36),
+      '32pt': defineType(32, 40, 0.41),
     },
     fontWeight: {
       regular: 400,

--- a/src/entries/popup/components/InjectToggle.tsx
+++ b/src/entries/popup/components/InjectToggle.tsx
@@ -23,11 +23,11 @@ export function InjectToggle() {
   return (
     <>
       <Box display="flex" flexDirection="row" gap="8px">
-        <Text size="17pt" weight="bold" color="labelTertiary">
+        <Text size="14pt" weight="bold" color="labelTertiary">
           Injecting?
         </Text>
         <Text
-          size="17pt"
+          size="14pt"
           weight="bold"
           color={status ? 'green' : 'red'}
           testId="injection-status"
@@ -43,7 +43,7 @@ export function InjectToggle() {
         padding="16px"
         style={{ borderRadius: 999 }}
       >
-        <Text color="labelSecondary" size="15pt" weight="bold">
+        <Text color="labelSecondary" size="14pt" weight="bold">
           TURN {status ? 'OFF' : 'ON'}
         </Text>
       </Box>

--- a/src/entries/popup/pages/_playgrounds/default.tsx
+++ b/src/entries/popup/pages/_playgrounds/default.tsx
@@ -26,14 +26,14 @@ export function Default() {
           Rainbow Rocks!!!
         </Text>
         <Stack space="16px">
-          <Text size="17pt" weight="bold" color="labelSecondary">
+          <Text size="14pt" weight="bold" color="labelSecondary">
             Mainnet Balance: {mainnetBalance?.formatted}
           </Text>
-          <Text size="17pt" weight="bold" color="labelSecondary">
+          <Text size="14pt" weight="bold" color="labelSecondary">
             Polygon Balance: {polygonBalance?.formatted}
           </Text>
           {firstTransactionTimestamp && (
-            <Text size="17pt" weight="bold" color="labelTertiary">
+            <Text size="14pt" weight="bold" color="labelTertiary">
               First transaction on:{' '}
               {new Date(firstTransactionTimestamp).toString()}
             </Text>
@@ -47,7 +47,7 @@ export function Default() {
           padding="16px"
           style={{ borderRadius: 999 }}
         >
-          <Text color="labelSecondary" size="15pt" weight="bold">
+          <Text color="labelSecondary" size="14pt" weight="bold">
             CLEAR STORAGE
           </Text>
         </Box>

--- a/src/entries/popup/pages/_playgrounds/ds.tsx
+++ b/src/entries/popup/pages/_playgrounds/ds.tsx
@@ -37,7 +37,7 @@ function Placeholder({
 
 function SectionHeading({ children }: { children: string }) {
   return (
-    <Text size="17pt" weight="bold" color="labelSecondary">
+    <Text size="14pt" weight="bold" color="label">
       {children}
     </Text>
   );
@@ -45,7 +45,7 @@ function SectionHeading({ children }: { children: string }) {
 
 function ExampleHeading({ children }: { children: string }) {
   return (
-    <Text size="15pt" weight="medium" color="labelTertiary">
+    <Text size="14pt" weight="medium" color="labelSecondary">
       {children}
     </Text>
   );
@@ -67,11 +67,11 @@ export function DesignSystem() {
                   padding="12px"
                   style={{ borderRadius: 999 }}
                 >
-                  <Text size="17pt" weight="bold" align="center">
+                  <Text size="14pt" weight="bold" align="center">
                     Default accent background
                   </Text>
                 </Box>
-                <Text size="17pt" weight="bold" color="accent" align="center">
+                <Text size="14pt" weight="bold" color="accent" align="center">
                   Default accent foreground
                 </Text>
               </Stack>
@@ -82,11 +82,11 @@ export function DesignSystem() {
                     padding="12px"
                     style={{ borderRadius: 999 }}
                   >
-                    <Text size="17pt" weight="bold" align="center">
+                    <Text size="14pt" weight="bold" align="center">
                       Custom accent background
                     </Text>
                   </Box>
-                  <Text size="17pt" weight="bold" color="accent" align="center">
+                  <Text size="14pt" weight="bold" color="accent" align="center">
                     Custom accent foreground
                   </Text>
                 </Stack>
@@ -95,7 +95,7 @@ export function DesignSystem() {
                 <ThemeProvider theme="dark">
                   <Box padding="12px" background="surfacePrimary">
                     <Text
-                      size="17pt"
+                      size="14pt"
                       weight="bold"
                       color="label"
                       align="center"
@@ -107,7 +107,7 @@ export function DesignSystem() {
                 <ThemeProvider theme="light">
                   <Box padding="12px" background="surfacePrimary">
                     <Text
-                      size="17pt"
+                      size="14pt"
                       weight="bold"
                       color="label"
                       align="center"

--- a/src/entries/popup/pages/index.tsx
+++ b/src/entries/popup/pages/index.tsx
@@ -28,7 +28,7 @@ export function Index() {
           padding="16px"
           style={{ borderRadius: 999, width: '100%' }}
         >
-          <Text color="labelSecondary" size="15pt" weight="bold">
+          <Text color="labelSecondary" size="14pt" weight="bold">
             Settings
           </Text>
         </Box>

--- a/src/entries/popup/pages/settings.tsx
+++ b/src/entries/popup/pages/settings.tsx
@@ -27,7 +27,7 @@ export function Settings() {
           padding="16px"
           style={{ borderRadius: 999, width: '100%' }}
         >
-          <Text color="labelSecondary" size="15pt" weight="bold">
+          <Text color="labelSecondary" size="14pt" weight="bold">
             Home
           </Text>
         </Box>


### PR DESCRIPTION
Fixes BX-44
Figma link: https://www.figma.com/file/9ewSwi4D4jEQX6bcE0WEqe/RDS-Web?node-id=2%3A3

## What changed (plus any additional context for devs)

I accidentally used the native type scale instead of web, so this migrates us to the correct values, while also adding letter spacing values.

## Final checklist

- [x] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [x] I have tested my changes in Chrome & Brave.
- [x] If your changes are visual, did you check both the light and dark themes?
