### PR TITLE
[BX-818][BX-861] Swap flow: disable f and m hotkeys when searching tokens

### DIFF
--- a/src/core/references/shortcuts.ts
+++ b/src/core/references/shortcuts.ts
@@ -173,6 +173,10 @@ export const shortcuts = {
       key: 'ArrowUp',
       modifier: 'altKey',
     },
+    SET_MAX_AMOUNT: {
+      display: 'M',
+      key: 'm',
+    },
     OPEN_NETWORK_MENU: {
       display: 'N',
       key: 'n',

--- a/src/entries/popup/pages/send/ToAddressInput.tsx
+++ b/src/entries/popup/pages/send/ToAddressInput.tsx
@@ -299,6 +299,7 @@ export const ToAddressInput = React.forwardRef<InputRefAPI, ToAddressProps>(
     useImperativeHandle(forwardedRef, () => ({
       blur: () => closeDropdown(),
       focus: () => openDropdown(),
+      isFocused: () => inputRef.current === document.activeElement,
     }));
 
     const onDropdownAction = useCallback(() => {

--- a/src/entries/popup/pages/send/ValueInput.tsx
+++ b/src/entries/popup/pages/send/ValueInput.tsx
@@ -3,7 +3,6 @@ import React, { useImperativeHandle } from 'react';
 
 import { i18n } from '~/core/languages';
 import { SupportedCurrencyKey, supportedCurrencies } from '~/core/references';
-import { shortcuts } from '~/core/references/shortcuts';
 import { ParsedAddressAsset } from '~/core/types/assets';
 import {
   Box,
@@ -20,7 +19,6 @@ import {
 import { TextOverflow } from '~/design-system/components/TextOverflow/TextOverflow';
 
 import { SendInputMask } from '../../components/InputMask/SendInputMask/SendInputMask';
-import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 
 interface InputAPI {
   blur: () => void;
@@ -67,19 +65,6 @@ export const ValueInput = React.forwardRef<InputAPI, ValueInputProps>(
       focus: () => independentFieldRef.current?.focus(),
       isFocused: () => independentFieldRef.current === document.activeElement,
     }));
-
-    useKeyboardShortcut({
-      handler: (e: KeyboardEvent) => {
-        switch (e.key) {
-          case shortcuts.send.SET_MAX_AMOUNT.key:
-            setMaxAssetAmount();
-            break;
-          case shortcuts.send.SWITCH_CURRENCY_LABEL.key:
-            switchIndependentField();
-            break;
-        }
-      },
-    });
 
     return (
       <Box paddingBottom="20px" paddingHorizontal="20px">

--- a/src/entries/popup/pages/send/index.tsx
+++ b/src/entries/popup/pages/send/index.tsx
@@ -321,6 +321,14 @@ export function Send() {
           sendTokenInputRef.current?.focus();
         }
       } else {
+        if (!toAddressInputRef.current?.isFocused?.()) {
+          if (e.key === shortcuts.send.SET_MAX_AMOUNT.key) {
+            setMaxAssetAmount();
+          }
+          if (e.key === shortcuts.send.SWITCH_CURRENCY_LABEL.key) {
+            switchIndependentField();
+          }
+        }
         if (
           e.key === shortcuts.send.OPEN_CONTACT_MENU.key &&
           !valueInputRef.current?.isFocused?.()

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -32,6 +32,7 @@ import {
   ExplainerSheet,
   useExplainerSheetParams,
 } from '../../components/ExplainerSheet/ExplainerSheet';
+import { SWAP_INPUT_MASK_ID } from '../../components/InputMask/SwapInputMask/SwapInputMask';
 import { Navbar } from '../../components/Navbar/Navbar';
 import { SwapFee } from '../../components/TransactionFee/TransactionFee';
 import {
@@ -51,6 +52,7 @@ import {
   useSwapPriceImpact,
 } from '../../hooks/swap/useSwapPriceImpact';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
+import { getActiveElement, getInputIsFocused } from '../../utils/activeElement';
 
 import { SwapReviewSheet } from './SwapReviewSheet/SwapReviewSheet';
 import { SwapSettings } from './SwapSettings/SwapSettings';
@@ -336,8 +338,23 @@ export function Swap() {
   useKeyboardShortcut({
     handler: (e: KeyboardEvent) => {
       if (e.key === shortcuts.swap.FLIP_ASSETS.key) {
-        e.preventDefault();
-        flipAssets();
+        const flippingAfterSearch =
+          getInputIsFocused() && getActiveElement()?.id === SWAP_INPUT_MASK_ID;
+        if (flippingAfterSearch || !getInputIsFocused()) {
+          e.preventDefault();
+          flipAssets();
+        }
+      }
+      if (e.key === shortcuts.swap.SET_MAX_AMOUNT.key) {
+        if (assetToSell) {
+          const maxxingAfterSearch =
+            getInputIsFocused() &&
+            getActiveElement()?.id === SWAP_INPUT_MASK_ID;
+          if (maxxingAfterSearch || !getInputIsFocused()) {
+            e.preventDefault();
+            setAssetToSellMaxValue();
+          }
+        }
       }
     },
   });


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Handling the case where you've focused a search input and cannot use 'm' or 'f' because of shortcuts. I also added the set maximum functionality to the swap page.

## Screen recordings / screenshots
send: https://recordit.co/1jZ9pjBj5N
swap: https://recordit.co/GIb7tQK3M6

## What to test
On Send: The bug happened when you had selected a token to send, but had not used the search bar yet. So pick an asset to send, then pick your destination address afterwards. Ensure that 'f' and 'm' can be typed into the destination search bar.

On Swap: Ensure that 'f' and 'm' can be typed into either search input without the flip or max functionality preventing the character from appearing in the input. Make sure that max works as expected because it's new.

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
