### PR TITLE
fix: iframe notification background

### DIFF
--- a/src/entries/iframe/notification.tsx
+++ b/src/entries/iframe/notification.tsx
@@ -43,7 +43,7 @@ export const Notification = ({
   extensionUrl: string;
 }) => {
   const [ref, setRef] = useState<HTMLIFrameElement>();
-  const [ready, setReady] = useState<boolean>(false);
+  const [iframeLoaded, setIframeLoaded] = useState<boolean>(false);
   const [siteTheme, setSiteTheme] = useState<'dark' | 'light'>('dark');
 
   const onRef = (ref: HTMLIFrameElement) => {
@@ -166,7 +166,7 @@ export const Notification = ({
     iframeLink.href = `${extensionUrl}popup.css`;
     iframeLink.rel = 'stylesheet';
     ref?.contentDocument?.head?.appendChild(iframeLink);
-
+    iframeLink.onload = () => setIframeLoaded(true);
     // get the iframe element
     const root = ref?.contentDocument?.getElementsByTagName('html')[0];
     if (root) {
@@ -176,10 +176,9 @@ export const Notification = ({
       // set rnbw theme
       root.setAttribute('class', colorScheme === 'dark' ? 'dt' : 'lt');
     }
-    setReady(true);
   }, [extensionUrl, ref?.contentDocument]);
 
-  return ready ? (
+  return (
     <iframe
       style={{
         top: INJECTED_NOTIFICATION_DIMENSIONS.top,
@@ -200,11 +199,12 @@ export const Notification = ({
             chainId={chainId}
             status={status}
             extensionUrl={extensionUrl}
+            iframeLoaded={iframeLoaded}
           />,
           container,
         )}
     </iframe>
-  ) : null;
+  );
 };
 
 const NotificationComponent = ({
@@ -212,11 +212,13 @@ const NotificationComponent = ({
   siteTheme,
   status,
   extensionUrl,
+  iframeLoaded,
 }: {
   chainId: ChainId;
   siteTheme: 'dark' | 'light';
   status: IN_DAPP_NOTIFICATION_STATUS;
   extensionUrl: string;
+  iframeLoaded: boolean;
 }) => {
   const { title, description } = useMemo(() => {
     switch (status) {
@@ -239,7 +241,7 @@ const NotificationComponent = ({
     }
   }, [chainId, status]);
 
-  return (
+  return iframeLoaded ? (
     <ThemeProvider theme={siteTheme}>
       <Box
         height="full"
@@ -313,5 +315,5 @@ const NotificationComponent = ({
         </Inline>
       </Box>
     </ThemeProvider>
-  );
+  ) : null;
 };


### PR DESCRIPTION
Fixes BX-869
Figma link (if any):

## What changed (plus any additional context for devs)

- fixed original ticket, it was happening because pancake has the document `style` attribute with a lot more information than `color-scheme` so the logic was wrong to get that attribute correctly. I changed it to get that info with regex instead
- also on pancakeswap you can see that for a fraction of a second the css styles aren't loaded on the notification iframe so i'm waiting on `iframeLink.onload` to render the notification so we show the notification when the styles are ready. You can see this bug here https://www.loom.com/share/f9675c3eda1f4065a0081972845c0ddd when i'm on pancake swap
- 

## Screen recordings / screenshots

fix for both issues
https://www.loom.com/share/9a96ae833bf946e4af5bc0c637ccbb3c

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
