### PR TITLE
feat: Don't pull yarn cache for CI stages that don't need them

### DIFF
--- a/.github/actions/testSetup/action.yml
+++ b/.github/actions/testSetup/action.yml
@@ -16,7 +16,7 @@ runs:
       name: node_modules.tar.gz
   - name: Unzip node_modules
     shell: 'bash'
-    run: tar xzvf node_modules.tar.gz
+    run: tar xzf node_modules.tar.gz
   - name: Download build artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check for frozen lockfile
         run: yarn check-lockfile
       - name: Zip node_modules
-        run: tar czvf node_modules.tar.gz node_modules/
+        run: tar czf node_modules.tar.gz node_modules/
       - name: Upload deps artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -46,7 +46,7 @@ jobs:
         with:
           name: node_modules.tar.gz
       - name: Unzip node_modules
-        run: tar xzvf node_modules.tar.gz
+        run: tar xzf node_modules.tar.gz
       - uses: actions/checkout@v3
         with:
             repository: 'rainbow-me/browser-extension-env'
@@ -214,7 +214,7 @@ jobs:
         with:
           name: node_modules.tar.gz
       - name: Unzip node_modules
-        run: tar xzvf node_modules.tar.gz
+        run: tar xzf node_modules.tar.gz
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -257,7 +257,7 @@ jobs:
         with:
           name: node_modules.tar.gz
       - name: Unzip node_modules
-        run: tar xzvf node_modules.tar.gz
+        run: tar xzf node_modules.tar.gz
       - name: DS Setup
         run: yarn ds:install
       - name: Graphql Setup


### PR DESCRIPTION
We are already pushing up the `node_modules` directory so pulling a 1.1+GB yarn cache every stage seems to add at least 30s of time that is wasted. I've removed the cache from the stages that don't need them.

I also turned off verbosity for `tar` and `untar`, but this only shaves 1s off. It does make logs harder to read so maybe worth doing regardless.
