### PR TITLE
Run CI on master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Not sure if this was left out intentionally, but should we be running CI on `master`?