### PR TITLE
Update en_US.json

### DIFF
--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -733,7 +733,7 @@
   },
   "seed_reveal": {
     "title": "Your Secret Recovery Phrase",
-    "write_down_seed_importance": "Store these words can access your entire wallet! Store them somewhere safe never share them.",
+    "write_down_seed_importance": "Anyone who has these words can access your entire wallet! Write them down somewhere safe and never share them!",
     "saved_these_words": "I've saved these words",
     "phrase_copied": "Recovery Phrase Copied"
   },


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

Updated the "write_down_seed_importance" item in en_US.json from "Store these words can access your entire wallet! Store them somewhere safe never share them." to  "Anyone who has these words can access your entire wallet! Write them down somewhere safe and never share them!" 

Previous wording was confusing.

## Screen recordings / screenshots

Previous wording:
![image](https://github.com/rainbow-me/browser-extension/assets/102825159/61f0dc84-c34e-444a-a667-fef634a1c4d7)


## What to test

<!--

Test to ensure that the wording does not overflow and still appears as it should in the UI.

-->
