### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-extension",
   "license": "GPL-3.0-only",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "scripts": {
     "//enable dev mode": "",
     "devmode:on": "sed -i'' -e 's/IS_DEV.*/IS_DEV=true/g' .env",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -68,7 +68,7 @@
     "notifications"
   ],
   "short_name": "Rainbow",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "web_accessible_resources": [
     {
       "matches": [


### PR DESCRIPTION
## Changes
- bump `1.2.25` to `1.2.26` to correct version mismatch caused by simultaneous merging and internal build publish