### PR TITLE
[BX-1102] Ens Registration Info

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "framer-motion": "10.2.3",
     "graphql-request": "5.2.0",
     "i18n-js": "4.1.1",
-    "idna-uts46-hx": "5.1.2",
+    "idna-uts46-hx": "3.5.0",
     "imgix-core-js": "2.3.2",
     "lodash": "4.17.21",
     "make-color-more-chill": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "framer-motion": "10.2.3",
     "graphql-request": "5.2.0",
     "i18n-js": "4.1.1",
+    "idna-uts46-hx": "5.1.2",
     "imgix-core-js": "2.3.2",
     "lodash": "4.17.21",
     "make-color-more-chill": "0.2.2",

--- a/src/core/graphql/config.js
+++ b/src/core/graphql/config.js
@@ -1,4 +1,11 @@
 exports.config = {
+  ens: {
+    schema: {
+      url: 'https://api.thegraph.com/subgraphs/name/ensdomains/ens',
+      method: 'POST',
+    },
+    document: './queries/ens.graphql',
+  },
   metadata: {
     document: './queries/metadata.graphql',
     schema: { method: 'GET', url: 'https://metadata.p.rainbow.me/v1/graph' },

--- a/src/core/graphql/index.ts
+++ b/src/core/graphql/index.ts
@@ -2,11 +2,15 @@ import gql from 'graphql-tag';
 
 import { RainbowFetchRequestOpts } from '../network/internal/rainbowFetch';
 
+import { getSdk as getEnsSdk } from './__generated__/ens';
 import { getSdk as getMetadataSdk } from './__generated__/metadata';
 import { getFetchRequester } from './utils/getFetchRequester';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { config } = require('./config.js');
+
+export const ensRequester = getFetchRequester(config.ens.schema);
+export const ensClient = getEnsSdk(ensRequester);
 
 export const metadataRequester = getFetchRequester(config.metadata.schema);
 export const metadataClient = getMetadataSdk(metadataRequester);

--- a/src/core/graphql/queries/ens.graphql
+++ b/src/core/graphql/queries/ens.graphql
@@ -1,0 +1,10 @@
+query getRegistration($id: ID!) {
+  registration(id: $id) {
+    id
+    registrationDate
+    expiryDate
+    registrant {
+      id
+    }
+  }
+}

--- a/src/core/resources/ens/ensRegistration.ts
+++ b/src/core/resources/ens/ensRegistration.ts
@@ -1,0 +1,111 @@
+import { keccak256 } from '@ethersproject/keccak256';
+import { toUtf8Bytes } from '@ethersproject/strings';
+import { useQuery } from '@tanstack/react-query';
+import uts46 from 'idna-uts46-hx';
+
+import { ensClient } from '~/core/graphql';
+import {
+  QueryConfig,
+  QueryFunctionArgs,
+  QueryFunctionResult,
+  createQueryKey,
+} from '~/core/react-query';
+
+const ENS_DOMAIN = '.eth';
+
+function normalizeENS(name: string) {
+  try {
+    return uts46.toUnicode(name, { useStd3ASCII: true });
+  } catch (err) {
+    return name;
+  }
+}
+
+function decodeLabelhash(hash: string) {
+  if (!(hash.startsWith('[') && hash.endsWith(']'))) {
+    throw Error(
+      'Expected encoded labelhash to start and end with square brackets',
+    );
+  }
+
+  if (hash.length !== 66) {
+    throw Error('Expected encoded labelhash to have a length of 66');
+  }
+
+  return `${hash.slice(1, -1)}`;
+}
+
+function isEncodedLabelhash(hash: string) {
+  return hash.startsWith('[') && hash.endsWith(']') && hash.length === 66;
+}
+
+function labelhash(unnormalisedLabelOrLabelhash: string) {
+  if (unnormalisedLabelOrLabelhash === '[root]') {
+    return '';
+  }
+  return isEncodedLabelhash(unnormalisedLabelOrLabelhash)
+    ? '0x' + decodeLabelhash(unnormalisedLabelOrLabelhash)
+    : keccak256(toUtf8Bytes(normalizeENS(unnormalisedLabelOrLabelhash)));
+}
+
+const fetchRegistration = async (ensName: string) => {
+  const response = await ensClient.getRegistration({
+    id: labelhash(ensName.replace(ENS_DOMAIN, '')),
+  });
+  const data = response.registration;
+
+  return {
+    registration: {
+      expiryDate: data?.expiryDate as string,
+      registrationDate: data?.registrationDate as string,
+    },
+  };
+};
+
+// ///////////////////////////////////////////////
+// Query Types
+
+export type EnsRegistrationArgs = {
+  name: string;
+};
+
+// ///////////////////////////////////////////////
+// Query Key
+
+const ensRegistrationQueryKey = ({ name }: EnsRegistrationArgs) =>
+  createQueryKey('ensRegistration', { name }, { persisterVersion: 1 });
+
+type EnsRegistrationQueryKey = ReturnType<typeof ensRegistrationQueryKey>;
+
+// ///////////////////////////////////////////////
+// Query Function
+
+async function ensRegistrationQueryFunction({
+  queryKey: [{ name }],
+}: QueryFunctionArgs<typeof ensRegistrationQueryKey>) {
+  const registration = fetchRegistration(name);
+  return registration;
+}
+
+type EnsRegistrationResult = QueryFunctionResult<
+  typeof ensRegistrationQueryFunction
+>;
+
+// ///////////////////////////////////////////////
+// Query Hook
+
+export function useEnsRegistration(
+  { name }: EnsRegistrationArgs,
+  config: QueryConfig<
+    EnsRegistrationResult,
+    Error,
+    EnsRegistrationResult,
+    EnsRegistrationQueryKey
+  > = {},
+) {
+  return useQuery(
+    ensRegistrationQueryKey({ name }),
+    ensRegistrationQueryFunction,
+    config,
+  );
+}

--- a/src/core/resources/ens/ensRegistration.ts
+++ b/src/core/resources/ens/ensRegistration.ts
@@ -56,8 +56,8 @@ const fetchRegistration = async (ensName: string) => {
 
   return {
     registration: {
-      expiryDate: data?.expiryDate as string,
-      registrationDate: data?.registrationDate as string,
+      expiryDate: data?.expiryDate as string | undefined,
+      registrationDate: data?.registrationDate as string | undefined,
     },
   };
 };

--- a/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
@@ -300,8 +300,8 @@ const EnsRegistrationSection = ({
   registration,
 }: {
   registration?: {
-    expiryDate: string;
-    registrationDate: string;
+    expiryDate: string | undefined;
+    registrationDate: string | undefined;
   };
 }) => {
   const expiryDate = useMemo(() => {

--- a/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
@@ -1,11 +1,13 @@
 import { DropdownMenuRadioGroup } from '@radix-ui/react-dropdown-menu';
 import clsx from 'clsx';
+import { format, formatDistanceStrict } from 'date-fns';
 import { ReactNode, useCallback, useMemo, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { Address, useEnsName } from 'wagmi';
 
 import { i18n } from '~/core/languages';
 import { selectNftCollections } from '~/core/resources/_selectors/nfts';
+import { useEnsRegistration } from '~/core/resources/ens/ensRegistration';
 import { useNfts } from '~/core/resources/nfts';
 import { useCurrentAddressStore } from '~/core/state';
 import { AddressOrEth } from '~/core/types/assets';
@@ -109,6 +111,12 @@ export default function NFTDetails() {
     addressOrName: nft?.name || '',
     enableProfile: nft?.familyName === 'ENS',
   });
+  const { data: ensRegistrationData } = useEnsRegistration(
+    { name: nft?.name || '' },
+    {
+      enabled: !!(nft?.name && nft?.familyName === 'ENS'),
+    },
+  );
   const { data: dominantColor } = useDominantColor({
     imageUrl: nft?.image_url || undefined,
   });
@@ -224,7 +232,13 @@ export default function NFTDetails() {
                   {'OpenSea'}
                 </Button>
               </Box>
-              <NFTPriceSection nft={nft} />
+              {ensRegistrationData ? (
+                <EnsRegistrationSection
+                  registration={ensRegistrationData.registration}
+                />
+              ) : (
+                <NFTPriceSection nft={nft} />
+              )}
             </Box>
           </Box>
           <Box paddingHorizontal="20px" paddingTop="24px">
@@ -281,6 +295,71 @@ export default function NFTDetails() {
     </Box>
   );
 }
+
+const EnsRegistrationSection = ({
+  registration,
+}: {
+  registration?: {
+    expiryDate: string;
+    registrationDate: string;
+  };
+}) => {
+  const expiryDate = useMemo(() => {
+    const dateStr = registration?.expiryDate;
+    if (dateStr) {
+      const date = new Date(parseInt(dateStr) * 1000);
+      return formatDistanceStrict(new Date(), date);
+    }
+    return '';
+  }, [registration]);
+  const registrationDate = useMemo(() => {
+    const dateStr = registration?.registrationDate;
+    if (dateStr) {
+      const date = new Date(parseInt(dateStr) * 1000);
+      return format(date, 'MMM d, Y');
+    }
+    return '';
+  }, [registration]);
+  return (
+    <Box paddingBottom="20px">
+      <Columns>
+        <Column>
+          <Stack space="12px">
+            <Text weight="semibold" size="14pt" color="labelTertiary">
+              {i18n.t('nfts.details.registered_on')}
+            </Text>
+            <Text weight="bold" size="14pt" color="label">
+              {registrationDate}
+            </Text>
+          </Stack>
+        </Column>
+        <Column>
+          <Stack space="12px" alignHorizontal="right">
+            <Inline alignVertical="center" space="4px">
+              <Text
+                weight="semibold"
+                size="14pt"
+                color="labelTertiary"
+                align="right"
+              >
+                {i18n.t('nfts.details.expires_in')}
+              </Text>
+              <Symbol
+                symbol="info.circle"
+                color="labelTertiary"
+                size={11}
+                weight="semibold"
+              />
+            </Inline>
+            <Text weight="bold" size="14pt" color="label">
+              {expiryDate}
+            </Text>
+          </Stack>
+        </Column>
+      </Columns>
+    </Box>
+  );
+};
 
 const NFTPriceSection = ({ nft }: { nft?: UniqueAsset | null }) => {
   const lastSaleDisplay = useMemo(() => {

--- a/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTDetails.tsx
@@ -344,12 +344,6 @@ const EnsRegistrationSection = ({
               >
                 {i18n.t('nfts.details.expires_in')}
               </Text>
-              <Symbol
-                symbol="info.circle"
-                color="labelTertiary"
-                size={11}
-                weight="semibold"
-              />
             </Inline>
             <Text weight="bold" size="14pt" color="label">
               {expiryDate}

--- a/static/allowlist.json
+++ b/static/allowlist.json
@@ -42,6 +42,7 @@
     "https://proportionate-newest-mountain.arbitrum-goerli.quiknode.pro",
     "https://bitter-prettiest-vineyard.ethereum-holesky.quiknode.pro",
     "https://alien-lively-thunder.optimism-sepolia.quiknode.pro",
-    "https://nftp.rainbow.me/"
+    "https://nftp.rainbow.me/",
+    "https://api.thegraph.com/subgraphs/name/ensdomains/ens"
   ]
 }

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -1206,7 +1206,9 @@
       "ens_bio": "Bio",
       "ens_cover": "Cover",
       "ens_address": "ETH Address",
-      "ens_website": "Website"
+      "ens_website": "Website",
+      "registered_on": "Registered on",
+      "expires_in": "Expires in"
     }
   },
   "points": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,10 +9717,10 @@ idb@7.0.1:
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.0.1.tgz#d2875b3a2f205d854ee307f6d196f246fea590a7"
   integrity sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==
 
-idna-uts46-hx@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-5.1.2.tgz#307cb604174690f8f4bba96588b199201bea1524"
-  integrity sha512-lLQOVOuJOq5uH5NWd5bnkXtpUY5uEQBVw918cC6ePmoEwa54EB/+c4rEKQ0HIspceomILY0WSap8mh0vSBHpoA==
+idna-uts46-hx@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-3.5.0.tgz#fad856b480bce4ff7477e7e0a42b5a39a8a4bcdc"
+  integrity sha512-0gMFl+zjvA8ZOohPQmLiWcd2Ad60AB9oKzqvLucEC5TyDzHl5mIB6ralW6h8BayVRm4ZmAVYnlI1pCYD2O7lBw==
   dependencies:
     punycode "^2.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,6 +9717,13 @@ idb@7.0.1:
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.0.1.tgz#d2875b3a2f205d854ee307f6d196f246fea590a7"
   integrity sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==
 
+idna-uts46-hx@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-5.1.2.tgz#307cb604174690f8f4bba96588b199201bea1524"
+  integrity sha512-lLQOVOuJOq5uH5NWd5bnkXtpUY5uEQBVw918cC6ePmoEwa54EB/+c4rEKQ0HIspceomILY0WSap8mh0vSBHpoA==
+  dependencies:
+    punycode "^2.1.1"
+
 ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
Figma link (if any): https://www.figma.com/file/hzfwKOddfRmeVO4KUsG9wM/Rainbow-BX?type=design&node-id=8127-263102&mode=design&t=P36zv51ZbKE5GZDM-0

## What changed (plus any additional context for devs)
The nft details page now displays registration info in place of the price section.

## Screen recordings / screenshots
PoW: https://recordit.co/uFOZyEB6aK

## What to test
Visit NFT details for ENS names, then make sure "Registered on" and "Expires in" displays correctly.

For documentation's sake: this is part two of BX-1102. The profile info was merged previously.
