### PR TITLE
fix: Don't route the rpcUrl through proxy if it's on a local IP range

### DIFF
--- a/src/core/providers/proxy.ts
+++ b/src/core/providers/proxy.ts
@@ -3,7 +3,10 @@ import { ChainId } from '../types/chains';
 export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
   if (
     endpoint !== 'http://127.0.0.1:8545' &&
-    endpoint !== 'http://localhost:8545'
+    endpoint !== 'http://localhost:8545' &&
+    !endpoint.includes('http://10.') &&
+    !endpoint.includes('http://192.') &&
+    !endpoint.includes('http://172.')
   ) {
     return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${
       process.env.RPC_PROXY_API_KEY


### PR DESCRIPTION
Fixes BX-####
Figma link (if any): -

## What changed (plus any additional context for devs)
Made `src\core\providers\proxy.ts` not proxy the traffic if the provided `rpcUrl` is running within a local IP range.

Context:

I was trying to add a RPC running on my local network (but not on my `localhost`) and Rainbow would throw the `rpc_not_responding` error. Upon looking into the code, I was able to see how that error would be caused by `useChainMetadata()` in `src\entries\popup\pages\settings\customChain\index.tsx`.

A few function calls deep, I've reached `getChainMetadataRPCUrl()` (L323) in `src\core\utils\chains.ts`. I've noticed that in L329, the `rpcUrl` is passed to `proxyRpcEndpoint()` before being further used by `JsonRpcProvider` from Ethers.

Within `proxyRpcEndpoint()` it seems that the code checks whether the RPC is running on `localhost` or `127.0.0.1`. If that is the case, it leaves the URL as it is. If it is something different, it appears to proxy the traffic through your servers (?) before sending the requests to the actual RPC.

This will not work if the provided URL is on user's local network (but not on `localhost`). If the IP starts with 10, 192 or 172, it should not be routed through your proxy.

## Screen recordings / screenshots
![image](https://github.com/rainbow-me/browser-extension/assets/87016182/0dd067a2-72cd-462d-83e6-d0df6dfb06dd)

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

Try to add a custom RPC which runs on your local network, but not on the same device.
