### PR TITLE
fix token details ui shift

### DIFF
--- a/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
@@ -192,8 +192,8 @@ export function PriceChart({ token }: { token: ParsedUserAsset }) {
         />
         <PriceChange changePercentage={changePercentage} date={date} />
       </Box>
-      {hasPriceData && (
-        <Box>
+      {shouldHaveData && (
+        <>
           <Box style={{ height: '222px' }} marginHorizontal="-20px">
             {data && (
               <LineChart
@@ -222,7 +222,7 @@ export function PriceChart({ token }: { token: ParsedUserAsset }) {
               );
             })}
           </Box>
-        </Box>
+        </>
       )}
     </>
   );

--- a/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
@@ -365,7 +365,7 @@ export function TokenDetails() {
             />
           }
           rightComponent={
-            !isSwappable ? (
+            isSwappable ? (
               <Inline alignVertical="center" space="7px">
                 <FavoriteButton token={token} />
                 <MoreOptions token={token} />


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

leaves space for the chart if it should have data (not testnet) and adds back favorite and more options on top

## Screen recordings / screenshots

before / after
(aave chart data was cached on the before vid, but you can see the shift later with kwenta)

https://github.com/rainbow-me/browser-extension/assets/6232729/bfb2da5b-8366-49b1-8f50-89289a6ea977

https://github.com/rainbow-me/browser-extension/assets/6232729/933823a9-9505-4699-a253-99ed1423da82

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
