### PR TITLE
Catch all the trezor init errors

### DIFF
--- a/src/entries/popup/handlers/trezor.ts
+++ b/src/entries/popup/handlers/trezor.ts
@@ -27,7 +27,11 @@ export async function signTransactionFromTrezor(
   transaction: ethers.providers.TransactionRequest,
 ): Promise<string> {
   try {
-    window.TrezorConnect.init(TREZOR_CONFIG);
+    try {
+      window.TrezorConnect.init(TREZOR_CONFIG);
+    } catch (e) {
+      // ignore already initialized error
+    }
     const { from: address } = transaction;
     const provider = getProvider({
       chainId: transaction.chainId,
@@ -110,7 +114,11 @@ export async function signMessageByTypeFromTrezor(
   address: Address,
   messageType: string,
 ): Promise<string> {
-  window.TrezorConnect.init(TREZOR_CONFIG);
+  try {
+    window.TrezorConnect.init(TREZOR_CONFIG);
+  } catch (e) {
+    // ignore already initialized error
+  }
   const path = await getPath(address);
   // Personal sign
   if (messageType === 'personal_sign') {

--- a/src/entries/popup/handlers/wallet.ts
+++ b/src/entries/popup/handlers/wallet.ts
@@ -337,7 +337,11 @@ export const importAccountAtIndex = async (
   switch (type) {
     case 'Trezor':
       {
-        window.TrezorConnect.init(TREZOR_CONFIG);
+        try {
+          window.TrezorConnect.init(TREZOR_CONFIG);
+        } catch (e) {
+          // ignore already initialized error
+        }
         const path = `m/${DEFAULT_HD_PATH}/${index}`;
         const result = await window.TrezorConnect.ethereumGetAddress({
           path,
@@ -388,7 +392,11 @@ export const connectTrezor = async () => {
   //   accountsEnabled: 2,
   // };
   try {
-    window.TrezorConnect.init(TREZOR_CONFIG);
+    try {
+      window.TrezorConnect.init(TREZOR_CONFIG);
+    } catch (e) {
+      // ignore already initialized error
+    }
     const path = `m/${DEFAULT_HD_PATH}`;
 
     const result = await window.TrezorConnect.ethereumGetPublicKey({


### PR DESCRIPTION
Fixes https://rainbow-me.sentry.io/issues/4302749209/?project=4504012577112064&query=is%3Aunresolved&referrer=issue-stream&stream_index=8

Figma link (if any):

## What changed (plus any additional context for devs)
I don't want to initialize trezor connect for everyone all the time, so we're doing it on the fly, however it will throw an error if we do it twice. This is why we're now ignoring the error "TrezorConnect it's already initialized" and continue with the execution.

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
