### PR TITLE
Small typo on L2 check

### DIFF
--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -507,7 +507,7 @@
       "cancel": "Cancel",
       "sending_on_network": "Sending on the %{chainName} network",
       "sending_on_l2_check_1": "I’m not sending to an exchange",
-      "sending_on_l2_check_2": "The person I’m sending to has a wallet that support %{chainName}",
+      "sending_on_l2_check_2": "The person I’m sending to has a wallet that supports %{chainName}",
       "complete_checks": "Complete the checks",
       "confirm_hw": "Confirm on your device"
     }


### PR DESCRIPTION
## What changed

One of the checks when sending tokens to another wallet on L2 has a small typo ;)

"wallet that support %{chainName}" -> "wallet that support**s** %{chainName}"

Sorry, this was just annoying me. Officially my worst PR of the year.

## Screenshots

![image](https://github.com/rainbow-me/browser-extension/assets/22108522/e9ecab47-5d02-43b8-b25b-94882a5083b3)

## What to test

- Click "Send" or press "S"
- Choose any L2 token and any wallet to send to.
- See typo on 2nd check.
