### PR TITLE
BX-1275 Simulation reverse arrows and colors

### DIFF
--- a/src/entries/popup/pages/messages/Simulation.tsx
+++ b/src/entries/popup/pages/messages/Simulation.tsx
@@ -123,23 +123,6 @@ export function SimulationOverview({
           <SimulationNoChangesDetected />
         ) : (
           <Stack space="14px">
-            {simulation.in.map(({ asset, quantity }, i) => (
-              <SimulatedChangeRow
-                key={`${asset.address}${i}`}
-                asset={asset}
-                quantity={quantity}
-                color="green"
-                symbol={
-                  <Symbol
-                    size={14}
-                    symbol="arrow.up.circle.fill"
-                    weight="bold"
-                    color="green"
-                  />
-                }
-                label={i18n.t('simulation.received')}
-              />
-            ))}
             {simulation.out.map(({ asset, quantity }, i) => (
               <SimulatedChangeRow
                 key={`${asset.address}${i}`}
@@ -149,12 +132,29 @@ export function SimulationOverview({
                 symbol={
                   <Symbol
                     size={14}
-                    symbol="arrow.down.circle.fill"
+                    symbol="arrow.up.circle.fill"
                     weight="bold"
                     color="red"
                   />
                 }
                 label={i18n.t('simulation.sent')}
+              />
+            ))}
+            {simulation.in.map(({ asset, quantity }, i) => (
+              <SimulatedChangeRow
+                key={`${asset.address}${i}`}
+                asset={asset}
+                quantity={quantity}
+                color="green"
+                symbol={
+                  <Symbol
+                    size={14}
+                    symbol="arrow.down.circle.fill"
+                    weight="bold"
+                    color="green"
+                  />
+                }
+                label={i18n.t('simulation.received')}
               />
             ))}
             {simulation?.approvals?.map(({ asset, quantityAllowed }, i) => (


### PR DESCRIPTION
Fixes [BX-1275](https://linear.app/rainbow/issue/BX-1275/reversed-arrows-and-colors-in-transaction-details)
Figma link (if any):

## What changed (plus any additional context for devs)

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
