### PR TITLE
fix: disable anonymized collection by default on firefox

### DIFF
--- a/src/core/state/currentSettings/analyticsDisabled.ts
+++ b/src/core/state/currentSettings/analyticsDisabled.ts
@@ -1,6 +1,7 @@
 import create from 'zustand';
 
 import { createStore } from '~/core/state/internal/createStore';
+import { getBrowser } from '~/entries/popup/hooks/useBrowser';
 
 export interface AnalyticsDisabledState {
   analyticsDisabled: boolean;
@@ -9,7 +10,7 @@ export interface AnalyticsDisabledState {
 
 export const analyticsDisabledStore = createStore<AnalyticsDisabledState>(
   (set) => ({
-    analyticsDisabled: false,
+    analyticsDisabled: getBrowser() === 'Firefox',
     setAnalyticsDisabled: (newanalyticsDisabled) =>
       set({ analyticsDisabled: newanalyticsDisabled }),
   }),


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- added browser check to default `analyticsDisabledStore` state for anonymized tracking

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test
- default tracking toggle on Firefox
<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
