### PR TITLE
[BX-1058] `esc` cant be used to exit txn details (it closes the bx instead)

### DIFF
--- a/src/design-system/components/BottomSheet/BottomSheet.tsx
+++ b/src/design-system/components/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 
 import { POPUP_DIMENSIONS } from '~/core/utils/dimensions';
 import { Box } from '~/design-system';
@@ -9,7 +9,6 @@ import { zIndexes } from '~/entries/popup/utils/zIndexes';
 interface BottomSheetProps {
   background?: BackgroundColor;
   children: ReactNode;
-  isModal?: boolean;
   show: boolean;
   zIndex?: number;
   onClickOutside?: VoidFunction;
@@ -18,11 +17,17 @@ interface BottomSheetProps {
 export const BottomSheet = ({
   background,
   children,
-  isModal = true,
   show,
   zIndex,
   onClickOutside,
 }: BottomSheetProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // capture focus on mount so that keystroke events are handled
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
   return (
     <AnimatePresence>
       {show && (
@@ -45,6 +50,8 @@ export const BottomSheet = ({
             exit={{ opacity: 0 }}
             key="background"
             transition={{ duration: 0.3 }}
+            ref={containerRef}
+            tabIndex={0}
           />
           <Box
             position="absolute"
@@ -61,7 +68,7 @@ export const BottomSheet = ({
             key="bottom"
             transition={{ duration: 0.3 }}
             layout
-            isModal={isModal}
+            isModal
           >
             <Box
               background="surfacePrimaryElevated"

--- a/src/entries/popup/components/Navbar/Navbar.tsx
+++ b/src/entries/popup/components/Navbar/Navbar.tsx
@@ -171,6 +171,7 @@ function NavbarButtonWithBack({
   symbolSize,
   testId,
   variant = 'flat',
+  withinModal,
 }: {
   height: ButtonSymbolProps['height'];
   onClick?: () => void;
@@ -178,6 +179,7 @@ function NavbarButtonWithBack({
   symbolSize?: SymbolProps['size'];
   testId?: string;
   variant?: 'flat' | 'transparent' | 'transparentHover';
+  withinModal?: boolean;
 }) {
   const { state } = useLocation();
   const { trackShortcut } = useKeyboardAnalytics();
@@ -188,7 +190,7 @@ function NavbarButtonWithBack({
       const closeWithEscape =
         e.key === shortcuts.global.CLOSE.key &&
         !radixIsActive() &&
-        !getActiveModal();
+        (withinModal || !getActiveModal());
       if (
         closeWithEscape ||
         (!getInputIsFocused() && e.key === shortcuts.global.BACK.key)
@@ -249,10 +251,12 @@ export function NavbarCloseButton({
   onClick,
   testId,
   variant,
+  withinModal,
 }: {
   onClick?: () => void;
   testId?: string;
   variant?: 'flat' | 'transparent' | 'transparentHover';
+  withinModal?: boolean;
 }) {
   return (
     <NavbarButtonWithBack
@@ -262,6 +266,7 @@ export function NavbarCloseButton({
       symbol="xmark"
       testId={testId}
       variant={variant}
+      withinModal={withinModal}
     />
   );
 }

--- a/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
@@ -677,9 +677,9 @@ function ActivityDetailsSheet({
     });
 
   return (
-    <BottomSheet zIndex={zIndexes.ACTIVITY_DETAILS} isModal={false} show>
+    <BottomSheet zIndex={zIndexes.ACTIVITY_DETAILS} show>
       <Navbar
-        leftComponent={<Navbar.CloseButton onClick={backToHome} />}
+        leftComponent={<Navbar.CloseButton onClick={backToHome} withinModal />}
         titleComponent={<ActivityPill transaction={tx} />}
         rightComponent={<MoreOptions transaction={tx} />}
       />


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Our navigation header back and close buttons usually check for a modal before moving back a page, but they were not configured to know what to do if they were inside of a modal. Transaction details is a full page screen that utilizes these keybinding and mostly behaves like a standalone screen. I added the `withinModal` prop to the back and close buttons to handle this case correctly. I also added an effect on mount to make transaction details captures focus in case something tries to use a shortcut without clicking on the modal.

## Screen recordings / screenshots

https://recordit.co/W0xu64Z7V3

## What to test
Make sure you can close transaction details without having to click on the screen.
