### PR TITLE
Missing wrap={false} on activity details > contract address 

### DIFF
--- a/src/entries/popup/components/AddressDisplay.tsx
+++ b/src/entries/popup/components/AddressDisplay.tsx
@@ -146,7 +146,7 @@ const ContractDisplay = ({
   chainId?: ChainId;
 }) => {
   return (
-    <Inline space="6px" alignVertical="center">
+    <Inline space="6px" alignVertical="center" wrap={false}>
       {!hideAvatar && <AddressIcon iconUrl={iconUrl} address={address} />}
       <TextOverflow size="12pt" weight="semibold" color="labelQuaternary">
         {name}


### PR DESCRIPTION
Fixes BX-1305

The 'to' field on txn details when it was a contract was missing the `wrap={false}`
| Before | After |
|--------|-------|
| <img src="https://github.com/rainbow-me/browser-extension/assets/41711440/386ea3f9-9beb-4adf-b06b-fe084e8ff13d" width="363" alt="Screenshot 2024-02-06 at 2 14 36 PM"> | <img src="https://github.com/rainbow-me/browser-extension/assets/41711440/b119f308-6e94-48d2-9026-73497cf1c11d" width="363" alt="Screenshot 2024-02-06 at 2 14 36 PM"> |
