### PR TITLE
fix: custom gas for mainnet only

### DIFF
--- a/src/entries/popup/components/TransactionFee/TransactionFee.tsx
+++ b/src/entries/popup/components/TransactionFee/TransactionFee.tsx
@@ -207,34 +207,36 @@ function Fee({
               dropdownContentMarginRight={speedMenuMarginRight}
               ref={switchTransactionSpeedMenuRef}
             />
-            <CursorTooltip
-              align="end"
-              arrowAlignment="right"
-              arrowCentered
-              text={i18n.t('tooltip.gwei_settings')}
-              textWeight="bold"
-              textSize="12pt"
-              textColor="labelSecondary"
-              hint={shortcuts.global.OPEN_CUSTOM_GAS_MENU.display}
-            >
-              <Lens
-                borderRadius="round"
-                boxShadow="12px accent"
-                borderWidth="2px"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                borderColor="fillSecondary"
-                style={{ height: 28, width: 28 }}
-                onClick={openCustomGasSheet}
+            {chainId === ChainId.mainnet ? (
+              <CursorTooltip
+                align="end"
+                arrowAlignment="right"
+                arrowCentered
+                text={i18n.t('tooltip.gwei_settings')}
+                textWeight="bold"
+                textSize="12pt"
+                textColor="labelSecondary"
+                hint={shortcuts.global.OPEN_CUSTOM_GAS_MENU.display}
               >
-                <Symbol
-                  weight="medium"
-                  symbol="slider.horizontal.3"
-                  size={12}
-                />
-              </Lens>
-            </CursorTooltip>
+                <Lens
+                  borderRadius="round"
+                  boxShadow="12px accent"
+                  borderWidth="2px"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  borderColor="fillSecondary"
+                  style={{ height: 28, width: 28 }}
+                  onClick={openCustomGasSheet}
+                >
+                  <Symbol
+                    weight="medium"
+                    symbol="slider.horizontal.3"
+                    size={12}
+                  />
+                </Lens>
+              </CursorTooltip>
+            ) : null}
           </Inline>
         </Column>
       </Columns>


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

adding back custom gas only for mainnet introduced here https://github.com/rainbow-me/browser-extension/commit/488bb88b8f4d1444299affc0178113ab1d07bd44#diff-946bbcf208d616f064d91ab5f8614978c455f259c4811d8d77cfbea94d40d4a3L207

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
