### PR TITLE
Prevent crash when tx fails [Sentry Bug]

### DIFF
--- a/src/entries/popup/pages/messages/SendTransaction/index.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/index.tsx
@@ -109,16 +109,15 @@ export function SendTransaction({
           chainId: txData.chainId as ChainId,
           transaction,
         });
+        approveRequest(result.hash);
+        setWaitingForDevice(false);
+
+        analytics.track(event.dappPromptSendTransactionApproved, {
+          chainId: txData.chainId,
+          dappURL: appHost,
+          dappName: appName,
+        });
       }
-
-      approveRequest(result.hash);
-      setWaitingForDevice(false);
-
-      analytics.track(event.dappPromptSendTransactionApproved, {
-        chainId: txData.chainId,
-        dappURL: appHost,
-        dappName: appName,
-      });
     } finally {
       setWaitingForDevice(false);
       setLoading(false);


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
Post send logic should only run if the tx went through.
Fixes https://rainbow-me.sentry.io/issues/4269716399/?environment=production&project=4504012577112064&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
