### PR TITLE
chore: bump version to 1.0.166

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-extension",
   "license": "GPL-3.0-only",
-  "version": "1.0.165",
+  "version": "1.0.166",
   "scripts": {
     "//enable dev mode": "",
     "devmode:on": "sed -i'' -e 's/IS_DEV.*/IS_DEV=true/g' .env",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -67,7 +67,7 @@
     "notifications"
   ],
   "short_name": "Rainbow",
-  "version": "1.0.165",
+  "version": "1.0.166",
   "web_accessible_resources": [
     {
       "matches": [


### PR DESCRIPTION
Bumps version to `1.0.166` to unblock Chrome Web Store nightly dev build uploads. Dev track builds were failing because the new notification permission justification needed to be manually added and submitted, and the versioning bump step failed. 166 is now released, but not reflected in manifest.json. We may want to run the commit step before the upload step in the future to prevent this.