### PR TITLE
[BX-1155] Prevent Test Data Override

### DIFF
--- a/src/core/resources/nfts/nfts.ts
+++ b/src/core/resources/nfts/nfts.ts
@@ -48,7 +48,7 @@ async function nftsQueryFunction({
   queryKey: [{ address }],
   pageParam,
 }: QueryFunctionArgs<typeof nftsQueryKey>) {
-  if (process.env.IS_TESTING) {
+  if (process.env.IS_TESTING === 'true') {
     return NFTS_TEST_DATA;
   }
   const chains = getBackendSupportedChains({ testnetMode: false }).map(


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Prevents catastrophic nft bug

## Screen recordings / screenshots
<img width="463" alt="Screen Shot 2023-12-11 at 11 21 56 PM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/c729274b-15d0-48a2-8074-31933732ad08">

## What to test
Make sure NFTs show up when IS_TESTING = 'false'
