### PR TITLE
Design System: Convert `Box` directional props to horizontal/vertical

### DIFF
--- a/src/design-system/styles/core.css.ts
+++ b/src/design-system/styles/core.css.ts
@@ -179,11 +179,11 @@ const boxBaseProperties = defineProperties({
   },
   shorthands: {
     padding: ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'],
-    paddingX: ['paddingLeft', 'paddingRight'],
-    paddingY: ['paddingTop', 'paddingBottom'],
+    paddingHorizontal: ['paddingLeft', 'paddingRight'],
+    paddingVertical: ['paddingTop', 'paddingBottom'],
     margin: ['marginTop', 'marginBottom', 'marginLeft', 'marginRight'],
-    marginX: ['marginLeft', 'marginRight'],
-    marginY: ['marginTop', 'marginBottom'],
+    marginHorizontal: ['marginLeft', 'marginRight'],
+    marginVertical: ['marginTop', 'marginBottom'],
     placeItems: ['justifyContent', 'alignItems'],
   },
 });


### PR DESCRIPTION
To reach parity with the app, and to also keep props consistent (`Stack`, `Inline`, etc use "vertical" & "horizontal").