### PR TITLE
fix: ignored track argument on yarn run generate-manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "// Bumps the pkg.json version": "",
     "bump": "node scripts/bump.js",
     "// Generates the manifest with the new pkg.json version": "",
-    "generate-manifest": "node scripts/generate-manifest.js internal",
+    "generate-manifest": "node scripts/generate-manifest.js",
     "generate-manifest:prod": "node scripts/generate-manifest.js prod",
     "// Generates a build using webpack secured by Lavamoat": "",
     "build": "yarn devmode:off && yarn build:webpack",

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -12,7 +12,7 @@ const tracks = {
   prod: manifestProd,
 };
 
-const track = process.argv[2];
+const track = process.argv[2] || 'internal';
 if (!Object.keys(tracks).includes(track)) {
   console.error('invalid track: %s', track);
   process.exit();


### PR DESCRIPTION
## What changed
- removed `internal` argument on `generate-manifest` command to allow pass through arguments; this fixes ignored `prod` on `yarn generate-manifest prod` which was previously interpreted as `node scripts/generate-manifest.js internal prod`
- added default `internal` track for `generate-manifest` script
