### PR TITLE
Add ability for messengers to be scoped via an `id`

### DIFF
--- a/src/core/messengers/README.md
+++ b/src/core/messengers/README.md
@@ -1,0 +1,104 @@
+# Messengers
+
+> Adapted from the [Cross-script Messaging section](https://www.notion.so/rainbowdotme/Browser-Extension-4c6de766d4404cc89555f44e3dd4dccb#a0cf10fa28e542b2aad845dcf837efce) of the tech spec.
+
+## What is a messenger?
+
+A **Messenger** abstracts the native messaging APIs (such as: `window.postMessage` & `chrome.runtime.sendMessage`) to make them asynchronous and create a unified API.
+
+- There are three main types of messengers:
+  - `windowMessenger`: A messenger that abstracts that `window` messaging API `window.postMessage` / `window.addEventListener('message')`.
+  - `extensionMessenger`: A messenger that abstracts the chrome runtime messaging API (`chrome.runtime.sendMessage` / `chrome.runtime.onMessage`).
+  - `bridgeMessenger`: A messenger to bridge between scripts that do not have a direct/scoped messenger.
+
+## Example usage
+
+`popup.ts`
+```tsx
+import { extensionMessenger } from '~/core/messengers';
+
+async function example() {
+	const result = await extensionMessenger.send('ping', { foo: 'bar' });
+	console.log(result) // "pong and bar"
+}
+```
+
+`background.ts`
+```tsx
+import { extensionMessenger } from '~/core/messengers';
+
+extensionMessenger.reply('ping', args => {
+  return `pong and ${args.foo}`;
+})
+```
+
+> Note: `extensionMessenger`, `windowMessenger` & `bridgeMessenger` share the same APIs.
+
+## API
+
+### available
+
+Whether or not the messenger is available in the current script type.
+
+Example: `extensionMessenger.available` will be falsy on the "inpage" script type as `chrome.runtime.id` is undefined.
+
+### name
+
+The name of the messenger.
+
+Example: `extensionMessenger.name === "extensionMessenger"`
+
+### send
+
+Sends a message to the `reply` handler. The `reply` handler resides in another script type.
+
+#### Arguments
+
+**topic**
+
+A scoped topic that the `reply` will listen for.
+
+**payload**
+
+The payload to send to the `reply` handler.
+
+**options (optional)**
+
+- **`id`** (optional): Identify & scope the request via an ID.
+
+#### Example
+
+`inpage.ts`
+```tsx
+import { extensionMessenger } from '~/core/messengers';
+
+const response = await bridgeMessenger.send('providerRequest', { id, method, payload }, { id })
+```
+
+### reply
+
+Replies to a message sent via `send`.
+
+#### Arguments
+
+**topic**
+
+A scoped topic that was sent from `send`.
+
+**callback**
+
+- **`payload`**: The payload sent from `send`.
+- **`meta.sender`**: The sender of the message.
+- **`meta.topic`**: The topic provided.
+- **`meta.id`**: An optional scoped identifier.
+
+#### Example
+
+`background.ts`
+```tsx
+import { extensionMessenger } from '~/core/messengers';
+
+const response = await bridgeMessenger.reply('providerRequest', ({ id, method, params }, meta) => {
+  // handle provider request
+})
+```

--- a/src/core/messengers/bridge.ts
+++ b/src/core/messengers/bridge.ts
@@ -22,15 +22,15 @@ const messenger = extensionMessenger.available
 export const bridgeMessenger = createMessenger({
   available: messenger.available,
   name: 'bridgeMessenger',
-  async send(topic, payload) {
+  async send(topic, payload, { id } = {}) {
     // The background script cannot send messages to the content script via
     // `chrome.runtime.sendMessage`, so we must use `chrome.tabs.sendMessage` instead.
     if (!windowMessenger.available) {
       const [activeTab] = await chrome.tabs.query({ active: true });
       if (!activeTab.id) throw new Error('No active tab.');
-      return chrome.tabs.sendMessage(activeTab.id, { topic, payload });
+      return chrome.tabs.sendMessage(activeTab.id, { topic, payload, id });
     }
-    return messenger.send(topic, payload);
+    return messenger.send(topic, payload, { id });
   },
   reply(topic, callback) {
     return messenger.reply(topic, callback);
@@ -45,26 +45,31 @@ export function setupBridgeMessengerRelay() {
   }
 
   // e.g. inpage -> content script -> background
-  windowMessenger.reply<unknown, unknown>('*', async (payload, { topic }) => {
-    if (!topic) return;
+  windowMessenger.reply<unknown, unknown>(
+    '*',
+    async (payload, { topic, id }) => {
+      if (!topic) return;
 
-    const topic_ = topic.replace('> ', '');
-    const response = await extensionMessenger.send<unknown, unknown>(
-      topic_,
-      payload,
-    );
-    return response;
-  });
+      const topic_ = topic.replace('> ', '');
+      const response = await extensionMessenger.send<unknown, unknown>(
+        topic_,
+        payload,
+        { id },
+      );
+      return response;
+    },
+  );
 
   // e.g. background -> content script -> inpage
   extensionMessenger.reply<unknown, unknown>(
     '*',
-    async (payload, { topic }) => {
+    async (payload, { topic, id }) => {
       if (!topic) return;
 
       const response = await windowMessenger.send<unknown, unknown>(
         topic,
         payload,
+        { id },
       );
       return response;
     },

--- a/src/core/messengers/internal/createMessenger.ts
+++ b/src/core/messengers/internal/createMessenger.ts
@@ -1,6 +1,10 @@
 export type CallbackOptions = {
+  /** The sender of the message. */
   sender: chrome.runtime.MessageSender;
+  /** The topic provided. */
   topic: string;
+  /** An optional scoped identifier. */
+  id?: number;
 };
 
 export type CallbackFunction<TPayload, TResponse> = (
@@ -11,13 +15,24 @@ export type CallbackFunction<TPayload, TResponse> = (
 export type Source = 'background' | 'content' | 'inpage' | 'popup';
 
 export type Messenger = {
+  /** Whether or not the messenger is available in the context. */
   available: boolean;
+  /** Name of the messenger */
   name: string;
+  /** Sends a message to the `reply` handler. */
   send: <TPayload, TResponse>(
+    /** A scoped topic that the `reply` will listen for. */
     topic: string,
+    /** The payload to send to the `reply` handler. */
     payload: TPayload,
+    options?: {
+      /** Identify & scope the request via an ID. */
+      id?: string | number;
+    },
   ) => Promise<TResponse>;
+  /** Replies to `send`. */
   reply: <TPayload, TResponse>(
+    /** A scoped topic that was sent from `send`. */
     topic: string,
     callback: CallbackFunction<TPayload, TResponse>,
   ) => () => void;

--- a/src/core/providers/RainbowProvider.ts
+++ b/src/core/providers/RainbowProvider.ts
@@ -58,11 +58,14 @@ export class RainbowProvider extends EventEmitter {
     // eslint-disable-next-line no-plusplus
     const id = this.#requestId++;
 
-    const response = await providerRequestTransport.send({
-      id,
-      method,
-      params,
-    });
+    const response = await providerRequestTransport.send(
+      {
+        id,
+        method,
+        params,
+      },
+      { id },
+    );
 
     if (response.id !== id) return;
     if (response.error) throw response.error;

--- a/src/core/transports/README.md
+++ b/src/core/transports/README.md
@@ -1,0 +1,41 @@
+# Transports
+
+> Adapted from the [Cross-script Messaging section](https://www.notion.so/rainbowdotme/Browser-Extension-4c6de766d4404cc89555f44e3dd4dccb#a0cf10fa28e542b2aad845dcf837efce) of the tech spec.
+
+## What is a transport?
+
+A Transport uses a Messenger internally to create a strongly typed & scoped API.
+
+## Example usage
+
+`inpage.ts`
+```tsx
+import { providerRequestTransport } from '~/core/transports';
+
+window.ethereum = class RainbowProvider {
+  async request({ method, params }) {
+    const { result } = await providerRequestTransport.send({ method, params });
+    return result;
+  }
+}
+```
+
+`background.ts`
+```tsx
+import { providerRequestTransport } from '~/core/transports';
+
+providerRequestTransport.reply(async ({ method, params }) => {
+	let result = null;
+	switch (method) {
+    case 'eth_chainId':
+			result = '0x1';
+			break;
+		case 'eth_requestAccounts':
+			result = ['0x123']
+			break;
+		default:
+			// ...
+  }
+	return { result } 
+})
+```

--- a/src/core/transports/internal/createTransport.ts
+++ b/src/core/transports/internal/createTransport.ts
@@ -20,8 +20,8 @@ export function createTransport<TPayload, TResponse>({
     );
   }
   return {
-    async send(payload: TPayload) {
-      return messenger.send<TPayload, TResponse>(topic, payload);
+    async send(payload: TPayload, { id }: { id: number }) {
+      return messenger.send<TPayload, TResponse>(topic, payload, { id });
     },
     async reply(
       callback: (

--- a/src/entries/popup/components/ApproveMessage.tsx
+++ b/src/entries/popup/components/ApproveMessage.tsx
@@ -9,14 +9,21 @@ export function ApproveMessage() {
   const { window } = useNotificationWindowStore();
 
   const pendingRequest = pendingRequests[0];
+
   const approveRequest = useCallback(() => {
     extensionMessenger.send(`message:${pendingRequest?.id}`, true);
-    if (window?.id) chrome.windows.remove(window.id);
+    // Wait until the message propagates to the background provider.
+    setTimeout(() => {
+      if (window?.id) chrome.windows.remove(window.id);
+    }, 50);
   }, [pendingRequest?.id, window?.id]);
 
   const rejectRequest = useCallback(() => {
     extensionMessenger.send(`message:${pendingRequest?.id}`, false);
-    if (window?.id) chrome.windows.remove(window.id);
+    // Wait until the message propagates to the background provider.
+    setTimeout(() => {
+      if (window?.id) chrome.windows.remove(window.id);
+    }, 50);
   }, [pendingRequest?.id, window?.id]);
 
   return (


### PR DESCRIPTION
## What changed (plus any additional context for devs)

This PR adds the ability for messengers to be scoped via an optional `id` argument, particularly useful for RPC requests to prevent race conditions.

I have had to switch the extension messenger to listen synchronously for a message reply as it is not possible to send back a message via `sendMessage` under a particular scope (have to [filter out the `id` manually](https://github.com/rainbow-me/browser-extension/compare/%40esteban/rpc-requests...jxom/scoped-messengers?expand=1#diff-8198a2490fa628a0332ec2524b427531fc3ad2d015d9e84bae16986d31c85865R30)).


## Screen recordings / screenshots

### Before

<img width="697" alt="Screenshot 2022-10-24 at 7 27 49 am" src="https://user-images.githubusercontent.com/7336481/197416622-22143336-1634-4c0a-8619-8ca364ca2e9d.png">

### After

<img width="763" alt="Screenshot 2022-10-24 at 7 23 55 am" src="https://user-images.githubusercontent.com/7336481/197416627-15c62db1-5352-42b7-bcfe-c9638e28ee69.png">

## What to test

Ensure that the RPC response `id` matches the request `id`.


## Final checklist

- [x] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [x] I have tested my changes in Chrome & Brave.
- [x] If your changes are visual, did you check both the light and dark themes?
