### PR TITLE
Updated script to point to a specific version of ff dev edition

### DIFF
--- a/.github/actions/firefoxTestsSetup/action.yml
+++ b/.github/actions/firefoxTestsSetup/action.yml
@@ -1,15 +1,23 @@
-name: 'Firefox tests setup'
-description: 'runs Firefox tests setup'
+name: 'Custom Firefox Developer Edition Setup'
+description: 'Setup a specific version of Firefox Developer Edition for testing'
 inputs:
   gh-access-token:
-    description: 'Github Access Token'
+    description: 'GitHub Access Token'
     required: true
 runs:
   using: 'composite'
   steps:
-  - uses: ./.github/actions/testsSetup
-    with:
-      gh-access-token: ${{ inputs.gh-access-token }}
-  - uses: browser-actions/setup-firefox@v1
-    with:
-      firefox-version: 'latest-devedition'
+    - uses: ./.github/actions/testsSetup
+      with:
+        gh-access-token: ${{ inputs.gh-access-token }}
+
+    - name: Download and Setup Firefox Developer Edition
+      shell: bash
+      run: |
+        FIREFOX_DEVEDITION_VERSION="122.0b9"
+        FIREFOX_DEVEDITION_URL="https://ftp.mozilla.org/pub/devedition/releases/$FIREFOX_DEVEDITION_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_DEVEDITION_VERSION.tar.bz2"
+        echo "Downloading Firefox Developer Edition $FIREFOX_DEVEDITION_VERSION"
+        wget -q -O firefox.tar.bz2 $FIREFOX_DEVEDITION_URL
+        tar -xjf firefox.tar.bz2
+        echo "Firefox Developer Edition installed"
+        echo "$(pwd)/firefox/firefox" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
             export BROWSER=firefox
             export OS=linux
-            export FIREFOX_BIN=/opt/hostedtoolcache/firefox/latest-devedition/x64/firefox
+            export FIREFOX_BIN="$(pwd)/firefox/firefox"
             yarn firefox:manifest && yarn firefox:zip
             yarn vitest:parallel --retry=5
       - name: Upload deps artifacts
@@ -122,7 +122,7 @@ jobs:
   #         command: |
   #           export BROWSER=firefox
   #           export OS=linux
-  #           export FIREFOX_BIN=/opt/hostedtoolcache/firefox/latest-devedition/x64/firefox
+  #           export FIREFOX_BIN="$(pwd)/firefox/firefox"
   #           yarn firefox:manifest && yarn firefox:zip
   #           yarn vitest:swap --retry=5
   #     - name: Upload deps artifacts
@@ -156,7 +156,7 @@ jobs:
           command: |
             export BROWSER=firefox
             export OS=linux
-            export FIREFOX_BIN=/opt/hostedtoolcache/firefox/latest-devedition/x64/firefox
+            export FIREFOX_BIN="$(pwd)/firefox/firefox"
             yarn firefox:manifest && yarn firefox:zip
             yarn vitest:send --retry=5
       - name: Upload deps artifacts
@@ -190,7 +190,7 @@ jobs:
           command: |
             export BROWSER=firefox
             export OS=linux
-            export FIREFOX_BIN=/opt/hostedtoolcache/firefox/latest-devedition/x64/firefox
+            export FIREFOX_BIN="$(pwd)/firefox/firefox"
             yarn firefox:manifest && yarn firefox:zip
             yarn vitest:dappInteractions --retry=5
       - name: Upload deps artifacts

--- a/e2e/parallel/settingsFlows.test.ts
+++ b/e2e/parallel/settingsFlows.test.ts
@@ -42,14 +42,25 @@ describe('Navigate Settings & Privacy and its flows', () => {
 
   it('should be able to toggle analytics', async () => {
     await navigateToSettingsPrivacy(driver, rootURL);
+
     // find toggle status and expect to be true
-    expect(await toggleStatus('analytics-toggle', driver)).toBe('true');
+    if (browser === 'firefox') {
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('false');
 
-    await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
-    expect(await toggleStatus('analytics-toggle', driver)).toBe('false');
+      await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('true');
 
-    await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
-    expect(await toggleStatus('analytics-toggle', driver)).toBe('true');
+      await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('false');
+    } else {
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('true');
+
+      await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('false');
+
+      await findElementByTestIdAndClick({ id: 'analytics-toggle', driver });
+      expect(await toggleStatus('analytics-toggle', driver)).toBe('true');
+    }
   });
 
   it('should be able to hide asset balances', async () => {

--- a/e2e/parallel/shortcuts-settings.test.ts
+++ b/e2e/parallel/shortcuts-settings.test.ts
@@ -120,6 +120,35 @@ describe.runIf(browser !== 'firefox')(
 
     it('should be able to toggle analytics with keyboard', async () => {
       await delayTime('medium');
+      if (browser === 'firefox') {
+        const defaultToggleStatus = await toggleStatus(
+          'analytics-toggle',
+          driver,
+        );
+        expect(defaultToggleStatus).toBe('false');
+        await executePerformShortcut({ driver, key: 'TAB', timesToPress: 2 });
+        await executePerformShortcut({ driver, key: 'ENTER' });
+        await delayTime('long');
+        const changedToggleStatus = await toggleStatus(
+          'analytics-toggle',
+          driver,
+        );
+        expect(changedToggleStatus).toBe('true');
+      } else {
+        const defaultToggleStatus = await toggleStatus(
+          'analytics-toggle',
+          driver,
+        );
+        expect(defaultToggleStatus).toBe('true');
+        await executePerformShortcut({ driver, key: 'TAB', timesToPress: 2 });
+        await executePerformShortcut({ driver, key: 'ENTER' });
+        await delayTime('long');
+        const changedToggleStatus = await toggleStatus(
+          'analytics-toggle',
+          driver,
+        );
+        expect(changedToggleStatus).toBe('false');
+      }
       const defaultToggleStatus = await toggleStatus(
         'analytics-toggle',
         driver,

--- a/e2e/parallel/shortcuts-settings.test.ts
+++ b/e2e/parallel/shortcuts-settings.test.ts
@@ -149,19 +149,6 @@ describe.runIf(browser !== 'firefox')(
         );
         expect(changedToggleStatus).toBe('false');
       }
-      const defaultToggleStatus = await toggleStatus(
-        'analytics-toggle',
-        driver,
-      );
-      expect(defaultToggleStatus).toBe('true');
-      await executePerformShortcut({ driver, key: 'TAB', timesToPress: 2 });
-      await executePerformShortcut({ driver, key: 'ENTER' });
-      await delayTime('long');
-      const changedToggleStatus = await toggleStatus(
-        'analytics-toggle',
-        driver,
-      );
-      expect(changedToggleStatus).toBe('false');
     });
 
     it('should be able to toggle hide asset balances with keyboard', async () => {


### PR DESCRIPTION
- Updated script to point to a specific version of ff dev edition.

- Changes to the `SettingsFlows` test and `ShortcutSettingsFlows` were due to the default toggle behavior being changed on Firefox while these tests were broken.