### PR TITLE
fix: include optimismL1SecurityFee on type2 tx parsing

### DIFF
--- a/src/core/utils/gas.ts
+++ b/src/core/utils/gas.ts
@@ -207,6 +207,7 @@ export const parseGasFeeParams = ({
   currency,
   additionalTime,
   secondsPerNewBlock,
+  optimismL1SecurityFee,
 }: {
   wei: string;
   speed: GasSpeed;
@@ -222,6 +223,7 @@ export const parseGasFeeParams = ({
   currency: SupportedCurrencyKey;
   additionalTime?: number;
   secondsPerNewBlock: number;
+  optimismL1SecurityFee?: string | null;
 }): GasFeeParams => {
   const maxBaseFee = parseGasFeeParam({
     wei: new BigNumber(multiply(wei, getBaseFeeMultiplier(speed))).toFixed(0),
@@ -258,7 +260,10 @@ export const parseGasFeeParams = ({
   };
 
   const feeAmount = add(maxBaseFee.amount, maxPriorityFeePerGas.amount);
-  const totalWei = multiply(gasLimit, feeAmount);
+  const totalWei = add(
+    multiply(gasLimit, feeAmount),
+    optimismL1SecurityFee || 0,
+  );
   const nativeTotalWei = convertRawAmountToBalance(
     totalWei,
     supportedCurrencies[nativeAsset?.symbol as SupportedCurrencyKey],
@@ -592,6 +597,7 @@ export const parseGasFeeParamsBySpeed = ({
         currency,
         additionalTime,
         secondsPerNewBlock,
+        optimismL1SecurityFee,
       });
 
     return {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

forgot to include optimismL1SecurityFee on parsing method for type 2 txs

this was making the ui show a very low value as tx fee, @welps reported 


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

## Final checklist

- [ ] I have tested my changes in a LavaMoat bundle (`yarn build`).
- [ ] I have tested my changes in Chrome & Brave.
- [ ] If your changes are visual, did you check both the light and dark themes?
