### PR TITLE
Fix external img border radius

### DIFF
--- a/src/entries/popup/components/ExternalImage/ExternalImage.tsx
+++ b/src/entries/popup/components/ExternalImage/ExternalImage.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import omit from 'lodash/omit';
 import * as React from 'react';
 
 import { Box, Text } from '~/design-system';
@@ -61,7 +62,7 @@ const ExternalImage = (
   return (
     <Box style={{ overflow: 'clip' }} borderRadius={props.borderRadius}>
       <img
-        {...props}
+        {...omit(props, 'borderRadius')}
         style={
           props.mask
             ? {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
Fixes this issue

<img width="656" alt="Screen Shot 2023-09-19 at 4 50 45 PM" src="https://github.com/rainbow-me/browser-extension/assets/1247834/b0c7a8a8-7939-44cc-9dfb-ade02a3d0578">




## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
