### PR TITLE
[BX-1258] Make wallet search autoFocus + buttons keyboard nav friendly

### DIFF
--- a/src/entries/popup/pages/walletSwitcher/index.tsx
+++ b/src/entries/popup/pages/walletSwitcher/index.tsx
@@ -386,6 +386,7 @@ export function WalletSwitcher() {
           onChange={(e) => setSearchQuery(e.target.value)}
           innerRef={searchInputRef}
           tabIndex={0}
+          autoFocus
         />
         <QuickPromo
           text={i18n.t('wallet_switcher.quick_promo.text')}
@@ -432,6 +433,7 @@ export function WalletSwitcher() {
             width="full"
             borderRadius="9px"
             testId={'add-wallet-button'}
+            tabIndex={0}
           >
             {i18n.t('wallet_switcher.add_another_wallet')}
           </Button>
@@ -446,6 +448,7 @@ export function WalletSwitcher() {
               height="32px"
               width="full"
               borderRadius="9px"
+              tabIndex={0}
             >
               {i18n.t('wallet_switcher.connect_hardware_wallet')}
             </Button>
@@ -461,6 +464,7 @@ export function WalletSwitcher() {
               height="32px"
               width="full"
               borderRadius="9px"
+              tabIndex={0}
             >
               Old Wallets UI [DEV]
             </Button>


### PR DESCRIPTION
This now auto-focuses:

<img width="351" alt="Screenshot 2024-01-12 at 12 32 00 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/f1ae7db2-ac1c-40af-8fd7-4d2b1606cbf6">

These can now be keyboard nav'd:

<img width="339" alt="Screenshot 2024-01-12 at 12 32 05 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/43cde7ec-44a7-434a-9368-5ccaa99d9b6e">

<video src="https://github.com/rainbow-me/browser-extension/assets/41711440/7dc81c31-8a86-4ada-8fe1-63c13db0ce54" >