### PR TITLE
inject rnbw a default only if invite code was validated

### DIFF
--- a/src/entries/background/handlers/handleTabAndWindowUpdates.ts
+++ b/src/entries/background/handlers/handleTabAndWindowUpdates.ts
@@ -1,6 +1,7 @@
 import { initializeMessenger } from '~/core/messengers';
 import { notificationWindowStore } from '~/core/state';
 import { isDefaultWalletStore } from '~/core/state/currentSettings/isDefaultWallet';
+import { useInviteCodeStore } from '~/core/state/inviteCode';
 import { pendingRequestStore } from '~/core/state/requests';
 
 const bridgeMessenger = initializeMessenger({ connect: 'inpage' });
@@ -26,7 +27,9 @@ export const handleTabAndWindowUpdates = () => {
 
   chrome.tabs.onActivated.addListener(() => {
     bridgeMessenger.send('rainbow_setDefaultProvider', {
-      rainbowAsDefault: isDefaultWalletStore.getState().isDefaultWallet,
+      rainbowAsDefault:
+        useInviteCodeStore.getState().inviteCodeValidated &&
+        isDefaultWalletStore.getState().isDefaultWallet,
     });
   });
 

--- a/src/entries/content/index.ts
+++ b/src/entries/content/index.ts
@@ -1,6 +1,7 @@
 import { initializeMessenger } from '~/core/messengers';
 import { setupBridgeMessengerRelay } from '~/core/messengers/internal/bridge';
 import { isDefaultWalletStore } from '~/core/state/currentSettings/isDefaultWallet';
+import { useInviteCodeStore } from '~/core/state/inviteCode';
 require('../../core/utils/lockdown');
 
 setupBridgeMessengerRelay();
@@ -9,6 +10,8 @@ const inpageMessenger = initializeMessenger({ connect: 'inpage' });
 
 setTimeout(() => {
   inpageMessenger.send('rainbow_setDefaultProvider', {
-    rainbowAsDefault: isDefaultWalletStore.getState().isDefaultWallet,
+    rainbowAsDefault:
+      useInviteCodeStore.getState().inviteCodeValidated &&
+      isDefaultWalletStore.getState().isDefaultWallet,
   });
 }, 1);


### PR DESCRIPTION
Fixes BX-860
Figma link (if any):

## What changed (plus any additional context for devs)

checking for `inviteCodeValidated` before injecting rnbw as default

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
