### PR TITLE
bx-608: create password alignment

### DIFF
--- a/src/entries/popup/components/Navbar/Navbar.tsx
+++ b/src/entries/popup/components/Navbar/Navbar.tsx
@@ -200,7 +200,7 @@ function NavbarButtonWithBack({
         height={height}
         onClick={click}
         symbol={symbol}
-        variant="transparentHover"
+        variant="flat"
         symbolSize={symbolSize}
         tabIndex={0}
       />

--- a/src/entries/popup/pages/createPassword/index.tsx
+++ b/src/entries/popup/pages/createPassword/index.tsx
@@ -89,7 +89,7 @@ export function CreatePassword() {
         onClick={() => setShowOnboardBeforeConnectSheet(false)}
       />
       <FullScreenContainer>
-        <Box alignItems="center" paddingBottom="10px">
+        <Box alignItems="center" paddingBottom="10px" paddingTop="8px">
           <Text size="16pt" weight="bold" color="label" align="center">
             {i18n.t('create_password.title')}
           </Text>


### PR DESCRIPTION
Fixes BX-608
Figma link (if any): https://www.figma.com/file/hzfwKOddfRmeVO4KUsG9wM/Rainbow-BX?node-id=3904%3A160628&t=NlpWqDDKXR3sMNH7-1

## What changed (plus any additional context for devs)
- Spacing in Create Password title
- Removal of transparent icon
- Fixed styling of back arrow (should be `flat` based on designs)

## Screen recordings / screenshots
<img width="591" alt="image" src="https://user-images.githubusercontent.com/3009331/235502012-ccf644f5-9f11-41fd-aad5-0b8df0810cca.png">

<img width="524" alt="image" src="https://user-images.githubusercontent.com/3009331/235502607-33b5799f-4cbf-4b89-a715-7273432546ce.png">



## Final checklist

- [x] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [x] I have tested my changes in Chrome & Brave.
- [x] If your changes are visual, did you check both the light and dark themes?
