### PR TITLE
Prevent Periodic NFT dups

### DIFF
--- a/src/core/resources/nfts/nfts.ts
+++ b/src/core/resources/nfts/nfts.ts
@@ -48,7 +48,7 @@ async function nftsQueryFunction({
   queryKey: [{ address }],
   pageParam,
 }: QueryFunctionArgs<typeof nftsQueryKey>) {
-  if (process.env.IS_TESTING) {
+  if (process.env.IS_TESTING === 'true') {
     return NFTS_TEST_DATA;
   }
   const chains = getBackendSupportedChains({ testnetMode: false }).map(
@@ -108,7 +108,9 @@ async function nftsQueryFunction({
       };
       return c.collection_id;
     });
-  const nftsResponse = await fetchNfts({ address, chains, collectionIds });
+  const nftsResponse = collectionIds?.length
+    ? await fetchNfts({ address, chains, collectionIds })
+    : [];
   const nfts = filterSimpleHashNFTs(nftsResponse, polygonAllowList).map(
     (nft) => {
       const uniqueAsset = simpleHashNFTToUniqueAsset(nft);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
In cases where we filtered out 50/50 polygon collections in a simple hash collections call, we would then proceed with the remaining logic and pass in an empty collection id array. This would sometimes cause duplicate NFTs to appear in the collection.

## What to test
This was fairly uncommon and didn't always happen so it's hard to illustrate a before and after. Please check that the logic looks alright and ensure you don't happen to run into the issue.