### PR TITLE
Storage refactor

### DIFF
--- a/src/analytics/flushQueuedEvents.ts
+++ b/src/analytics/flushQueuedEvents.ts
@@ -4,7 +4,7 @@ import { analytics } from '.';
 
 export const flushQueuedEvents = async () => {
   const queuedEvents = await SessionStorage.get('queuedEvents');
-  const events = queuedEvents?.queuedEvents || [];
+  const events = queuedEvents || [];
   for (const event of events) {
     analytics.track(event.eventName, event.meta);
   }

--- a/src/analytics/flushQueuedEvents.ts
+++ b/src/analytics/flushQueuedEvents.ts
@@ -1,10 +1,12 @@
+import { SessionStorage } from '~/core/storage';
+
 import { analytics } from '.';
 
 export const flushQueuedEvents = async () => {
-  const queuedEvents = await chrome.storage.session.get('queuedEvents');
+  const queuedEvents = await SessionStorage.get('queuedEvents');
   const events = queuedEvents?.queuedEvents || [];
   for (const event of events) {
     analytics.track(event.eventName, event.meta);
   }
-  chrome.storage.session.set({ queuedEvents: [] });
+  SessionStorage.set('queuedEvents', []);
 };

--- a/src/analytics/queueEvent.ts
+++ b/src/analytics/queueEvent.ts
@@ -2,8 +2,10 @@
 // / It's REALLY important that no other code is imported here,
 // as this code is used in the background script
 
+import { SessionStorage } from '~/core/storage';
+
 export const queueEventTracking = async (eventName: string, meta = {}) => {
-  const queuedEvents = await chrome.storage.session.get('queuedEvents');
+  const queuedEvents = await SessionStorage.get('queuedEvents');
   const events = queuedEvents?.queuedEvents || [];
   const newEvent = {
     eventName,
@@ -13,5 +15,5 @@ export const queueEventTracking = async (eventName: string, meta = {}) => {
     },
   };
   events.push(newEvent);
-  await chrome.storage.session.set({ queuedEvents: events });
+  await SessionStorage.set('queuedEvents', events);
 };

--- a/src/analytics/queueEvent.ts
+++ b/src/analytics/queueEvent.ts
@@ -6,7 +6,7 @@ import { SessionStorage } from '~/core/storage';
 
 export const queueEventTracking = async (eventName: string, meta = {}) => {
   const queuedEvents = await SessionStorage.get('queuedEvents');
-  const events = queuedEvents?.queuedEvents || [];
+  const events = queuedEvents || [];
   const newEvent = {
     eventName,
     meta: {

--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -10,7 +10,7 @@ import {
 import * as Sentry from '@sentry/browser';
 import { Address } from 'wagmi';
 
-import { LocalStorage } from '../storage';
+import { LocalStorage, SessionStorage } from '../storage';
 import { KeychainType } from '../types/keychainTypes';
 import { isLowerCaseMatch } from '../utils/strings';
 
@@ -217,16 +217,16 @@ class KeychainManager {
       },
 
       setSalt: (val: string | null) => {
-        return chrome.storage.session.set({ salt: val });
+        return SessionStorage.set('salt', val);
       },
       getSalt: () => {
-        return chrome.storage.session.get('salt');
+        return SessionStorage.get('salt');
       },
       setEncryptionKey: (val: string | null) => {
-        return chrome.storage.session.set({ encryptionKey: val });
+        return SessionStorage.set('encryptionKey', val);
       },
       getEncryptionKey: () => {
-        return chrome.storage.session.get('encryptionKey');
+        return SessionStorage.get('encryptionKey');
       },
 
       getLastStorageState: () => {
@@ -420,7 +420,7 @@ class KeychainManager {
     privates.get(this).password = '';
 
     await LocalStorage.set('vault', null);
-    await chrome.storage.session.set({ keychainManager: null });
+    await SessionStorage.set('keychainManager', null);
     await privates.get(this).setEncryptionKey(null);
     await privates.get(this).setSalt(null);
   }

--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -10,6 +10,7 @@ import {
 import * as Sentry from '@sentry/browser';
 import { Address } from 'wagmi';
 
+import { LocalStorage } from '../storage';
 import { KeychainType } from '../types/keychainTypes';
 import { isLowerCaseMatch } from '../utils/strings';
 
@@ -212,7 +213,7 @@ class KeychainManager {
           this.state.vault = '';
         }
         // Store them in the fs
-        await chrome.storage.local.set({ vault: this.state.vault });
+        await LocalStorage.set('vault', this.state.vault);
       },
 
       setSalt: (val: string | null) => {
@@ -229,7 +230,7 @@ class KeychainManager {
       },
 
       getLastStorageState: () => {
-        return chrome.storage.local.get('vault');
+        return LocalStorage.get('vault');
       },
     });
 
@@ -418,7 +419,7 @@ class KeychainManager {
 
     privates.get(this).password = '';
 
-    await chrome.storage.local.set({ vault: null });
+    await LocalStorage.set('vault', null);
     await chrome.storage.session.set({ keychainManager: null });
     await privates.get(this).setEncryptionKey(null);
     await privates.get(this).setSalt(null);

--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -71,7 +71,7 @@ class KeychainManager {
             this.state.vault = storageState.vault;
           }
 
-          const { encryptionKey } = await privates.get(this).getEncryptionKey();
+          const encryptionKey = await privates.get(this).getEncryptionKey();
           if (encryptionKey) {
             const key = await importKey(encryptionKey);
             const vault = (await decryptWithKey(
@@ -183,7 +183,7 @@ class KeychainManager {
         // Encrypt the serialized keychains
         const pwd = privates.get(this).password;
         const { encryptionKey } = await privates.get(this).getEncryptionKey();
-        const { salt } = await privates.get(this).getSalt();
+        const salt = await privates.get(this).getSalt();
 
         if (serializedKeychains.length > 0) {
           const result = { vault: '', exportedKeyString: '', salt: '' };

--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -66,9 +66,9 @@ class KeychainManager {
       rehydrate: async () => {
         try {
           // Get the vault from storage
-          const storageState = await privates.get(this).getLastStorageState();
-          if (storageState) {
-            this.state.vault = storageState.vault;
+          const vault = await privates.get(this).getLastStorageState();
+          if (vault) {
+            this.state.vault = vault;
           }
 
           const encryptionKey = await privates.get(this).getEncryptionKey();
@@ -182,7 +182,7 @@ class KeychainManager {
 
         // Encrypt the serialized keychains
         const pwd = privates.get(this).password;
-        const { encryptionKey } = await privates.get(this).getEncryptionKey();
+        const encryptionKey = await privates.get(this).getEncryptionKey();
         const salt = await privates.get(this).getSalt();
 
         if (serializedKeychains.length > 0) {
@@ -266,7 +266,7 @@ class KeychainManager {
     if (this.state.vault) {
       return true;
     } else {
-      const { vault } = await privates.get(this).getLastStorageState();
+      const vault = await privates.get(this).getLastStorageState();
       if (vault) {
         return true;
       }

--- a/src/core/react-query/queryClient.ts
+++ b/src/core/react-query/queryClient.ts
@@ -2,7 +2,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { QueryClient } from '@tanstack/react-query';
 import { PersistQueryClientOptions } from '@tanstack/react-query-persist-client';
 
-import { Storage } from '../storage';
+import { LocalStorage } from '../storage';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,9 +21,9 @@ export const queryClient = new QueryClient({
 const asyncStoragePersister = createAsyncStoragePersister({
   key: 'rainbow.react-query',
   storage: {
-    getItem: Storage.get,
-    setItem: Storage.set,
-    removeItem: Storage.remove,
+    getItem: LocalStorage.get,
+    setItem: LocalStorage.set,
+    removeItem: LocalStorage.remove,
   },
 });
 

--- a/src/core/state/internal/persistStorage.ts
+++ b/src/core/state/internal/persistStorage.ts
@@ -1,16 +1,16 @@
 import { StateStorage } from 'zustand/middleware';
 
-import { Storage } from '~/core/storage';
+import { LocalStorage } from '~/core/storage';
 
 export const persistStorage: StateStorage = {
   getItem: async (key: string): Promise<string | null> => {
-    return (await Storage.get(key)) || null;
+    return (await LocalStorage.get(key)) || null;
   },
   setItem: async (key: string, value: string): Promise<void> => {
-    await Storage.set(key, value);
+    await LocalStorage.set(key, value);
   },
   removeItem: async (key: string): Promise<void> => {
-    await Storage.remove(key);
+    await LocalStorage.remove(key);
   },
 };
 

--- a/src/core/state/internal/syncStores.ts
+++ b/src/core/state/internal/syncStores.ts
@@ -1,4 +1,4 @@
-import { Storage } from '~/core/storage';
+import { LocalStorage } from '~/core/storage';
 
 import * as stores from '../index';
 
@@ -21,12 +21,12 @@ async function syncStore({ store }: { store: StoreWithPersist<unknown> }) {
       );
       const version = persistOptions.version;
       const newStore = persistOptions.serialize?.({ state, version });
-      await Storage.set(storageName, newStore);
+      await LocalStorage.set(storageName, newStore);
     }
     store.persist.rehydrate();
   };
 
-  Storage.listen(storageName, listener);
+  LocalStorage.listen(storageName, listener);
 }
 
 export function syncStores() {

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -1,4 +1,4 @@
-export const Storage = {
+export const LocalStorage = {
   async clear() {
     await chrome?.storage?.local?.clear();
   },

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -40,9 +40,17 @@ export const SessionStorage = {
     try {
       await chrome?.storage?.session?.set({ [key]: value });
     } catch (e) {
-      // If we got a quota related error, let's log the size of the keys
-      // that can grow exponentially to see where we are at
-      if ((e as Error)?.message.toLowerCase().indexOf('quota') !== -1) {
+      // This is where the quota error should show up
+      const chromeError = chrome.runtime.lastError?.message;
+
+      if (
+        chromeError?.indexOf('quota') != -1 ||
+        // We're still checking on both places just in case
+        (e as Error)?.message.toLowerCase().indexOf('quota') !== -1
+      ) {
+        // If we got a quota related error, let's log the size of the keys
+        // that can grow exponentially to see where we are at
+
         const queuedEvents = await SessionStorage.get('queuedEvents');
         const rateLimits = await SessionStorage.get('rateLimits');
 

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -29,3 +29,35 @@ export const LocalStorage = {
     return () => chrome.storage?.local?.onChanged?.removeListener(listener);
   },
 };
+
+export const SessionStorage = {
+  async clear() {
+    await chrome?.storage?.session?.clear();
+  },
+  async set(key: string, value: unknown) {
+    await chrome?.storage?.session?.set({ [key]: value });
+  },
+  async get(key: string) {
+    const result = await chrome?.storage?.session?.get(key);
+    return result[key];
+  },
+  async remove(key: string) {
+    await chrome?.storage?.session?.remove(key);
+  },
+  async listen<TValue = unknown>(
+    key: string,
+    callback: (newValue: TValue, oldValue: TValue) => void,
+  ) {
+    const listener = (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => {
+      if (!changes[key] || changes[key]?.newValue === changes[key]?.oldValue)
+        return;
+      const newValue = changes[key]?.newValue;
+      const oldValue = changes[key]?.oldValue;
+      callback(newValue, oldValue);
+    };
+    chrome.storage?.session?.onChanged?.addListener(listener);
+    return () => chrome.storage?.session?.onChanged?.removeListener(listener);
+  },
+};

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -59,7 +59,7 @@ export const SessionStorage = {
           queuedEvents?.length || 0,
         );
         logger.info(
-          'SessionStorage queuedEvents size: ',
+          'SessionStorage rateLimits size: ',
           (rateLimits && Object.keys(rateLimits).length) || 0,
         );
       }

--- a/src/core/utils/settings.ts
+++ b/src/core/utils/settings.ts
@@ -1,12 +1,11 @@
+import { SessionStorage } from '../storage';
 import { KeychainWallet } from '../types/keychainTypes';
 
 export const setSettingWallets = (settingsWallet: null | KeychainWallet) => {
-  chrome.storage.session.set({ settingsWallet });
+  SessionStorage.set('settingsWallet', settingsWallet);
 };
 
 export const getSettingWallets = async (): Promise<KeychainWallet> => {
-  const { settingsWallet } = await chrome.storage.session.get([
-    'settingsWallet',
-  ]);
+  const { settingsWallet } = await SessionStorage.get('settingsWallet');
   return settingsWallet;
 };

--- a/src/core/utils/settings.ts
+++ b/src/core/utils/settings.ts
@@ -6,6 +6,5 @@ export const setSettingWallets = (settingsWallet: null | KeychainWallet) => {
 };
 
 export const getSettingWallets = async (): Promise<KeychainWallet> => {
-  const { settingsWallet } = await SessionStorage.get('settingsWallet');
-  return settingsWallet;
+  return SessionStorage.get('settingsWallet');
 };

--- a/src/core/wagmi/createTestWagmiClient.ts
+++ b/src/core/wagmi/createTestWagmiClient.ts
@@ -18,7 +18,7 @@ import {
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 
 import { queryClient } from '../react-query';
-import { Storage } from '../storage';
+import { LocalStorage } from '../storage';
 
 const noopStorage = {
   getItem: () => '',
@@ -40,9 +40,9 @@ const { chains, provider, webSocketProvider } = configureChains(
 const asyncStoragePersister = createAsyncStoragePersister({
   key: 'rainbow.wagmi',
   storage: {
-    getItem: Storage.get,
-    setItem: Storage.set,
-    removeItem: Storage.remove,
+    getItem: LocalStorage.get,
+    setItem: LocalStorage.set,
+    removeItem: LocalStorage.remove,
   },
 });
 

--- a/src/core/wagmi/createWagmiClient.ts
+++ b/src/core/wagmi/createWagmiClient.ts
@@ -10,7 +10,7 @@ import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 
 import { proxyRpcEndpoint } from '../providers';
 import { queryClient } from '../react-query';
-import { Storage } from '../storage';
+import { LocalStorage } from '../storage';
 import { ChainId, hardhat, hardhatOptimism } from '../types/chains';
 import { SUPPORTED_CHAINS } from '../utils/chains';
 
@@ -83,9 +83,9 @@ const { chains, provider, webSocketProvider } = configureChains(
 const asyncStoragePersister = createAsyncStoragePersister({
   key: 'rainbow.wagmi',
   storage: {
-    getItem: Storage.get,
-    setItem: Storage.set,
-    removeItem: Storage.remove,
+    getItem: LocalStorage.get,
+    setItem: LocalStorage.set,
+    removeItem: LocalStorage.remove,
   },
 });
 

--- a/src/entries/background/handlers/handleDisconnect.ts
+++ b/src/entries/background/handlers/handleDisconnect.ts
@@ -1,11 +1,14 @@
+import { SessionStorage } from '~/core/storage';
+
 const POPUP_INSTANCE_DATA_EXPIRY = 180000;
 export function handleDisconnect() {
   chrome.runtime.onConnect.addListener(function (port) {
     if (port.name === 'popup') {
       port.onDisconnect.addListener(async function () {
-        await chrome.storage.session.set({
-          expiry: Date.now() + POPUP_INSTANCE_DATA_EXPIRY,
-        });
+        await SessionStorage.set(
+          'expiry',
+          Date.now() + POPUP_INSTANCE_DATA_EXPIRY,
+        );
       });
     }
   });

--- a/src/entries/background/handlers/handleProviderRequest.ts
+++ b/src/entries/background/handlers/handleProviderRequest.ts
@@ -121,7 +121,7 @@ const messengerProviderRequest = async (
 };
 
 const resetRateLimit = async (host: string, second: boolean) => {
-  const { rateLimits } = await SessionStorage.get('rateLimits');
+  const rateLimits = await SessionStorage.get('rateLimits');
   if (second) {
     if (rateLimits[host]) {
       rateLimits[host].perSecond = 0;
@@ -139,7 +139,7 @@ const resetRateLimit = async (host: string, second: boolean) => {
 const checkRateLimit = async (host: string) => {
   try {
     // Read from session
-    let { rateLimits } = await SessionStorage.get('rateLimits');
+    let rateLimits = await SessionStorage.get('rateLimits');
 
     // Initialize if needed
     if (rateLimits === undefined) {

--- a/src/entries/background/handlers/handleProviderRequest.ts
+++ b/src/entries/background/handlers/handleProviderRequest.ts
@@ -16,6 +16,7 @@ import {
   notificationWindowStore,
   pendingRequestStore,
 } from '~/core/state';
+import { SessionStorage } from '~/core/storage';
 import { providerRequestTransport } from '~/core/transports';
 import { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
 import { isSupportedChainId } from '~/core/utils/chains';
@@ -120,7 +121,7 @@ const messengerProviderRequest = async (
 };
 
 const resetRateLimit = async (host: string, second: boolean) => {
-  const { rateLimits } = await chrome.storage.session.get('rateLimits');
+  const { rateLimits } = await SessionStorage.get('rateLimits');
   if (second) {
     if (rateLimits[host]) {
       rateLimits[host].perSecond = 0;
@@ -132,13 +133,13 @@ const resetRateLimit = async (host: string, second: boolean) => {
     }
     minuteTimer = null;
   }
-  return chrome.storage.session.set({ rateLimits });
+  return SessionStorage.set('rateLimits', rateLimits);
 };
 
 const checkRateLimit = async (host: string) => {
   try {
     // Read from session
-    let { rateLimits } = await chrome.storage.session.get('rateLimits');
+    let { rateLimits } = await SessionStorage.get('rateLimits');
 
     // Initialize if needed
     if (rateLimits === undefined) {
@@ -177,7 +178,7 @@ const checkRateLimit = async (host: string) => {
     }
 
     // Write to session
-    chrome.storage.session.set({ rateLimits });
+    SessionStorage.set('rateLimits', rateLimits);
 
     // Check rate limits
     if (rateLimits[host].perSecond > MAX_REQUEST_PER_SECOND) {

--- a/src/entries/popup/components/IdleTimer/IdleTimer.tsx
+++ b/src/entries/popup/components/IdleTimer/IdleTimer.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { SessionStorage } from '~/core/storage';
+
 function debounce(func: CallableFunction, delay: number) {
   let timeId: NodeJS.Timeout | undefined;
   return function (...args: unknown[]) {
@@ -13,7 +15,7 @@ function debounce(func: CallableFunction, delay: number) {
 }
 
 const recordActivity = debounce(() => {
-  chrome.storage.session.set({ lastUnlock: new Date().toJSON() });
+  SessionStorage.set('lastUnlock', new Date().toJSON());
 }, 1000);
 
 export const IdleTimer = () => {

--- a/src/entries/popup/components/ImportWallet/ImportWalletSelection.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletSelection.tsx
@@ -29,7 +29,7 @@ import { useImportWalletSessionSecrets } from './useImportWalletSessionSecrets';
 const derivedAccountsStore = {
   get: () =>
     SessionStorage.get('derivedAccountsFromSecrets').then(
-      (r) => (r && r.derivedAccountsFromSecrets) || {},
+      (derivedAccountsFromSecrets) => derivedAccountsFromSecrets || {},
     ) as Promise<Record<string, Address[]>>,
   set: async (derivedAccountsFromSecrets: Record<string, Address[]>) =>
     SessionStorage.set(

--- a/src/entries/popup/components/ImportWallet/ImportWalletSelection.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletSelection.tsx
@@ -3,6 +3,7 @@ import { Address } from 'wagmi';
 
 import { i18n } from '~/core/languages';
 import { useCurrentAddressStore } from '~/core/state';
+import { SessionStorage } from '~/core/storage';
 import {
   Box,
   Button,
@@ -27,14 +28,15 @@ import { useImportWalletSessionSecrets } from './useImportWalletSessionSecrets';
 
 const derivedAccountsStore = {
   get: () =>
-    chrome.storage.session
-      .get({ derivedAccountsFromSecrets: {} })
-      .then((r) => r.derivedAccountsFromSecrets) as Promise<
-      Record<string, Address[]>
-    >,
+    SessionStorage.get('derivedAccountsFromSecrets').then(
+      (r) => (r && r.derivedAccountsFromSecrets) || {},
+    ) as Promise<Record<string, Address[]>>,
   set: async (derivedAccountsFromSecrets: Record<string, Address[]>) =>
-    chrome.storage.session.set({ derivedAccountsFromSecrets }),
-  clear: () => chrome.storage.session.set({ derivedAccountsFromSecrets: {} }),
+    SessionStorage.set(
+      'derivedAccountsFromSecrets',
+      derivedAccountsFromSecrets,
+    ),
+  clear: () => SessionStorage.set('derivedAccountsFromSecrets', {}),
 };
 
 const derivedAccountsFromSecret = async (secret: string) => {

--- a/src/entries/popup/components/_dev/ClearStorage.tsx
+++ b/src/entries/popup/components/_dev/ClearStorage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Storage } from '~/core/storage';
+import { LocalStorage } from '~/core/storage';
 import { Box, Text } from '~/design-system';
 
 export function ClearStorage() {
@@ -9,7 +9,7 @@ export function ClearStorage() {
       as="button"
       background="accent"
       boxShadow="24px accent"
-      onClick={Storage.clear}
+      onClick={LocalStorage.clear}
       padding="16px"
       style={{ borderRadius: 999 }}
     >

--- a/src/entries/popup/handlers/importWalletSecrets.ts
+++ b/src/entries/popup/handlers/importWalletSecrets.ts
@@ -3,7 +3,7 @@ import { SessionStorage } from '~/core/storage';
 export const getImportWalletSecrets = async () => {
   try {
     const result = await SessionStorage.get('importWalletSecrets');
-    return (result['importWalletSecrets'] as string[]) || [''];
+    return (result as string[]) || [''];
   } catch (e) {
     console.log('Error while getting import wallet secrets: ', e);
     return [''];

--- a/src/entries/popup/handlers/importWalletSecrets.ts
+++ b/src/entries/popup/handlers/importWalletSecrets.ts
@@ -1,6 +1,8 @@
+import { SessionStorage } from '~/core/storage';
+
 export const getImportWalletSecrets = async () => {
   try {
-    const result = await chrome.storage.session.get('importWalletSecrets');
+    const result = await SessionStorage.get('importWalletSecrets');
     return (result['importWalletSecrets'] as string[]) || [''];
   } catch (e) {
     console.log('Error while getting import wallet secrets: ', e);
@@ -10,9 +12,7 @@ export const getImportWalletSecrets = async () => {
 
 export const setImportWalletSecrets = async (importWalletSecrets: string[]) => {
   try {
-    await chrome.storage.session.set({
-      importWalletSecrets,
-    });
+    await SessionStorage.set('importWalletSecrets', importWalletSecrets);
   } catch (e) {
     console.log('Error while setting import wallet secrets: ', e);
   }
@@ -20,7 +20,7 @@ export const setImportWalletSecrets = async (importWalletSecrets: string[]) => {
 
 export const removeImportWalletSecrets = async () => {
   try {
-    await chrome.storage.session.remove('importWalletSecrets');
+    await SessionStorage.remove('importWalletSecrets');
   } catch (e) {
     console.log('Error while removing import wallet secrets: ', e);
   }

--- a/src/entries/popup/handlers/wallet.ts
+++ b/src/entries/popup/handlers/wallet.ts
@@ -18,6 +18,7 @@ import {
   WalletExecuteRapProps,
 } from '~/core/raps/references';
 import { gasStore } from '~/core/state';
+import { SessionStorage } from '~/core/storage';
 import {
   TransactionGasParams,
   TransactionLegacyGasParams,
@@ -230,21 +231,21 @@ export const signTypedData = async (
 
 export const lock = async () => {
   await walletAction('lock', {});
-  await chrome.storage.session.set({ userStatus: 'LOCKED' });
+  await SessionStorage.set('userStatus', 'LOCKED');
   return;
 };
 
 export const unlock = async (password: string): Promise<boolean> => {
   const res = await walletAction('unlock', password);
   if (res) {
-    await chrome.storage.session.set({ userStatus: 'READY' });
+    await SessionStorage.set('userStatus', 'READY');
   }
   return res as boolean;
 };
 
 export const wipe = async () => {
   await walletAction('wipe', {});
-  await chrome.storage.session.set({ userStatus: 'NEW' });
+  await SessionStorage.set('userStatus', 'NEW');
   return;
 };
 export const testSandbox = async () => {
@@ -260,7 +261,7 @@ export const updatePassword = async (password: string, newPassword: string) => {
   // We have a password
   // It's unlocked
   // Then it's ready to use
-  await chrome.storage.session.set({ userStatus: 'READY' });
+  await SessionStorage.set('userStatus', 'READY');
   return ret as boolean;
 };
 
@@ -305,7 +306,7 @@ export const create = async () => {
   if (passwordSet) {
     newStatus = 'READY';
   }
-  await chrome.storage.session.set({ userStatus: newStatus });
+  await SessionStorage.set('userStatus', newStatus);
   return address as Address;
 };
 
@@ -318,7 +319,7 @@ export const importWithSecret = async (seed: string) => {
   if (passwordSet) {
     newStatus = 'READY';
   }
-  await chrome.storage.session.set({ userStatus: newStatus });
+  await SessionStorage.set('userStatus', newStatus);
   return address as Address;
 };
 
@@ -541,7 +542,7 @@ export const importAccountsFromHW = async (
   const { passwordSet } = await getStatus();
   if (!passwordSet) {
     // we probably need to set a password
-    await chrome.storage.session.set({ userStatus: 'NEEDS_PASSWORD' });
+    await SessionStorage.set('userStatus', 'NEEDS_PASSWORD');
   }
   return address;
 };

--- a/src/entries/popup/hooks/useAuth.tsx
+++ b/src/entries/popup/hooks/useAuth.tsx
@@ -10,6 +10,7 @@ import React, {
 
 import { autoLockTimerOptions } from '~/core/references/autoLockTimer';
 import { useAutoLockTimerStore } from '~/core/state/currentSettings/autoLockTimer';
+import { SessionStorage } from '~/core/storage';
 
 import * as wallet from '../handlers/wallet';
 
@@ -59,7 +60,7 @@ const useSessionStatus = () => {
   const updateStatus = useCallback(async () => {
     const newStatus = await getUserStatus();
     setStatus(newStatus);
-    await chrome.storage.session.set({ userStatus: newStatus });
+    await SessionStorage.set('userStatus', newStatus);
   }, []);
 
   useEffect(() => {
@@ -74,7 +75,7 @@ const useSessionStatus = () => {
         // to not interfere with onboarding status, only autolock if status is READY
         if (userStatus === 'READY') {
           const { lastUnlock: lastUnlockFromStorage } =
-            await chrome.storage.session.get('lastUnlock');
+            await SessionStorage.get('lastUnlock');
           if (lastUnlockFromStorage) {
             const lastUnlock = new Date(lastUnlockFromStorage);
             const now = new Date();
@@ -123,6 +124,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setStatus(newValue);
       }
     };
+    // Keeping this as a session storage listener because this gave us a lot of problems in the past
     chrome.storage.session?.onChanged?.addListener(listener);
     return () => chrome.storage.session?.onChanged?.removeListener(listener);
   }, [setStatus, status]);

--- a/src/entries/popup/hooks/useAuth.tsx
+++ b/src/entries/popup/hooks/useAuth.tsx
@@ -74,8 +74,7 @@ const useSessionStatus = () => {
         const userStatus = await getUserStatus();
         // to not interfere with onboarding status, only autolock if status is READY
         if (userStatus === 'READY') {
-          const { lastUnlock: lastUnlockFromStorage } =
-            await SessionStorage.get('lastUnlock');
+          const lastUnlockFromStorage = await SessionStorage.get('lastUnlock');
           if (lastUnlockFromStorage) {
             const lastUnlock = new Date(lastUnlockFromStorage);
             const now = new Date();

--- a/src/entries/popup/hooks/useExpiryListener.ts
+++ b/src/entries/popup/hooks/useExpiryListener.ts
@@ -15,8 +15,8 @@ export function useExpiryListener() {
   const previousAddress = usePrevious(currentAddress);
 
   const checkExpiry = async () => {
-    const expiryEntry = await SessionStorage.get('expiry');
-    const expired = Date.now() > (expiryEntry?.expiry || 0);
+    const expiry = await SessionStorage.get('expiry');
+    const expired = Date.now() > (expiry || 0);
     if (expired) {
       await resetValues();
       await clearLastPage();

--- a/src/entries/popup/hooks/useExpiryListener.ts
+++ b/src/entries/popup/hooks/useExpiryListener.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useCurrentAddressStore } from '~/core/state';
 import { useNavRestorationStore } from '~/core/state/navRestoration';
 import { usePopupInstanceStore } from '~/core/state/popupInstances';
+import { SessionStorage } from '~/core/storage';
 
 import usePrevious from './usePrevious';
 
@@ -14,7 +15,7 @@ export function useExpiryListener() {
   const previousAddress = usePrevious(currentAddress);
 
   const checkExpiry = async () => {
-    const expiryEntry = await chrome.storage.session.get('expiry');
+    const expiryEntry = await SessionStorage.get('expiry');
     const expired = Date.now() > (expiryEntry?.expiry || 0);
     if (expired) {
       await resetValues();

--- a/src/entries/popup/pages/settings/privacy/walletsAndKeys/recoveryPhrase/recoveryPhraseVerify.tsx
+++ b/src/entries/popup/pages/settings/privacy/walletsAndKeys/recoveryPhrase/recoveryPhraseVerify.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { SessionStorage } from '~/core/storage';
 import { Box } from '~/design-system';
 import { SeedVerifyQuiz } from '~/entries/popup/components/SeedVerifyQuiz/SeedVerifyQuiz';
 import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
@@ -11,9 +12,7 @@ export function RecoveryPhraseVerify() {
   const { state } = useLocation();
 
   const goBackToChooseGroup = useCallback(async () => {
-    await chrome.storage.session.set({
-      walletToAdd: state?.wallet?.accounts?.[0],
-    });
+    await SessionStorage.set('walletToAdd', state?.wallet?.accounts?.[0]);
     navigate(-3);
   }, [navigate, state?.wallet?.accounts]);
 

--- a/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
+++ b/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
@@ -267,9 +267,9 @@ const ChooseWalletGroup = () => {
 
       setWallets(controlledWallets);
 
-      const sessionData = await SessionStorage.get('walletToAdd');
-      if (sessionData.walletToAdd) {
-        setCreateWalletAddress(sessionData.walletToAdd);
+      const walletToAdd = await SessionStorage.get('walletToAdd');
+      if (walletToAdd) {
+        setCreateWalletAddress(walletToAdd);
         SessionStorage.remove('walletToAdd');
       }
     };

--- a/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
+++ b/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
@@ -4,6 +4,7 @@ import { Address } from 'wagmi';
 
 import { i18n } from '~/core/languages';
 import { shortcuts } from '~/core/references/shortcuts';
+import { SessionStorage } from '~/core/storage';
 import { KeychainType, KeychainWallet } from '~/core/types/keychainTypes';
 import {
   Box,
@@ -266,10 +267,10 @@ const ChooseWalletGroup = () => {
 
       setWallets(controlledWallets);
 
-      const sessionData = await chrome.storage.session.get('walletToAdd');
+      const sessionData = await SessionStorage.get('walletToAdd');
       if (sessionData.walletToAdd) {
         setCreateWalletAddress(sessionData.walletToAdd);
-        chrome.storage.session.remove('walletToAdd');
+        SessionStorage.remove('walletToAdd');
       }
     };
     fetchWallets();


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
did some research about SessionStorage quota and [there's actually a 10MB limit](https://developer.chrome.com/docs/extensions/reference/storage/#property-session) but for a normal user we store less than 20kb.

However there's 2 keys that can grow unlimitedly during the session which are:
- rateLimit (per dapp) - this stores a key for the host and a timestamp for every dapp that you have connected to in the current browser's session
- queuedEvents:  this are all the tracking event from the service worker that we put in memory to be able to send it to the server through the popup (since we can't do it directly from the service worker)

I highly doubt any of these two is a real offender but anyways I'm taking two actions:
- Replaced our direct usage of chrome.storage.session and chrome.storage.local for our own wrappers (LocalStorage and Session Storage).
This allow us to improve the usage a big (chrome api sucks), we can add custom error handlers or process the data before storing it (encryption, compression, etc).
- Added logging in case the quota is exceeded so we can see what's going on.

Gonna archive the sentry error and keep an eye in the future for the new errors that we might get.

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
Passing tests should be enough