### PR TITLE
send customrpc checks

### DIFF
--- a/src/core/resources/assets/customNetworkAssets.ts
+++ b/src/core/resources/assets/customNetworkAssets.ts
@@ -189,9 +189,12 @@ async function customNetworkAssetsFunction({
           chain.id === ChainId.mainnet
             ? ETH_MAINNET_ASSET.address
             : AddressZero;
-        const nativeAssetBalance = await provider.getBalance(address);
+        const nativeAssetBalance = (
+          await provider.getBalance(address)
+        )?.toString();
         const customNetworkNativeAssetParsed =
-          nativeAssetBalance && !isZero(nativeAssetBalance.toString())
+          nativeAssetBalance &&
+          (filterZeroBalance ? !isZero(nativeAssetBalance) : true)
             ? parseUserAssetBalances({
                 asset: {
                   address: nativeAssetAddress,
@@ -209,7 +212,7 @@ async function customNetworkAssetsFunction({
                   icon_url: getCustomChainIconUrl(chain.id, nativeAssetAddress),
                 },
                 currency,
-                balance: nativeAssetBalance.toString(),
+                balance: nativeAssetBalance,
               })
             : null;
 

--- a/src/entries/popup/hooks/useCustomNetworkAsset.ts
+++ b/src/entries/popup/hooks/useCustomNetworkAsset.ts
@@ -3,13 +3,20 @@ import { useCustomNetworkAssets } from '~/core/resources/assets/customNetworkAss
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { UniqueId } from '~/core/types/assets';
 
-export function useCustomNetworkAsset(uniqueId?: UniqueId) {
+export function useCustomNetworkAsset({
+  uniqueId,
+  filterZeroBalance,
+}: {
+  uniqueId?: UniqueId;
+  filterZeroBalance?: boolean;
+}) {
   const { currentAddress } = useCurrentAddressStore();
   const { currentCurrency: currency } = useCurrentCurrencyStore();
   return useCustomNetworkAssets(
     {
       address: currentAddress,
       currency,
+      filterZeroBalance,
     },
     {
       select: uniqueId ? selectUserAssetWithUniqueId(uniqueId) : undefined,

--- a/src/entries/popup/hooks/useGas.ts
+++ b/src/entries/popup/hooks/useGas.ts
@@ -100,8 +100,9 @@ const useGas = ({
       !enabled ||
       chainId !== ChainId.mainnet ||
       !nativeAsset
-    )
+    ) {
       return;
+    }
 
     const { data } = gasData as MeteorologyResponse;
     const currentBaseFee = data.currentBaseFee;
@@ -318,7 +319,6 @@ export const useTransactionGas = ({
     chainId,
     transactionRequest: useDebounce(transactionRequest, 500),
   });
-
   return useGas({
     chainId,
     address,

--- a/src/entries/popup/hooks/useNativeAsset.ts
+++ b/src/entries/popup/hooks/useNativeAsset.ts
@@ -34,9 +34,10 @@ export const useNativeAsset = ({
     chainId,
   });
 
-  const { data: customNetworkNativeAsset } = useCustomNetworkAsset(
-    `${AddressZero}_${chainId}`,
-  );
+  const { data: customNetworkNativeAsset } = useCustomNetworkAsset({
+    uniqueId: `${AddressZero}_${chainId}`,
+    filterZeroBalance: false,
+  });
 
   const chain = chains.find((chain) => chain.id === chainId);
   const isChainIdCustomNetwork = isCustomChain(chainId);

--- a/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
@@ -192,7 +192,7 @@ function NetworkBanner({
   if (chainId === ChainId.mainnet) return null;
 
   const chainName =
-    ChainNameDisplay[chainId] || findCustomChainForChainId(chainId)?.name;
+    ChainNameDisplay[chainId] || findCustomChainForChainId(chainId)?.name || '';
 
   return (
     <>

--- a/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
@@ -316,7 +316,7 @@ export function TokenDetails() {
 
   const { data: userAsset, isFetched } = useUserAsset(uniqueId);
   const { data: customAsset, isFetched: isCustomAssetFetched } =
-    useCustomNetworkAsset(uniqueId);
+    useCustomNetworkAsset({ uniqueId });
 
   const { isWatchingWallet } = useWallets();
 

--- a/src/entries/popup/pages/send/ReviewSheet.tsx
+++ b/src/entries/popup/pages/send/ReviewSheet.tsx
@@ -514,40 +514,45 @@ export const ReviewSheet = ({
           {notSendingOnEthereum && (
             <Box paddingHorizontal="16px" paddingBottom="20px">
               <Stack space="20px">
-                {isSideChain(chain?.id || ChainId.mainnet) ? (
-                  <Box
-                    as={motion.div}
-                    background="fillSecondary"
-                    padding="8px"
-                    width="full"
-                    borderRadius="12px"
-                    onClick={showL2Explainer}
-                    initial={{ zIndex: 0 }}
-                    whileHover={{ scale: transformScales['1.04'] }}
-                    whileTap={{ scale: transformScales['0.96'] }}
-                    transition={transitions.bounce}
-                  >
-                    <Inline alignVertical="center" alignHorizontal="justify">
-                      <Inline alignVertical="center" space="8px" wrap={false}>
-                        <ChainBadge
-                          chainId={asset?.chainId || ChainId.mainnet}
-                          size="16"
-                        />
-                        <Text size="12pt" weight="bold" color="labelSecondary">
-                          {i18n.t('send.review.sending_on_network', {
-                            chainName,
-                          })}
-                        </Text>
-                      </Inline>
+                <Box
+                  as={motion.div}
+                  background="fillSecondary"
+                  padding="8px"
+                  width="full"
+                  borderRadius="12px"
+                  onClick={() =>
+                    isSideChain(chain?.id || ChainId.mainnet)
+                      ? showL2Explainer()
+                      : null
+                  }
+                  initial={{ zIndex: 0 }}
+                  whileHover={{ scale: transformScales['1.04'] }}
+                  whileTap={{ scale: transformScales['0.96'] }}
+                  transition={transitions.bounce}
+                >
+                  <Inline alignVertical="center" alignHorizontal="justify">
+                    <Inline alignVertical="center" space="8px" wrap={false}>
+                      <ChainBadge
+                        chainId={asset?.chainId || ChainId.mainnet}
+                        size="16"
+                      />
+                      <Text size="12pt" weight="bold" color="labelSecondary">
+                        {i18n.t('send.review.sending_on_network', {
+                          chainName,
+                        })}
+                      </Text>
+                    </Inline>
+                    {isSideChain(chain?.id || ChainId.mainnet) ? (
                       <Symbol
                         weight="bold"
                         symbol="info.circle.fill"
                         size={12}
                         color="labelTertiary"
                       />
-                    </Inline>
-                  </Box>
-                ) : null}
+                    ) : null}
+                  </Inline>
+                </Box>
+
                 <Box paddingHorizontal="7px">
                   <Stack space="12px">
                     <Columns alignVertical="center" space="7px">

--- a/src/entries/popup/pages/send/ReviewSheet.tsx
+++ b/src/entries/popup/pages/send/ReviewSheet.tsx
@@ -266,7 +266,8 @@ export const ReviewSheet = ({
   >;
 }) => {
   const { visibleOwnedWallets } = useWallets();
-  const [sendingOnL2Checks, setSendingOnL2Checks] = useState(false);
+  const [notSendingOnEthereumChecks, setNotSendingOnEthereumChecks] =
+    useState(false);
   const prevShow = usePrevious(show);
   const [sending, setSending] = useState(false);
   const confirmSendButtonRef = useRef<HTMLButtonElement>(null);
@@ -279,8 +280,10 @@ export const ReviewSheet = ({
     isCustomChain(asset?.chainId as ChainId) &&
     asset?.native?.balance?.amount === '0';
 
-  const sendingOnL2 = useMemo(
-    () => isL2Chain(asset?.chainId || ChainId.mainnet),
+  const notSendingOnEthereum = useMemo(
+    () =>
+      isL2Chain(asset?.chainId || ChainId.mainnet) ||
+      isCustomChain(asset?.chainId || ChainId.mainnet),
     [asset?.chainId],
   );
 
@@ -294,10 +297,10 @@ export const ReviewSheet = ({
     [toAddress, visibleOwnedWallets],
   );
 
-  const sendEnabled = useMemo(() => {
-    if (!sendingOnL2) return true;
-    return sendingOnL2Checks;
-  }, [sendingOnL2, sendingOnL2Checks]);
+  const sendEnabled = useMemo(
+    () => !notSendingOnEthereum || notSendingOnEthereumChecks,
+    [notSendingOnEthereum, notSendingOnEthereumChecks],
+  );
 
   const handleSend = useCallback(async () => {
     if (sendEnabled && !sending) {
@@ -326,7 +329,7 @@ export const ReviewSheet = ({
 
   useEffect(() => {
     if (prevShow && !show) {
-      setSendingOnL2Checks(false);
+      setNotSendingOnEthereumChecks(false);
     }
   }, [prevShow, show]);
 
@@ -494,12 +497,14 @@ export const ReviewSheet = ({
                     </Columns>
                   </Row>
                 </Rows>
-                {sendingOnL2 && <Separator color="separatorTertiary" />}
+                {notSendingOnEthereum && (
+                  <Separator color="separatorTertiary" />
+                )}
               </Stack>
             </Box>
           </Stack>
 
-          {sendingOnL2 && (
+          {notSendingOnEthereum && (
             <Box paddingHorizontal="16px" paddingBottom="20px">
               <Stack space="20px">
                 <Box
@@ -542,12 +547,14 @@ export const ReviewSheet = ({
                           width="16px"
                           height="16px"
                           borderRadius="6px"
-                          selected={sendingOnL2Checks}
+                          selected={notSendingOnEthereumChecks}
                           backgroundSelected="blue"
                           borderColorSelected="blue"
                           borderColor="labelTertiary"
                           onClick={() =>
-                            setSendingOnL2Checks(!sendingOnL2Checks)
+                            setNotSendingOnEthereumChecks(
+                              !notSendingOnEthereumChecks,
+                            )
                           }
                         />
                       </Column>
@@ -555,7 +562,9 @@ export const ReviewSheet = ({
                         <Lens
                           testId="L2-check-1"
                           onClick={() =>
-                            setSendingOnL2Checks(!sendingOnL2Checks)
+                            setNotSendingOnEthereumChecks(
+                              !notSendingOnEthereumChecks,
+                            )
                           }
                         >
                           <Text

--- a/src/entries/popup/pages/send/ReviewSheet.tsx
+++ b/src/entries/popup/pages/send/ReviewSheet.tsx
@@ -1,3 +1,4 @@
+import { getNetwork } from '@wagmi/core';
 import { motion } from 'framer-motion';
 import React, {
   useCallback,
@@ -271,23 +272,29 @@ export const ReviewSheet = ({
   const prevShow = usePrevious(show);
   const [sending, setSending] = useState(false);
   const confirmSendButtonRef = useRef<HTMLButtonElement>(null);
+  const { chains } = getNetwork();
+  const chain = useMemo(
+    () => chains.find((c) => c.id === asset?.chainId),
+    [asset?.chainId, chains],
+  );
 
   const { displayName: walletDisplayName } = useWalletInfo({
     address: toAddress,
   });
 
   const shouldHideAmount =
-    isCustomChain(asset?.chainId as ChainId) &&
+    isCustomChain(chain?.id as ChainId) &&
     asset?.native?.balance?.amount === '0';
 
   const notSendingOnEthereum = useMemo(
     () =>
-      isL2Chain(asset?.chainId || ChainId.mainnet) ||
-      isCustomChain(asset?.chainId || ChainId.mainnet),
-    [asset?.chainId],
+      isL2Chain(chain?.id || ChainId.mainnet) ||
+      isCustomChain(chain?.id || ChainId.mainnet),
+    [chain?.id],
   );
 
-  const chainName = ChainNameDisplay[asset?.chainId || ChainId.mainnet];
+  const chainName =
+    ChainNameDisplay[asset?.chainId || ChainId.mainnet] || chain?.name;
 
   const isToWalletOwner = useMemo(
     () =>
@@ -507,38 +514,40 @@ export const ReviewSheet = ({
           {notSendingOnEthereum && (
             <Box paddingHorizontal="16px" paddingBottom="20px">
               <Stack space="20px">
-                <Box
-                  as={motion.div}
-                  background="fillSecondary"
-                  padding="8px"
-                  width="full"
-                  borderRadius="12px"
-                  onClick={showL2Explainer}
-                  initial={{ zIndex: 0 }}
-                  whileHover={{ scale: transformScales['1.04'] }}
-                  whileTap={{ scale: transformScales['0.96'] }}
-                  transition={transitions.bounce}
-                >
-                  <Inline alignVertical="center" alignHorizontal="justify">
-                    <Inline alignVertical="center" space="8px">
-                      <ChainBadge
-                        chainId={asset?.chainId || ChainId.mainnet}
-                        size="16"
+                {isSideChain(chain?.id || ChainId.mainnet) ? (
+                  <Box
+                    as={motion.div}
+                    background="fillSecondary"
+                    padding="8px"
+                    width="full"
+                    borderRadius="12px"
+                    onClick={showL2Explainer}
+                    initial={{ zIndex: 0 }}
+                    whileHover={{ scale: transformScales['1.04'] }}
+                    whileTap={{ scale: transformScales['0.96'] }}
+                    transition={transitions.bounce}
+                  >
+                    <Inline alignVertical="center" alignHorizontal="justify">
+                      <Inline alignVertical="center" space="8px" wrap={false}>
+                        <ChainBadge
+                          chainId={asset?.chainId || ChainId.mainnet}
+                          size="16"
+                        />
+                        <Text size="12pt" weight="bold" color="labelSecondary">
+                          {i18n.t('send.review.sending_on_network', {
+                            chainName,
+                          })}
+                        </Text>
+                      </Inline>
+                      <Symbol
+                        weight="bold"
+                        symbol="info.circle.fill"
+                        size={12}
+                        color="labelTertiary"
                       />
-                      <Text size="12pt" weight="bold" color="labelSecondary">
-                        {i18n.t('send.review.sending_on_network', {
-                          chainName,
-                        })}
-                      </Text>
                     </Inline>
-                    <Symbol
-                      weight="bold"
-                      symbol="info.circle.fill"
-                      size={12}
-                      color="labelTertiary"
-                    />
-                  </Inline>
-                </Box>
+                  </Box>
+                ) : null}
                 <Box paddingHorizontal="7px">
                   <Stack space="12px">
                     <Columns alignVertical="center" space="7px">


### PR DESCRIPTION
Fixes BX-1194
Figma link (if any):

## What changed (plus any additional context for devs)

- adding send checks for custom rpcs
- fetching native assets for tx fee, there was a bug where users with a token balance but no native asset balance would see "undefined" as tx fee when trying to send a token since we were filtering out native assets with balance 0

## Screen recordings / screenshots

<img width="464" alt="image" src="https://github.com/rainbow-me/browser-extension/assets/12115171/f782f06e-e743-4543-9a16-e257aaac74a5">



<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
