### PR TITLE
[BX-1105] NFT Empty State

### DIFF
--- a/src/entries/popup/pages/home/NFTs/NFTs.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTs.tsx
@@ -177,7 +177,6 @@ export function PostReleaseNFTs() {
             width="full"
             style={{
               height: groupedGalleryRowVirtualizer.getTotalSize(),
-              minHeight: '436px',
               position: 'relative',
             }}
           >
@@ -226,7 +225,6 @@ export function PostReleaseNFTs() {
             width="full"
             style={{
               height: collectionGalleryRowVirtualizer.getTotalSize(),
-              minHeight: '436px',
               position: 'relative',
             }}
           >
@@ -430,7 +428,7 @@ export function NFTEmptyState() {
       marginTop="-20px"
       paddingTop="80px"
       ref={ref}
-      style={{ height: 336 }}
+      style={{ height: 336 - (nftsEnabled ? 64 : 0) }}
       width="full"
     >
       <Box paddingBottom="14px">

--- a/src/entries/popup/pages/home/NFTs/NFTs.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTs.tsx
@@ -8,6 +8,7 @@ import { selectNftCollections } from '~/core/resources/_selectors/nfts';
 import { useNfts } from '~/core/resources/nfts';
 import { getNftCount } from '~/core/resources/nfts/nfts';
 import { useCurrentAddressStore } from '~/core/state';
+import { useFeatureFlagsStore } from '~/core/state/currentSettings/featureFlags';
 import { useNftsStore } from '~/core/state/nfts';
 import { UniqueAsset } from '~/core/types/nfts';
 import { chunkArray } from '~/core/utils/assets';
@@ -101,7 +102,7 @@ export function PostReleaseNFTs() {
         const sectionRowCount = Math.ceil(assetCount / 3);
 
         const thumbnailHeight =
-          sectionRowCount * (sectionRowCount > 1 ? 106 : 96);
+          sectionRowCount * (sectionRowCount > 1 ? 112 : 96);
         return PADDING + COLLECTION_HEADER_HEIGHT + thumbnailHeight;
       } else {
         const finalCellPadding =
@@ -159,7 +160,7 @@ export function PostReleaseNFTs() {
 
   // we don't have a design for loading / empty state yet
   if (isInitialLoading || Object.values(nfts || {}).length === 0) {
-    return <PreReleaseNFTs />;
+    return <NFTEmptyState />;
   }
 
   return (
@@ -405,10 +406,12 @@ const NftThumbnail = memo(
 
 NftThumbnail.displayName = 'NftThumbnail';
 
-export function PreReleaseNFTs() {
+export function NFTEmptyState() {
   const ref = useCoolMode({ emojis: ['🌈', '🖼️'] });
   const { currentAddress: address } = useCurrentAddressStore();
   const { data: ensName } = useEnsName({ address });
+  const { featureFlags } = useFeatureFlagsStore();
+  const nftsEnabled = featureFlags.nfts_enabled;
 
   const openProfile = useCallback(
     () =>
@@ -464,7 +467,9 @@ export function PreReleaseNFTs() {
             weight="semibold"
             color="labelTertiary"
           >
-            {i18n.t('nfts.coming_soon_header')}
+            {nftsEnabled
+              ? i18n.t('nfts.empty_state_header')
+              : i18n.t('nfts.coming_soon_header')}
           </Text>
         </Stack>
       </Box>
@@ -475,35 +480,39 @@ export function PreReleaseNFTs() {
           size="12pt"
           weight="medium"
         >
-          {i18n.t('nfts.coming_soon_description')}
+          {nftsEnabled
+            ? i18n.t('nfts.empty_state_description')
+            : i18n.t('nfts.coming_soon_description')}
         </Text>
       </Inset>
-      <Lens
-        borderRadius="8px"
-        cursor="pointer"
-        onClick={openProfile}
-        padding="6px"
-        width="fit"
-      >
-        <Inline alignHorizontal="center" alignVertical="center" space="3px">
-          <Text
-            align="center"
-            color="accent"
-            cursor="pointer"
-            size="12pt"
-            weight="heavy"
-          >
-            {i18n.t('nfts.view_on_web')}
-          </Text>
-          <Symbol
-            color="accent"
-            cursor="pointer"
-            size={9.5}
-            symbol="chevron.right"
-            weight="heavy"
-          />
-        </Inline>
-      </Lens>
+      {!nftsEnabled && (
+        <Lens
+          borderRadius="8px"
+          cursor="pointer"
+          onClick={openProfile}
+          padding="6px"
+          width="fit"
+        >
+          <Inline alignHorizontal="center" alignVertical="center" space="3px">
+            <Text
+              align="center"
+              color="accent"
+              cursor="pointer"
+              size="12pt"
+              weight="heavy"
+            >
+              {i18n.t('nfts.view_on_web')}
+            </Text>
+            <Symbol
+              color="accent"
+              cursor="pointer"
+              size={9.5}
+              symbol="chevron.right"
+              weight="heavy"
+            />
+          </Inline>
+        </Lens>
+      )}
     </Box>
   );
 }

--- a/src/entries/popup/pages/home/NFTs/SortDropdown.tsx
+++ b/src/entries/popup/pages/home/NFTs/SortDropdown.tsx
@@ -38,7 +38,7 @@ export default function SortdDropdown() {
           <Box style={{ paddingRight: 7, paddingLeft: 7 }}>
             <Inline alignVertical="center" space="6px">
               <Symbol
-                symbol="clock"
+                symbol={sort === 'recent' ? 'clock' : 'list.bullet'}
                 weight="bold"
                 size={13}
                 color="labelSecondary"

--- a/src/entries/popup/pages/home/TabHeader.tsx
+++ b/src/entries/popup/pages/home/TabHeader.tsx
@@ -17,7 +17,7 @@ import { useUserAssetsBalance } from '../../hooks/useUserAssetsBalance';
 import { useVisibleTokenCount } from '../../hooks/useVisibleTokenCount';
 
 import DisplayModeDropdown from './NFTs/DisplayModeDropdown';
-import SortdDropdown from './NFTs/SortDropdown';
+import SortDropdown from './NFTs/SortDropdown';
 
 export function TabHeader({
   activeTab,
@@ -114,7 +114,7 @@ export function TabHeader({
         {activeTab === 'nfts' && featureFlags.nfts_enabled && (
           <Inline alignVertical="center" space="8px">
             <DisplayModeDropdown />
-            <SortdDropdown />
+            <SortDropdown />
           </Inline>
         )}
       </Box>

--- a/src/entries/popup/pages/home/index.tsx
+++ b/src/entries/popup/pages/home/index.tsx
@@ -51,7 +51,7 @@ import { ROUTES } from '../../urls';
 import { Activities } from './Activity/ActivitiesList';
 import { Header } from './Header';
 import { MoreMenu } from './MoreMenu';
-import { PostReleaseNFTs, PreReleaseNFTs } from './NFTs/NFTs';
+import { NFTEmptyState, PostReleaseNFTs } from './NFTs/NFTs';
 import { AppConnection } from './NetworkMenu';
 import { Points } from './Points';
 import { TabHeader } from './TabHeader';
@@ -149,7 +149,7 @@ const Tabs = memo(function Tabs({
           <PostReleaseNFTs />
         )}
         {activeTab === 'nfts' && !featureFlags.nfts_enabled && (
-          <PreReleaseNFTs />
+          <NFTEmptyState />
         )}
         {activeTab === 'points' && <Points />}
       </Content>

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -1172,7 +1172,9 @@
   },
   "nfts": {
     "coming_soon_header": "Coming Soon",
+    "empty_state_header": "NFTs",
     "coming_soon_description": "NFTs are coming soon. Stay tuned!",
+    "empty_state_description": "Your NFTs will appear here!",
     "view_on_web": "View on Web",
     "display_mode_gallery": "Gallery",
     "display_mode_collections": "Collections",


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Repurposing prelaunch NFT component for NFT empty state UI as Christian requested. I also fixed the alphabetical sort dropdown trigger icon and made some changes to prevent over-scroll on empty state and shorter lists when viewing in collection mode.

@DanielSinclair I could use your input on final copy for this screen.

## Screen recordings / screenshots
PoW: https://recordit.co/wwjxkfmlM4

## What to test
Make sure that when NFTs are enabled, but no NFTs exist, that the placeholder UI appears with the new copy appears.
