### PR TITLE
Remove secret phrase option on right click context - HW wallets

### DIFF
--- a/src/entries/popup/pages/settings/walletsAndKeys/walletsAndKeys.tsx
+++ b/src/entries/popup/pages/settings/walletsAndKeys/walletsAndKeys.tsx
@@ -89,17 +89,19 @@ function WalletsAndKeysContextMenu({
           <div>{children}</div>
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem
-            symbolLeft="lock.square.fill"
-            onSelect={() =>
-              navigate(
-                ROUTES.SETTINGS__PRIVACY__WALLETS_AND_KEYS__WALLET_DETAILS__RECOVERY_PHRASE_WARNING,
-                { state: { wallet } },
-              )
-            }
-          >
-            {t('context_menu.view_secret_phrase')}
-          </ContextMenuItem>
+          {wallet.type !== KeychainType.HardwareWalletKeychain && (
+            <ContextMenuItem
+              symbolLeft="lock.square.fill"
+              onSelect={() =>
+                navigate(
+                  ROUTES.SETTINGS__PRIVACY__WALLETS_AND_KEYS__WALLET_DETAILS__RECOVERY_PHRASE_WARNING,
+                  { state: { wallet } },
+                )
+              }
+            >
+              {t('context_menu.view_secret_phrase')}
+            </ContextMenuItem>
+          )}
           <ContextMenuItem
             symbolLeft="plus.circle.fill"
             onSelect={() => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Right click could direct to secret phrase reveal on HW wallets
- This just hides the button on hw wallets

## Screen recordings / screenshots
<video src="https://github.com/rainbow-me/browser-extension/assets/41711440/45ba08f0-8f77-4bff-9184-4e29a36cb53e">