### PR TITLE
[BX-1331][BX-1332] Swap Default Values

### DIFF
--- a/e2e/serial/swap/1_swapFlow1.test.ts
+++ b/e2e/serial/swap/1_swapFlow1.test.ts
@@ -272,7 +272,7 @@ it.skip('should be able to set default values for settings and go back to swap',
 
 it('should be able to open token to sell input and select assets', async () => {
   await findElementByTestIdAndClick({
-    id: 'token-to-sell-search-token-input',
+    id: `${SWAP_VARIABLES.ETH_MAINNET_ID}-token-to-sell-token-input-remove`,
     driver,
   });
   await findElementByTestIdAndClick({

--- a/e2e/serial/swap/2_swapFlow2.test.ts
+++ b/e2e/serial/swap/2_swapFlow2.test.ts
@@ -117,11 +117,16 @@ it('should be able to connect to hardhat', async () => {
 });
 
 it('should be able to go to swap flow', async () => {
+  await delayTime('very-long');
   await findElementByTestIdAndClick({ id: 'header-link-swap', driver });
   await delayTime('long');
 });
 
 it('should be able to go to review a unlock and swap', async () => {
+  await findElementByTestIdAndClick({
+    id: `${SWAP_VARIABLES.ETH_MAINNET_ID}-token-to-sell-token-input-remove`,
+    driver,
+  });
   await findElementByTestIdAndClick({
     id: `${SWAP_VARIABLES.USDC_MAINNET_ID}-token-to-sell-row`,
     driver,

--- a/e2e/serial/swap/3_shortcuts-swapFlow.test.ts
+++ b/e2e/serial/swap/3_shortcuts-swapFlow.test.ts
@@ -113,6 +113,17 @@ describe('Complete swap flow via shortcuts and keyboard navigation', () => {
   });
 
   it('should be able to select asset to sell with keyboard navigation', async () => {
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_UP',
+      timesToPress: 2,
+    });
+    await executePerformShortcut({
+      driver,
+      key: 'ENTER',
+      timesToPress: 1,
+    });
+
     const inputSearch = await findElementByTestId({
       id: 'token-to-sell-search-token-input',
       driver,

--- a/src/entries/popup/hooks/swap/useSwapInputs.ts
+++ b/src/entries/popup/hooks/swap/useSwapInputs.ts
@@ -173,8 +173,13 @@ export const useSwapInputs = ({
   const setAssetToSellMaxValue = useCallback(() => {
     setAssetToSellValue(assetToSellMaxValue.amount);
     setIndependentValue(assetToSellMaxValue.amount);
+    saveSwapAmount({ amount: assetToSellMaxValue.amount });
     setIndependentFieldIfOccupied('sellField');
-  }, [assetToSellMaxValue.amount, setIndependentFieldIfOccupied]);
+  }, [
+    assetToSellMaxValue.amount,
+    saveSwapAmount,
+    setIndependentFieldIfOccupied,
+  ]);
 
   const flipAssets = useCallback(() => {
     if (bridge && assetToSell && !assetToBuy) return;

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -163,6 +163,8 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
   const [inputToOpenOnMount, setInputToOpenOnMount] = useState<
     'sell' | 'buy' | null
   >(null);
+  const [defaultAssetWasSet, setDefaultAssetWasSet] = useState<boolean>(false);
+  const [defaultValueWasSet, setDefaultValueWasSet] = useState<boolean>(false);
   const { isFirefox } = useBrowser();
 
   // translate based on the context, bridge or swap
@@ -393,7 +395,8 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
         if (savedTokenToSell) {
           setAssetToSell(savedTokenToSell);
         } else {
-          setInputToOpenOnMount('sell');
+          setAssetToSell(assetsToSell[0]);
+          setDefaultAssetWasSet(true);
         }
         setDidPopulateSavedTokens(true);
       }
@@ -419,6 +422,12 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
             break;
         }
       }
+    }
+
+    if (defaultAssetWasSet && !defaultValueWasSet) {
+      setAssetToSellMaxValue();
+      setDefaultValueWasSet(true);
+      assetToBuyInputRef.current?.focus();
     }
 
     return () => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Selecting highest balance assets and setting max value by default. This behavior is overridden by `selectedToken` flows and saved swap values.

## Screen recordings / screenshots
PoW: https://recordit.co/h5tD15KHoJ

## What to test
Ensure the new defaults populate when navigating directly to swap with no saved values.
