### PR TITLE
[BX-1095][BX-1096] NFT Keyboard Nav + Shortcuts

### DIFF
--- a/src/core/references/shortcuts.ts
+++ b/src/core/references/shortcuts.ts
@@ -160,6 +160,22 @@ export const shortcuts = {
       display: 'W',
       key: 'w',
     },
+    NFT_DISPLAY_MODE_GROUPED: {
+      display: '1',
+      key: '1',
+    },
+    NFT_DISPLAY_MODE_COLLECTION: {
+      display: '2',
+      key: '2',
+    },
+    NFT_SORT_RECENT: {
+      display: '1',
+      key: '1',
+    },
+    NFT_SORT_ABC: {
+      display: '2',
+      key: '2',
+    },
   },
   wallets: {
     CHOOSE_WALLET_GROUP_NEW: {

--- a/src/entries/popup/pages/home/NFTs/DisplayModeDropdown.tsx
+++ b/src/entries/popup/pages/home/NFTs/DisplayModeDropdown.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { i18n } from '~/core/languages';
 import { shortcuts } from '~/core/references/shortcuts';
 import { useCurrentThemeStore } from '~/core/state/currentSettings/currentTheme';
 import { useNftsStore } from '~/core/state/nfts';
 import { Box, Inline, Stack, Symbol, Text } from '~/design-system';
+import { Lens } from '~/design-system/components/Lens/Lens';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,6 +15,7 @@ import {
 } from '~/entries/popup/components/DropdownMenu/DropdownMenu';
 import { HomeMenuRow } from '~/entries/popup/components/HomeMenuRow/HomeMenuRow';
 import { ShortcutHint } from '~/entries/popup/components/ShortcutHint/ShortcutHint';
+import { useKeyboardShortcut } from '~/entries/popup/hooks/useKeyboardShortcut';
 
 import { gradientBorderDark, gradientBorderLight } from './NFTs.css';
 
@@ -26,35 +28,56 @@ export default function DisplayModeDropdown() {
     [setNftDisplayMode],
   );
   const { currentTheme } = useCurrentThemeStore();
+  const [open, setIsOpen] = useState(false);
+
+  useKeyboardShortcut({
+    condition: () => open,
+    handler: (e) => {
+      e.stopImmediatePropagation();
+      if (e.key === shortcuts.home.NFT_DISPLAY_MODE_GROUPED.key) {
+        onValueChange('grouped');
+        setIsOpen(false);
+      } else if (e.key === shortcuts.home.NFT_DISPLAY_MODE_COLLECTION.key) {
+        onValueChange('byCollection');
+        setIsOpen(false);
+      }
+    },
+  });
+
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={open}
+      onOpenChange={(openChange) => (!openChange ? setIsOpen(false) : null)}
+    >
       <DropdownMenuTrigger asChild>
-        <Box
-          className={
-            currentTheme === 'dark' ? gradientBorderDark : gradientBorderLight
-          }
-          style={{ display: 'flex', alignItems: 'center' }}
-        >
-          <Box style={{ paddingRight: 7, paddingLeft: 7 }}>
-            <Inline alignVertical="center" space="6px">
-              <Symbol
-                symbol={
-                  displayMode === 'grouped'
-                    ? 'square.grid.2x2'
-                    : 'checklist.unchecked'
-                }
-                weight="bold"
-                size={13}
-                color="labelSecondary"
-              />
-              <Symbol
-                symbol="chevron.down"
-                weight="bold"
-                size={10}
-                color="labelTertiary"
-              />
-            </Inline>
-          </Box>
+        <Box onClick={() => setIsOpen(true)}>
+          <Lens
+            className={
+              currentTheme === 'dark' ? gradientBorderDark : gradientBorderLight
+            }
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
+            <Box style={{ paddingRight: 7, paddingLeft: 7 }}>
+              <Inline alignVertical="center" space="6px">
+                <Symbol
+                  symbol={
+                    displayMode === 'grouped'
+                      ? 'square.grid.2x2'
+                      : 'checklist.unchecked'
+                  }
+                  weight="bold"
+                  size={13}
+                  color="labelSecondary"
+                />
+                <Symbol
+                  symbol="chevron.down"
+                  weight="bold"
+                  size={10}
+                  color="labelTertiary"
+                />
+              </Inline>
+            </Box>
+          </Lens>
         </Box>
       </DropdownMenuTrigger>
       <DropdownMenuContent marginRight="16px" marginTop="6px">
@@ -79,7 +102,7 @@ export default function DisplayModeDropdown() {
                   }
                   rightComponent={
                     <ShortcutHint
-                      hint={shortcuts.home.GO_TO_SETTINGS.display}
+                      hint={shortcuts.home.NFT_DISPLAY_MODE_GROUPED.display}
                     />
                   }
                 />
@@ -100,7 +123,7 @@ export default function DisplayModeDropdown() {
                   }
                   rightComponent={
                     <ShortcutHint
-                      hint={shortcuts.home.GO_TO_SETTINGS.display}
+                      hint={shortcuts.home.NFT_DISPLAY_MODE_COLLECTION.display}
                     />
                   }
                 />

--- a/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
@@ -1035,51 +1035,39 @@ export const NFTInfoRow = ({
         {label}
       </Text>
     </Inline>
-    <Box
-      style={{
-        paddingRight: onClick ? 2 : 0,
-      }}
-    >
-      <Lens
-        onClick={onClick}
-        cursor="pointer"
-        tabIndex={onClick ? 0 : -1}
-        padding="2px"
-        borderRadius="6px"
-      >
-        <Bleed vertical="2px">
-          <Inline alignVertical="center" space="6px">
-            <Inline>
-              <TextOverflow
-                color="labelSecondary"
-                size="12pt"
-                weight="semibold"
-                cursor="text"
-                userSelect="all"
-              >
-                {value}
-              </TextOverflow>
-              <Text
-                color="labelQuaternary"
-                size="12pt"
-                weight="semibold"
-                cursor="text"
-              >
-                {subValue}
-              </Text>
-            </Inline>
-            {valueSymbol && (
-              <Symbol
-                size={14}
-                symbol={valueSymbol}
-                weight="medium"
-                color="labelTertiary"
-                cursor="pointer"
-              />
-            )}
+    <Box onClick={onClick} cursor="pointer" padding="2px">
+      <Bleed vertical="2px">
+        <Inline alignVertical="center" space="6px">
+          <Inline space="2px">
+            <TextOverflow
+              color="labelSecondary"
+              size="12pt"
+              weight="semibold"
+              cursor="text"
+              userSelect="all"
+            >
+              {value}
+            </TextOverflow>
+            <Text
+              color="labelQuaternary"
+              size="12pt"
+              weight="semibold"
+              cursor="text"
+            >
+              {subValue}
+            </Text>
           </Inline>
-        </Bleed>
-      </Lens>
+          {valueSymbol && (
+            <Symbol
+              size={14}
+              symbol={valueSymbol}
+              weight="medium"
+              color="labelTertiary"
+              cursor="pointer"
+            />
+          )}
+        </Inline>
+      </Bleed>
     </Box>
   </Box>
 );

--- a/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
@@ -17,13 +17,16 @@ import {
   getBlockExplorerHostForChain,
 } from '~/core/utils/chains';
 import { copyAddress } from '~/core/utils/copy';
+import { getUniqueAssetImageThumbnailURL } from '~/core/utils/nfts';
 import { convertRawAmountToDecimalFormat } from '~/core/utils/numbers';
 import { capitalize } from '~/core/utils/strings';
 import { goToNewTab } from '~/core/utils/tabs';
 import {
   AccentColorProvider,
+  Bleed,
   Box,
   Button,
+  ButtonSymbol,
   Column,
   Columns,
   Inline,
@@ -39,6 +42,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '~/design-system/components/Accordion/Accordion';
+import { Lens } from '~/design-system/components/Lens/Lens';
 import { SymbolProps } from '~/design-system/components/Symbol/Symbol';
 import {
   TextStyles,
@@ -118,7 +122,7 @@ export default function NFTDetails() {
                 style={{ height: 320, width: 320 }}
               >
                 <ExternalImage
-                  src={nft?.image_url || ''}
+                  src={nft ? getUniqueAssetImageThumbnailURL(nft) : ''}
                   height={320}
                   width={320}
                   borderRadius="16px"
@@ -133,38 +137,42 @@ export default function NFTDetails() {
                           {nft?.name}
                         </Text>
                       </Box>
-                      <Inline alignVertical="center" space="7px">
-                        <Box
-                          borderRadius="round"
-                          style={{
-                            overflow: 'none',
-                            height: 16,
-                            width: 16,
-                          }}
-                        >
-                          <ExternalImage
-                            src={nft?.collection.image_url || ''}
-                            height={16}
-                            width={16}
-                            borderRadius="round"
-                          />
-                        </Box>
-                        <TextOverflow
-                          size="12pt"
-                          weight="bold"
-                          color="labelTertiary"
-                          maxWidth={256}
-                        >
-                          {nft?.collection.name}
-                        </TextOverflow>
-                        <Symbol
-                          color="labelTertiary"
-                          cursor="pointer"
-                          size={10}
-                          symbol="chevron.right"
-                          weight="bold"
-                        />
-                      </Inline>
+                      <Lens borderRadius="6px" bubblesOnKeyDown padding="2px">
+                        <Bleed vertical="2px" horizontal="2px">
+                          <Inline alignVertical="center" space="7px">
+                            <Box
+                              borderRadius="round"
+                              style={{
+                                overflow: 'none',
+                                height: 16,
+                                width: 16,
+                              }}
+                            >
+                              <ExternalImage
+                                src={nft?.collection.image_url || ''}
+                                height={16}
+                                width={16}
+                                borderRadius="round"
+                              />
+                            </Box>
+                            <TextOverflow
+                              size="12pt"
+                              weight="bold"
+                              color="labelTertiary"
+                              maxWidth={256}
+                            >
+                              {nft?.collection.name}
+                            </TextOverflow>
+                            <Symbol
+                              color="labelTertiary"
+                              cursor="pointer"
+                              size={10}
+                              symbol="chevron.right"
+                              weight="bold"
+                            />
+                          </Inline>
+                        </Bleed>
+                      </Lens>
                     </NFTCollectionDropdownMenu>
                   </Column>
                   <Column width="content">
@@ -176,11 +184,12 @@ export default function NFTDetails() {
                       }}
                     >
                       <NFTDropdownMenu nft={nft}>
-                        <Symbol
+                        <ButtonSymbol
                           symbol="ellipsis.circle"
                           color="accent"
-                          weight="bold"
-                          size={16}
+                          height={'32px'}
+                          variant="transparent"
+                          tabIndex={0}
                         />
                       </NFTDropdownMenu>
                     </Box>
@@ -196,6 +205,7 @@ export default function NFTDetails() {
                   borderRadius="round"
                   symbol="arrow.up.right.square.fill"
                   onClick={() => goToNewTab({ url: getOpenseaUrl({ nft }) })}
+                  tabIndex={0}
                 >
                   {'OpenSea'}
                 </Button>
@@ -531,6 +541,7 @@ const NFTNavbar = ({ nft }: { nft?: UniqueAsset | null }) => {
                 symbol="ellipsis.circle"
                 height="32px"
                 variant="transparent"
+                tabIndex={0}
               />
             </NFTDropdownMenu>
           </Inline>
@@ -947,6 +958,7 @@ const NFTLinkButton = ({
       symbol={symbol}
       height="32px"
       onClick={() => goToNewTab({ url })}
+      tabIndex={0}
     >
       {title}
     </Button>
@@ -1023,37 +1035,51 @@ export const NFTInfoRow = ({
         {label}
       </Text>
     </Inline>
-    <Box onClick={onClick} cursor="pointer">
-      <Inline alignVertical="center" space="6px">
-        <Inline space="2px">
-          <TextOverflow
-            color="labelSecondary"
-            size="12pt"
-            weight="semibold"
-            cursor="text"
-            userSelect="all"
-          >
-            {value}
-          </TextOverflow>
-          <Text
-            color="labelQuaternary"
-            size="12pt"
-            weight="semibold"
-            cursor="text"
-          >
-            {subValue}
-          </Text>
-        </Inline>
-        {valueSymbol && (
-          <Symbol
-            size={14}
-            symbol={valueSymbol}
-            weight="medium"
-            color="labelTertiary"
-            cursor="pointer"
-          />
-        )}
-      </Inline>
+    <Box
+      style={{
+        paddingRight: onClick ? 2 : 0,
+      }}
+    >
+      <Lens
+        onClick={onClick}
+        cursor="pointer"
+        tabIndex={onClick ? 0 : -1}
+        padding="2px"
+        borderRadius="6px"
+      >
+        <Bleed vertical="2px">
+          <Inline alignVertical="center" space="6px">
+            <Inline>
+              <TextOverflow
+                color="labelSecondary"
+                size="12pt"
+                weight="semibold"
+                cursor="text"
+                userSelect="all"
+              >
+                {value}
+              </TextOverflow>
+              <Text
+                color="labelQuaternary"
+                size="12pt"
+                weight="semibold"
+                cursor="text"
+              >
+                {subValue}
+              </Text>
+            </Inline>
+            {valueSymbol && (
+              <Symbol
+                size={14}
+                symbol={valueSymbol}
+                weight="medium"
+                color="labelTertiary"
+                cursor="pointer"
+              />
+            )}
+          </Inline>
+        </Bleed>
+      </Lens>
     </Box>
   </Box>
 );

--- a/src/entries/popup/pages/home/NFTs/NFTs.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTs.tsx
@@ -385,7 +385,7 @@ function CollectionSection({
 const NftThumbnail = memo(
   ({ imageSrc, onClick }: { imageSrc?: string; onClick: () => void }) => {
     return (
-      <Box
+      <Lens
         style={{ height: 96, width: 96 }}
         borderRadius="10px"
         background="fillQuaternary"
@@ -397,7 +397,7 @@ const NftThumbnail = memo(
           height={96}
           width={96}
         />
-      </Box>
+      </Lens>
     );
   },
 );

--- a/src/entries/popup/pages/home/NFTs/SortDropdown.tsx
+++ b/src/entries/popup/pages/home/NFTs/SortDropdown.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { i18n } from '~/core/languages';
 import { shortcuts } from '~/core/references/shortcuts';
 import { useCurrentThemeStore } from '~/core/state/currentSettings/currentTheme';
 import { useNftsStore } from '~/core/state/nfts';
 import { Box, Inline, Stack, Symbol, Text } from '~/design-system';
+import { Lens } from '~/design-system/components/Lens/Lens';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,6 +15,7 @@ import {
 } from '~/entries/popup/components/DropdownMenu/DropdownMenu';
 import { HomeMenuRow } from '~/entries/popup/components/HomeMenuRow/HomeMenuRow';
 import { ShortcutHint } from '~/entries/popup/components/ShortcutHint/ShortcutHint';
+import { useKeyboardShortcut } from '~/entries/popup/hooks/useKeyboardShortcut';
 
 import { gradientBorderDark, gradientBorderLight } from './NFTs.css';
 
@@ -26,36 +28,57 @@ export default function SortdDropdown() {
     [setNftSort],
   );
   const { currentTheme } = useCurrentThemeStore();
+  const [open, setIsOpen] = useState(false);
+
+  useKeyboardShortcut({
+    condition: () => open,
+    handler: (e) => {
+      e.stopImmediatePropagation();
+      if (e.key === shortcuts.home.NFT_SORT_RECENT.key) {
+        onValueChange('recent');
+        setIsOpen(false);
+      } else if (e.key === shortcuts.home.NFT_SORT_ABC.key) {
+        onValueChange('alphabetical');
+        setIsOpen(false);
+      }
+    },
+  });
+
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={open}
+      onOpenChange={(openChange) => !openChange && setIsOpen(false)}
+    >
       <DropdownMenuTrigger asChild>
-        <Box
-          className={
-            currentTheme === 'dark' ? gradientBorderDark : gradientBorderLight
-          }
-          style={{ display: 'flex', alignItems: 'center' }}
-        >
-          <Box style={{ paddingRight: 7, paddingLeft: 7 }}>
-            <Inline alignVertical="center" space="6px">
-              <Symbol
-                symbol={sort === 'recent' ? 'clock' : 'list.bullet'}
-                weight="bold"
-                size={13}
-                color="labelSecondary"
-              />
-              <Text weight="bold" size="14pt" color="label">
-                {sort === 'recent'
-                  ? i18n.t('nfts.sort_option_recent')
-                  : i18n.t('nfts.sort_option_abc')}
-              </Text>
-              <Symbol
-                symbol="chevron.down"
-                weight="bold"
-                size={10}
-                color="labelTertiary"
-              />
-            </Inline>
-          </Box>
+        <Box onClick={() => setIsOpen(true)}>
+          <Lens
+            className={
+              currentTheme === 'dark' ? gradientBorderDark : gradientBorderLight
+            }
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
+            <Box style={{ paddingRight: 7, paddingLeft: 7 }}>
+              <Inline alignVertical="center" space="6px">
+                <Symbol
+                  symbol={sort === 'recent' ? 'clock' : 'list.bullet'}
+                  weight="bold"
+                  size={13}
+                  color="labelSecondary"
+                />
+                <Text weight="bold" size="14pt" color="label">
+                  {sort === 'recent'
+                    ? i18n.t('nfts.sort_option_recent')
+                    : i18n.t('nfts.sort_option_abc')}
+                </Text>
+                <Symbol
+                  symbol="chevron.down"
+                  weight="bold"
+                  size={10}
+                  color="labelTertiary"
+                />
+              </Inline>
+            </Box>
+          </Lens>
         </Box>
       </DropdownMenuTrigger>
       <DropdownMenuContent marginRight="16px" marginTop="6px">
@@ -76,7 +99,7 @@ export default function SortdDropdown() {
                   }
                   rightComponent={
                     <ShortcutHint
-                      hint={shortcuts.home.GO_TO_SETTINGS.display}
+                      hint={shortcuts.home.NFT_SORT_RECENT.display}
                     />
                   }
                 />
@@ -92,9 +115,7 @@ export default function SortdDropdown() {
                     </Text>
                   }
                   rightComponent={
-                    <ShortcutHint
-                      hint={shortcuts.home.GO_TO_SETTINGS.display}
-                    />
+                    <ShortcutHint hint={shortcuts.home.NFT_SORT_ABC.display} />
                   }
                 />
               </DropdownMenuRadioItem>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Added support for keyboard navigation on the gallery page and the details page. Also added shortcuts that activate when the NFT dropdowns are in use.

## Screen recordings / screenshots
PoW: https://recordit.co/ICzDbgfbGh

## What to test
Make sure the gallery and details pages are navigable with the keyboard and that the 1/2 keys work when activating the dropdown. 
