### PR TITLE
Fix asset deduping

### DIFF
--- a/src/entries/popup/hooks/send/useSendAsset.ts
+++ b/src/entries/popup/hooks/send/useSendAsset.ts
@@ -1,4 +1,4 @@
-import sortedUniqBy from 'lodash/sortedUniqBy';
+import uniqBy from 'lodash/uniqBy';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -67,7 +67,7 @@ export const useSendAsset = () => {
 
   const allAssets = useMemo(
     () =>
-      sortedUniqBy(
+      uniqBy(
         [...assets, ...customNetworkAssets].sort(
           (a: ParsedUserAsset, b: ParsedUserAsset) =>
             parseFloat(b?.native?.balance?.amount) -

--- a/src/entries/popup/hooks/useVisibleTokenCount.ts
+++ b/src/entries/popup/hooks/useVisibleTokenCount.ts
@@ -1,4 +1,4 @@
-import sortedUniqBy from 'lodash/sortedUniqBy';
+import uniqBy from 'lodash/uniqBy';
 import { useMemo } from 'react';
 
 import {
@@ -51,7 +51,7 @@ export const useVisibleTokenCount = () => {
 
   const allAssets = useMemo(
     () =>
-      sortedUniqBy(
+      uniqBy(
         [...assets, ...customNetworkAssets].sort(
           (a: ParsedUserAsset, b: ParsedUserAsset) =>
             parseFloat(b?.native?.balance?.amount) -

--- a/src/entries/popup/pages/home/Tokens.tsx
+++ b/src/entries/popup/pages/home/Tokens.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { motion } from 'framer-motion';
-import sortedUniqBy from 'lodash/sortedUniqBy';
+import uniqBy from 'lodash/uniqBy';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Address } from 'wagmi';
 
@@ -123,9 +123,12 @@ export function Tokens() {
     },
   );
 
+  console.log('assets', assets);
+  console.log('customNetworkAssets', customNetworkAssets);
+
   const allAssets = useMemo(
     () =>
-      sortedUniqBy(
+      uniqBy(
         [...assets, ...customNetworkAssets].sort(
           (a: ParsedUserAsset, b: ParsedUserAsset) =>
             parseFloat(b?.native?.balance?.amount) -
@@ -135,6 +138,8 @@ export function Tokens() {
       ),
     [assets, customNetworkAssets],
   );
+
+  console.log('allAssets', allAssets);
 
   const containerRef = useContainerRef();
   const assetsRowVirtualizer = useVirtualizer({

--- a/src/entries/popup/pages/home/Tokens.tsx
+++ b/src/entries/popup/pages/home/Tokens.tsx
@@ -123,9 +123,6 @@ export function Tokens() {
     },
   );
 
-  console.log('assets', assets);
-  console.log('customNetworkAssets', customNetworkAssets);
-
   const allAssets = useMemo(
     () =>
       uniqBy(
@@ -138,8 +135,6 @@ export function Tokens() {
       ),
     [assets, customNetworkAssets],
   );
-
-  console.log('allAssets', allAssets);
 
   const containerRef = useContainerRef();
   const assetsRowVirtualizer = useVirtualizer({


### PR DESCRIPTION
Fixes BX-1216
Figma link (if any):

## What changed (plus any additional context for devs)

The assumption the assets array was already sorted before deduping is wrong since assets with no balance are randomly sorted at the end.

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
