### PR TITLE
Hide unverified token search results for short queries

### DIFF
--- a/src/core/resources/search/tokenSearch.ts
+++ b/src/core/resources/search/tokenSearch.ts
@@ -34,6 +34,7 @@ export type TokenSearchArgs = {
   list: TokenSearchListId;
   threshold: TokenSearchThreshold;
   query: string;
+  disabled?: boolean;
 };
 
 // ///////////////////////////////////////////////
@@ -138,7 +139,15 @@ export async function fetchTokenSearch(
 // Query Hook
 
 export function useTokenSearch(
-  { chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs,
+  {
+    chainId,
+    fromChainId,
+    keys,
+    list,
+    threshold,
+    query,
+    disabled,
+  }: TokenSearchArgs,
   config: QueryConfig<
     TokenSearchResult,
     Error,
@@ -149,6 +158,9 @@ export function useTokenSearch(
   return useQuery(
     tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query }),
     tokenSearchQueryFunction,
-    config,
+    {
+      ...config,
+      enabled: !disabled,
+    },
   );
 }

--- a/src/core/resources/search/tokenSearch.ts
+++ b/src/core/resources/search/tokenSearch.ts
@@ -34,7 +34,6 @@ export type TokenSearchArgs = {
   list: TokenSearchListId;
   threshold: TokenSearchThreshold;
   query: string;
-  disabled?: boolean;
 };
 
 // ///////////////////////////////////////////////
@@ -139,15 +138,7 @@ export async function fetchTokenSearch(
 // Query Hook
 
 export function useTokenSearch(
-  {
-    chainId,
-    fromChainId,
-    keys,
-    list,
-    threshold,
-    query,
-    disabled,
-  }: TokenSearchArgs,
+  { chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs,
   config: QueryConfig<
     TokenSearchResult,
     Error,
@@ -158,9 +149,6 @@ export function useTokenSearch(
   return useQuery(
     tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query }),
     tokenSearchQueryFunction,
-    {
-      ...config,
-      enabled: !disabled,
-    },
+    config,
   );
 }

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -400,7 +400,7 @@ export function useSearchCurrencyLists({
     targetVerifiedAssets,
     targetUnverifiedAssets,
     crosschainExactMatches,
-    disableUnverifiedSearch,
+    enableUnverifiedSearch,
   ]);
 
   return {

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -161,15 +161,19 @@ export function useSearchCurrencyLists({
   const {
     data: targetUnverifiedAssets,
     isLoading: targetUnverifiedAssetsLoading,
-  } = useTokenSearch({
-    chainId: outputChainId,
-    keys,
-    list: 'highLiquidityAssets',
-    threshold,
-    query,
-    fromChainId,
-    disabled: disableUnverifiedSearch,
-  });
+  } = useTokenSearch(
+    {
+      chainId: outputChainId,
+      keys,
+      list: 'highLiquidityAssets',
+      threshold,
+      query,
+      fromChainId,
+    },
+    {
+      enabled: !disableUnverifiedSearch,
+    },
+  );
 
   const { favorites } = useFavoriteAssets();
 

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -67,7 +67,7 @@ export function useSearchCurrencyLists({
   searchQuery?: string;
 }) {
   const query = searchQuery?.toLowerCase() || '';
-  const disableUnverifiedSearch = query.trim().length < 3;
+  const enableUnverifiedSearch = query.trim().length > 2;
 
   const isCrosschainSearch = useMemo(() => {
     return inputChainId && inputChainId !== outputChainId;
@@ -171,7 +171,7 @@ export function useSearchCurrencyLists({
       fromChainId,
     },
     {
-      enabled: !disableUnverifiedSearch,
+      enabled: enableUnverifiedSearch,
     },
   );
 
@@ -369,7 +369,7 @@ export function useSearchCurrencyLists({
         });
       }
 
-      if (targetUnverifiedAssets?.length && !disableUnverifiedSearch) {
+      if (targetUnverifiedAssets?.length && enableUnverifiedSearch) {
         sections.push({
           data: filterAssetsFromFavoritesBridgeAndAssetToSell(
             targetUnverifiedAssets,

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -363,7 +363,7 @@ export function useSearchCurrencyLists({
         });
       }
 
-      if (targetUnverifiedAssets?.length) {
+      if (targetUnverifiedAssets?.length && query.length > 2) {
         sections.push({
           data: filterAssetsFromFavoritesBridgeAndAssetToSell(
             targetUnverifiedAssets,

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -363,7 +363,7 @@ export function useSearchCurrencyLists({
         });
       }
 
-      if (targetUnverifiedAssets?.length && query.length > 2) {
+      if (targetUnverifiedAssets?.length && query.trim().length > 2) {
         sections.push({
           data: filterAssetsFromFavoritesBridgeAndAssetToSell(
             targetUnverifiedAssets,

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -67,6 +67,7 @@ export function useSearchCurrencyLists({
   searchQuery?: string;
 }) {
   const query = searchQuery?.toLowerCase() || '';
+  const disableUnverifiedSearch = query.trim().length < 3;
 
   const isCrosschainSearch = useMemo(() => {
     return inputChainId && inputChainId !== outputChainId;
@@ -167,6 +168,7 @@ export function useSearchCurrencyLists({
     threshold,
     query,
     fromChainId,
+    disabled: disableUnverifiedSearch,
   });
 
   const { favorites } = useFavoriteAssets();
@@ -363,7 +365,7 @@ export function useSearchCurrencyLists({
         });
       }
 
-      if (targetUnverifiedAssets?.length && query.trim().length > 2) {
+      if (targetUnverifiedAssets?.length && !disableUnverifiedSearch) {
         sections.push({
           data: filterAssetsFromFavoritesBridgeAndAssetToSell(
             targetUnverifiedAssets,
@@ -394,6 +396,7 @@ export function useSearchCurrencyLists({
     targetVerifiedAssets,
     targetUnverifiedAssets,
     crosschainExactMatches,
+    disableUnverifiedSearch,
   ]);
 
   return {


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Speeds up the swap output search by filtering out unverified results if the search query length is less than 3 characters