### PR TITLE
improve wallet switcher banner logic

### DIFF
--- a/src/core/state/appConnectionWalletSwitcher/appConnectionSwitcher.ts
+++ b/src/core/state/appConnectionWalletSwitcher/appConnectionSwitcher.ts
@@ -10,24 +10,8 @@ export interface AppConnectionWalletSwitcherStore {
     Record<Address, boolean>
   >;
   nudgeSheetInteractionsByApp: Record<string, boolean>;
-  addressInAppHasInteractedWithNudgeSheet: ({
-    address,
-    host,
-  }: {
-    address: Address;
-    host?: string;
-  }) => boolean;
   appHasInteractedWithNudgeSheet: ({ host }: { host?: string }) => boolean;
   setNudgeSheetDisabled: () => void;
-  setAddressInAppHasInteractedWithNudgeSheet: ({
-    address,
-    host,
-    interacted,
-  }: {
-    address: Address;
-    host: string;
-    interacted?: boolean;
-  }) => void;
   setAppHasInteractedWithNudgeSheet: ({
     host,
     interacted,
@@ -45,13 +29,6 @@ export const appConnectionWalletSwitcherStore =
       nudgeSheetEnabled: true,
       nudgeSheetInteractionsByAddressByApp: {},
       nudgeSheetInteractionsByApp: {},
-      addressInAppHasInteractedWithNudgeSheet: ({ address, host }) => {
-        const nudgeSheetInteractionsByAddressByApp =
-          get().nudgeSheetInteractionsByAddressByApp;
-        return (
-          !!host && !!nudgeSheetInteractionsByAddressByApp?.[host]?.[address]
-        );
-      },
       appHasInteractedWithNudgeSheet: ({ host }) => {
         const nudgeSheetInteractionsByApp = get().nudgeSheetInteractionsByApp;
         return !!host && !!nudgeSheetInteractionsByApp[host];
@@ -59,22 +36,6 @@ export const appConnectionWalletSwitcherStore =
       setNudgeSheetDisabled: () => {
         set({
           nudgeSheetEnabled: false,
-        });
-      },
-      setAddressInAppHasInteractedWithNudgeSheet: ({
-        address,
-        host,
-        interacted = true,
-      }) => {
-        const nudgeSheetInteractionsByAddressByApp =
-          get().nudgeSheetInteractionsByAddressByApp;
-        set({
-          nudgeSheetInteractionsByAddressByApp: {
-            ...nudgeSheetInteractionsByAddressByApp,
-            [host]: {
-              [address]: interacted,
-            },
-          },
         });
       },
       setAppHasInteractedWithNudgeSheet: ({ host, interacted = true }) => {
@@ -112,7 +73,7 @@ export const appConnectionWalletSwitcherStore =
     {
       persist: {
         name: 'appConnectionWalletSwitcherStore',
-        version: 0,
+        version: 1,
       },
     },
   );

--- a/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
+++ b/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
@@ -76,8 +76,6 @@ export const AppConnectionWatcher = () => {
   const {
     nudgeSheetEnabled,
     appHasInteractedWithNudgeSheet,
-    addressInAppHasInteractedWithNudgeSheet,
-    setAddressInAppHasInteractedWithNudgeSheet,
     setAppHasInteractedWithNudgeSheet,
   } = useAppConnectionWalletSwitcherStore();
 
@@ -124,34 +122,20 @@ export const AppConnectionWatcher = () => {
       shouldAnimateOut.current = true;
       setShowNudgeSheet(true);
       if (dappMetadata?.appHost) {
-        setAddressInAppHasInteractedWithNudgeSheet({
-          address: currentAddress,
-          host: dappMetadata?.appHost,
-        });
         setAppHasInteractedWithNudgeSheet({ host: dappMetadata?.appHost });
       }
       return true;
-    } else if (
-      !addressInAppHasInteractedWithNudgeSheet({
-        address: currentAddress,
-        host: dappMetadata?.appHost,
-      })
-    ) {
+    } else {
       shouldAnimateOut.current = true;
       setShowNudgeBanner(true);
       timeoutRef.current = setTimeout(handleBannerTimeout, 4000);
       return true;
     }
-    shouldAnimateOut.current = false;
-    return false;
   }, [
-    addressInAppHasInteractedWithNudgeSheet,
     appHasInteractedWithNudgeSheet,
-    currentAddress,
     dappMetadata?.appHost,
     handleBannerTimeout,
     nudgeSheetEnabled,
-    setAddressInAppHasInteractedWithNudgeSheet,
     setAppHasInteractedWithNudgeSheet,
   ]);
 

--- a/src/entries/popup/hooks/useAppSession.ts
+++ b/src/entries/popup/hooks/useAppSession.ts
@@ -22,10 +22,8 @@ export function useAppSession({ host = '' }: { host?: string }) {
   } = useAppSessionsStore();
 
   const activeSession = getActiveSession({ host });
-  const {
-    setAddressInAppHasInteractedWithNudgeSheet,
-    clearAppHasInteractedWithNudgeSheet,
-  } = useAppConnectionWalletSwitcherStore();
+  const { clearAppHasInteractedWithNudgeSheet } =
+    useAppConnectionWalletSwitcherStore();
 
   const updateAppSessionAddress = React.useCallback(
     ({ address }: { address: Address }) => {
@@ -100,11 +98,6 @@ export function useAppSession({ host = '' }: { host?: string }) {
       if (newActiveSession) {
         messenger.send(`accountsChanged:${host}`, newActiveSession?.address);
         messenger.send(`chainChanged:${host}`, newActiveSession?.chainId);
-        setAddressInAppHasInteractedWithNudgeSheet({
-          address,
-          host,
-          interacted: false,
-        });
       } else {
         messenger.send(`disconnect:${host}`, []);
         clearAppHasInteractedWithNudgeSheet({
@@ -112,11 +105,7 @@ export function useAppSession({ host = '' }: { host?: string }) {
         });
       }
     },
-    [
-      clearAppHasInteractedWithNudgeSheet,
-      removeSession,
-      setAddressInAppHasInteractedWithNudgeSheet,
-    ],
+    [clearAppHasInteractedWithNudgeSheet, removeSession],
   );
 
   const disconnectAppSession = React.useCallback(() => {


### PR DESCRIPTION
Fixes BX-1042
Figma link (if any):

## What changed (plus any additional context for devs)

check ticket for more details

updated logic

banner sheet will appear the first time you switch account and you haven’t checked the “not show me this again” checkbox, after that the banner nudge will appear for all wallets except for the one that’s connected

## Screen recordings / screenshots


https://github.com/rainbow-me/browser-extension/assets/12115171/d0acca47-f991-4b11-8496-d9b79873b218



<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
