### PR TITLE
fix: asset filtering by networks settings

### DIFF
--- a/src/core/resources/_selectors/assets.ts
+++ b/src/core/resources/_selectors/assets.ts
@@ -21,8 +21,11 @@ export function selectorFilterByUserChains<T>({
 }): T {
   const { userChains } = userChainsStore.getState();
   const allUserChainIds = Object.keys(userChains)
-    .map((chainId) => chainIdMap[Number(chainId)])
-    .flat();
+    .map((chainId) =>
+      userChains[Number(chainId)] ? chainIdMap[Number(chainId)] : undefined,
+    )
+    .flat()
+    .filter(Boolean);
   const filteredAssetsDictByChain = Object.keys(data).reduce((acc, key) => {
     const chainKey = Number(key);
     if (allUserChainIds.includes(chainKey) || isCustomChain(chainKey)) {

--- a/src/core/state/userChains/index.ts
+++ b/src/core/state/userChains/index.ts
@@ -5,42 +5,33 @@ import { ChainId } from '~/core/types/chains';
 
 import { createStore } from '../internal/createStore';
 
-type MainnetChainId =
-  | ChainId.mainnet
-  | ChainId.optimism
-  | ChainId.polygon
-  | ChainId.arbitrum
-  | ChainId.bsc
-  | ChainId.zora
-  | ChainId.base;
-
 export interface UserChainsState {
   /**
    * Mainnet chains in network settings
    */
-  userChains: Record<MainnetChainId, boolean>;
+  userChains: Record<number, boolean>;
   /**
    * Mainnet chains ordered from network settings
    */
-  userChainsOrder: (MainnetChainId | number)[];
+  userChainsOrder: (number | number)[];
   updateUserChain: ({
     chainId,
     enabled,
   }: {
-    chainId: MainnetChainId;
+    chainId: number;
     enabled: boolean;
   }) => void;
   updateUserChains: ({
     chainIds,
     enabled,
   }: {
-    chainIds: MainnetChainId[];
+    chainIds: number[];
     enabled: boolean;
   }) => void;
   updateUserChainsOrder: ({
     userChainsOrder,
   }: {
-    userChainsOrder: (MainnetChainId | number)[];
+    userChainsOrder: (number | number)[];
   }) => void;
   addUserChain: ({ chainId }: { chainId: ChainId }) => void;
   removeUserChain: ({ chainId }: { chainId: ChainId }) => void;
@@ -51,12 +42,10 @@ const chains = SUPPORTED_MAINNET_CHAINS.reduce(
     ...acc,
     [chain.id]: true,
   }),
-  {} as Record<MainnetChainId, boolean>,
+  {} as Record<number, boolean>,
 );
 
-const userChainsOrder = Object.keys(chains).map(
-  (id) => Number(id) as MainnetChainId,
-);
+const userChainsOrder = Object.keys(chains).map((id) => Number(id) as number);
 
 export const userChainsStore = createStore<UserChainsState>(
   (set, get) => ({
@@ -69,8 +58,8 @@ export const userChainsStore = createStore<UserChainsState>(
           acc[chainId] = enabled;
           return acc;
         },
-        {} as Record<MainnetChainId, boolean>,
-      ) satisfies Record<MainnetChainId, boolean>;
+        {} as Record<number, boolean>,
+      ) satisfies Record<number, boolean>;
       set({
         userChains: {
           ...userChains,


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)


filtering assets by network broke, so any change on networks settings weren't filtering assets correctly, this pr fixes that

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
