### PR TITLE
fix: do not default to mm provider when toggle is off

### DIFF
--- a/src/core/providers/RainbowInjectedProvider.ts
+++ b/src/core/providers/RainbowInjectedProvider.ts
@@ -26,13 +26,6 @@ export type RequestResponse =
       result: any;
     };
 
-const getMetaMaskProvider = () => {
-  return window.walletRouter.providers.find(
-    (provider) =>
-      provider.isMetaMask && !(provider as RainbowInjectedProvider).isRainbow,
-  );
-};
-
 /**
  * The provider injected into `window.ethereum`.
  *
@@ -121,17 +114,6 @@ export class RainbowInjectedProvider extends EventEmitter {
       'rainbow_prefetchDappMetadata',
       window.location.href,
     );
-    if (!this.rainbowIsDefaultProvider) {
-      const provider = getMetaMaskProvider();
-      if (provider) {
-        // using RainbowInjectedProvider as type since wagmi Ethereum type is different
-        const response = await (provider as RainbowInjectedProvider).request({
-          method,
-          params,
-        });
-        return response;
-      }
-    }
 
     // eslint-disable-next-line no-plusplus
     const id = this.requestId++;


### PR DESCRIPTION
Fixes BX-1088
Figma link (if any):

## What changed (plus any additional context for devs)

now:

when our default rnbw provider toggle is off and the user has metamask, we're relaying requests to mm provider
this was probably causing the issue, users had the tooggle off, eip6963 was picking rainbow correctly but we were relaying requests to mm

with this pr:
when our default rnbw provider toggle is off and the user has metamask we're still using rainbow provider if the dapp pick the rainbow provider 
this won't affect the window.ethereum override when the rnbw by default tooggle is on since that logic is happening on `inpage`


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
