### PR TITLE
chore: updates allow scripts and policy

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -624,6 +624,16 @@
         "eslint>strip-ansi>ansi-regex": true
       }
     },
+    "external:../node_modules/uglify-js/tools/node.js": {
+      "builtin": {
+        "fs.readFileSync": true
+      },
+      "globals": {
+        "AST_Node": true,
+        "OutputStream": true,
+        "process.env": true
+      }
+    },
     "file-loader": {
       "builtin": {
         "path": true
@@ -1723,6 +1733,8 @@
       "packages": {
         "copy-webpack-plugin>serialize-javascript": true,
         "esbuild": true,
+        "external:../node_modules/uglify-js/package.json": true,
+        "external:../node_modules/uglify-js/tools/node.js": true,
         "vitest>vite>terser": true,
         "webpack>schema-utils": true,
         "webpack>terser-webpack-plugin>@jridgewell/trace-mapping": true,

--- a/package.json
+++ b/package.json
@@ -185,7 +185,17 @@
       "@foundry-rs/hardhat-anvil>hardhat>ethereumjs-util>ethereum-cryptography>secp256k1": false,
       "@foundry-rs/hardhat-anvil>hardhat>ws>bufferutil": false,
       "@foundry-rs/hardhat-anvil>hardhat>ws>utf-8-validate": false,
-      "esbuild": false
+      "esbuild": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>ethereumjs-util>ethereum-cryptography>secp256k1": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>ethereumjs-vm>core-js-pure": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>keccak": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>web3": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>web3-provider-engine>eth-block-tracker>json-rpc-engine>babelify>babel-core>babel-runtime>core-js": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>websocket>bufferutil": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>ganache-core>websocket>utf-8-validate": false,
+      "@foundry-rs/hardhat-anvil>ethereum-waffle>@ethereum-waffle/provider>postinstall-postinstall": false,
+      "@foundry-rs/hardhat-anvil>hardhat>ethereum-cryptography>keccak": false,
+      "@foundry-rs/hardhat-anvil>hardhat>ethereum-cryptography>secp256k1": false
     }
   },
   "lint-staged": {


### PR DESCRIPTION
When setting up the repo, I was alerted that some packages were missing configuration in Lavamoat

<img width="1915" alt="image" src="https://user-images.githubusercontent.com/3009331/204391983-d5ae27de-2a3c-40f8-b3e7-4eb4538d8260.png">

After running, `yarn allow-scripts auto`, the following gets added to around `allowScripts` + policy gets updated.

Opening a PR to see if CI passes.
