### PR TITLE
[BX-710] Keyboard shortcut F doesnt work after unfocus on swaps

### DIFF
--- a/src/entries/popup/hooks/swap/useSwapInputs.ts
+++ b/src/entries/popup/hooks/swap/useSwapInputs.ts
@@ -115,38 +115,47 @@ export const useSwapInputs = ({
     }, 100);
   }, [assetToSellMaxValue.amount, setAssetToSellValue]);
 
-  const flipAssets = useCallback(() => {
-    const isCrosschainSwap =
-      assetToSell && assetToBuy && assetToSell.chainId !== assetToBuy.chainId;
-    if (isCrosschainSwap) {
-      setAssetToBuyValue('');
-      setAssetToSellValue(assetToBuyValue);
-      setIndependentField('sellField');
-      focusOnInput(assetToSellInputRef);
-    } else if (independentField === 'buyField') {
-      setAssetToBuyValue('');
-      setAssetToSellValue(independentValue);
-      setIndependentField('sellField');
-      focusOnInput(assetToSellInputRef);
-    } else {
-      setAssetToSellValue('');
-      setAssetToBuyValue(independentValue);
-      setIndependentField('buyField');
-      focusOnInput(assetToBuyInputRef);
-    }
-    setAssetToBuy(assetToSell);
-    setAssetToSell(assetToBuy);
-    setAssetToSellDropdownClosed(true);
-    setAssetToBuyDropdownClosed(true);
-  }, [
-    assetToBuy,
-    assetToBuyValue,
-    assetToSell,
-    independentField,
-    independentValue,
-    setAssetToBuy,
-    setAssetToSell,
-  ]);
+  const flipAssets = useCallback(
+    (noFocus?: boolean) => {
+      const isCrosschainSwap =
+        assetToSell && assetToBuy && assetToSell.chainId !== assetToBuy.chainId;
+      if (isCrosschainSwap) {
+        setAssetToBuyValue('');
+        setAssetToSellValue(assetToBuyValue);
+        setIndependentField('sellField');
+        if (!noFocus) {
+          focusOnInput(assetToSellInputRef);
+        }
+      } else if (independentField === 'buyField') {
+        setAssetToBuyValue('');
+        setAssetToSellValue(independentValue);
+        setIndependentField('sellField');
+        if (!noFocus) {
+          focusOnInput(assetToSellInputRef);
+        }
+      } else {
+        setAssetToSellValue('');
+        setAssetToBuyValue(independentValue);
+        setIndependentField('buyField');
+        if (!noFocus) {
+          focusOnInput(assetToBuyInputRef);
+        }
+      }
+      setAssetToBuy(assetToSell);
+      setAssetToSell(assetToBuy);
+      setAssetToSellDropdownClosed(true);
+      setAssetToBuyDropdownClosed(true);
+    },
+    [
+      assetToBuy,
+      assetToBuyValue,
+      assetToSell,
+      independentField,
+      independentValue,
+      setAssetToBuy,
+      setAssetToSell,
+    ],
+  );
 
   const assetToSellDisplay = useMemo(
     () =>

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -335,6 +335,8 @@ export function Swap() {
         const focusingAssetToSell =
           activeElement === assetToSellInputRef.current;
         const focusingAssetToBuy = activeElement === assetToBuyInputRef.current;
+        const noFocus = !focusingAssetToSell && !focusingAssetToBuy;
+        const tokenSelected = assetToSell || assetToBuy;
         const focusNewInput = () => {
           setTimeout(() => {
             if (focusingAssetToSell) {
@@ -350,6 +352,8 @@ export function Swap() {
         } else if (focusingAssetToBuy && assetToBuy) {
           flipAssets();
           focusNewInput();
+        } else if (noFocus && tokenSelected) {
+          flipAssets(true);
         }
       }
     },
@@ -450,7 +454,7 @@ export function Swap() {
                       borderWidth={'1px'}
                       borderColor="buttonStroke"
                       style={{ width: 42, height: 32, zIndex: 10 }}
-                      onClick={flipAssets}
+                      onClick={() => flipAssets()}
                     >
                       <Box width="full" height="full" alignItems="center">
                         <Inline


### PR DESCRIPTION
## What changed (plus any additional context for devs)
You can now flip asset swap assets without having to have an input focused

## Screen recordings / screenshots

https://recordit.co/a8vJTeK7l6

## What to test

Make sure you can flip assets on the swap screen without needing to focus an input

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
