### PR TITLE
fix: swap review speed menu margin

### DIFF
--- a/src/entries/popup/components/TransactionFee/TransactionFee.tsx
+++ b/src/entries/popup/components/TransactionFee/TransactionFee.tsx
@@ -23,6 +23,7 @@ import {
   Text,
 } from '~/design-system';
 import { TextOverflow } from '~/design-system/components/TextOverflow/TextOverflow';
+import { Space } from '~/design-system/styles/designTokens';
 
 import { useDefaultTxSpeed } from '../../hooks/useDefaultTxSpeed';
 import { useSwapGas, useTransactionGas } from '../../hooks/useGas';
@@ -46,6 +47,7 @@ type FeeProps = {
     transactionSpeedSwitched: keyof EventProperties;
     transactionSpeedClicked: keyof EventProperties;
   };
+  speedMenuMarginRight?: Space;
   setSelectedSpeed: React.Dispatch<React.SetStateAction<GasSpeed>>;
   setCustomMaxBaseFee: (maxBaseFee?: string) => void;
   setCustomMaxPriorityFee: (maxPriorityFee?: string) => void;
@@ -62,6 +64,7 @@ function Fee({
   plainTriggerBorder,
   selectedSpeed,
   flashbotsEnabled,
+  speedMenuMarginRight,
   setSelectedSpeed,
   setCustomMaxBaseFee,
   setCustomMaxPriorityFee,
@@ -163,6 +166,7 @@ function Fee({
               accentColor={accentColor}
               plainTriggerBorder={plainTriggerBorder}
               onOpenChange={onSpeedOpenChange}
+              dropdownContentMarginRight={speedMenuMarginRight}
             />
             {chainId === ChainId.mainnet ? (
               <Box
@@ -255,6 +259,7 @@ type SwapFeeProps = {
   assetToBuy?: ParsedSearchAsset;
   enabled?: boolean;
   flashbotsEnabled?: boolean;
+  speedMenuMarginRight?: Space;
 };
 
 export function SwapFee({
@@ -267,6 +272,7 @@ export function SwapFee({
   assetToBuy,
   enabled = true,
   flashbotsEnabled,
+  speedMenuMarginRight,
 }: SwapFeeProps) {
   const { defaultTxSpeed } = useDefaultTxSpeed({ chainId });
   const {
@@ -302,6 +308,7 @@ export function SwapFee({
       currentBaseFee={currentBaseFee}
       baseFeeTrend={baseFeeTrend}
       flashbotsEnabled={false}
+      speedMenuMarginRight={speedMenuMarginRight}
     />
   );
 }

--- a/src/entries/popup/components/TransactionFee/TransactionSpeedsMenu.tsx
+++ b/src/entries/popup/components/TransactionFee/TransactionSpeedsMenu.tsx
@@ -10,6 +10,7 @@ import {
   GasSpeed,
 } from '~/core/types/gas';
 import { Box, Inline, Stack, Symbol, Text } from '~/design-system';
+import { Space } from '~/design-system/styles/designTokens';
 
 import {
   DropdownMenu,
@@ -95,6 +96,7 @@ export const SwitchSpeedMenuSelector = ({
 };
 
 interface SwitchTransactionSpeedMenuProps {
+  dropdownContentMarginRight?: Space;
   selectedSpeed: GasSpeed;
   gasFeeParamsBySpeed: GasFeeParamsBySpeed | GasFeeLegacyParamsBySpeed | null;
   chainId: Chain['id'];
@@ -106,6 +108,7 @@ interface SwitchTransactionSpeedMenuProps {
 }
 
 export const SwitchTransactionSpeedMenu = ({
+  dropdownContentMarginRight,
   selectedSpeed,
   gasFeeParamsBySpeed,
   onSpeedChanged,
@@ -152,7 +155,10 @@ export const SwitchTransactionSpeedMenu = ({
       <DropdownMenuTrigger asChild accentColor={accentColor}>
         {menuTrigger}
       </DropdownMenuTrigger>
-      <DropdownMenuContent accentColor={accentColor}>
+      <DropdownMenuContent
+        marginRight={dropdownContentMarginRight}
+        accentColor={accentColor}
+      >
         <DropdownMenuLabel>{i18n.t('transaction_fee.title')}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuRadioGroup

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
@@ -590,6 +590,7 @@ const SwapReviewSheetWithQuote = ({
                     assetToBuy={assetToBuy}
                     enabled={show}
                     defaultSpeed={selectedGas.option}
+                    speedMenuMarginRight="12px"
                   />
                 </Row>
                 <Row>


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

speed menu in review swap sheet was out of the bottom sheet, this PR adds a margin for that screen

before

<img width="359" alt="image" src="https://user-images.githubusercontent.com/12115171/229840763-85d79a68-685c-4d1b-95eb-fd446e4cbb03.png">


now

<img width="359" alt="image" src="https://user-images.githubusercontent.com/12115171/229840574-2b9604e2-2117-46e0-a03f-c38da0e4eb2d.png">

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
