### PR TITLE
improve price discovery on l2s (unsupported networks)

### DIFF
--- a/src/core/resources/assets/customNetworkAssets.ts
+++ b/src/core/resources/assets/customNetworkAssets.ts
@@ -19,7 +19,6 @@ import {
   AssetMetadata,
   ParsedAssetsDict,
   ParsedUserAsset,
-  ZerionAssetPrice,
 } from '~/core/types/assets';
 import { ChainId, ChainName } from '~/core/types/chains';
 import {
@@ -33,7 +32,7 @@ import {
   customChainIdsToAssetNames,
   getCustomChains,
 } from '~/core/utils/chains';
-import { isZero } from '~/core/utils/numbers';
+import { convertDecimalFormatToRawAmount, isZero } from '~/core/utils/numbers';
 import { RainbowError, logger } from '~/logger';
 import { ETH_MAINNET_ASSET } from '~/test/utils';
 
@@ -263,18 +262,15 @@ async function customNetworkAssetsFunction({
         if (parsedAsset?.native.price) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          allCustomNetworkAssets[i].native.price = parsedAsset.native.price;
-          allCustomNetworkAssets[i].price =
-            parsedAsset?.price as ZerionAssetPrice;
-          // Now we have the price, we have to calculate the native balance
-          if (allCustomNetworkAssets[i].isNativeAsset) {
-            const assetWithPriceAndNativeBalance = parseUserAssetBalances({
-              asset: allCustomNetworkAssets[i],
-              currency,
-              balance: nativeAssetBalance.toString(),
-            });
-            allCustomNetworkAssets[i] = assetWithPriceAndNativeBalance;
-          }
+          const assetWithPriceAndNativeBalance = parseUserAssetBalances({
+            asset: allCustomNetworkAssets[i],
+            currency,
+            balance: convertDecimalFormatToRawAmount(
+              allCustomNetworkAssets[i].balance.amount,
+              allCustomNetworkAssets[i].decimals,
+            ),
+          });
+          allCustomNetworkAssets[i] = assetWithPriceAndNativeBalance;
         }
       });
 

--- a/src/core/utils/numbers.ts
+++ b/src/core/utils/numbers.ts
@@ -462,5 +462,14 @@ export const convertRawAmountToDecimalFormat = (
 ): string =>
   new BigNumber(value).dividedBy(new BigNumber(10).pow(decimals)).toFixed();
 
+/**
+ * @desc convert from decimal format to raw amount
+ */
+export const convertDecimalFormatToRawAmount = (
+  value: string,
+  decimals = 18,
+): string =>
+  new BigNumber(value).multipliedBy(new BigNumber(10).pow(decimals)).toFixed(0);
+
 export const fromWei = (number: BigNumberish): string =>
   convertRawAmountToDecimalFormat(number, 18);

--- a/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
@@ -77,7 +77,7 @@ function TokenPrice({
         gap="10px"
       >
         <Text size="16pt" weight="heavy" cursor="text" userSelect="all">
-          {!isLoading && !hasPriceData
+          {!isLoading && !hasPriceData && !fallbackPrice
             ? i18n.t('token_details.not_available')
             : formatCurrency(token.native.price?.amount || fallbackPrice)}
         </Text>
@@ -129,7 +129,7 @@ const usePriceChart = ({
       const chart = await fetchPriceChart(time, chainId, address);
       if (!chart && mainnetAddress)
         return fetchPriceChart(time, ChainId.mainnet, mainnetAddress);
-      return chart;
+      return chart || null;
     },
     queryKey: createQueryKey('price chart', { address, chainId, time }),
     keepPreviousData: true,
@@ -160,10 +160,12 @@ export function PriceChart({ token }: { token: ParsedUserAsset }) {
     time: selectedTime,
   });
 
-  const lastPrice = data && data[data.length - 1]?.price;
+  const lastPrice =
+    (data && data[data.length - 1]?.price) || token.price?.value;
   const selectedTimePriceChange = {
     date: chartTimeToTimestamp[selectedTime],
-    changePercentage: percentDiff(lastPrice, data?.[0]?.price),
+    changePercentage:
+      percentDiff(lastPrice, data?.[0]?.price || token.price?.value) || 0,
   };
 
   const [indicatorPointPriceChange, setIndicatorPoint] = useReducer<
@@ -192,7 +194,7 @@ export function PriceChart({ token }: { token: ParsedUserAsset }) {
         />
         <PriceChange changePercentage={changePercentage} date={date} />
       </Box>
-      {shouldHaveData && (
+      {((shouldHaveData && isLoading) || hasPriceData) && (
         <>
           <Box style={{ height: '222px' }} marginHorizontal="-20px">
             {data && (


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
We had a bug that we were only calculating prices for native assets on unsupported networks.
This PR fixes it.

## Screen recordings / screenshots

Before

![Screen Shot 2023-12-15 at 10 35 11 AM](https://github.com/rainbow-me/browser-extension/assets/1247834/d546eaad-6fe1-4708-8137-4a427b639f2b)


After
<img width="434" alt="Screen Shot 2023-12-15 at 10 35 11 AM" src="https://github.com/rainbow-me/browser-extension/assets/1247834/d8994d3c-35c0-4314-86f2-891fe5e6c45e">


<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
