### PR TITLE
[BX-1139] support enter/return keypress to submit "save contact" form

### DIFF
--- a/src/core/providers/proxy.ts
+++ b/src/core/providers/proxy.ts
@@ -4,9 +4,9 @@ export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
   if (
     endpoint !== 'http://127.0.0.1:8545' &&
     endpoint !== 'http://localhost:8545' &&
-    !endpoint.includes('http://10.') &&
-    !endpoint.includes('http://192.168') &&
-    !endpoint.match(/http:\/\/172.(1[6-9]|2[0-9]|3[0-1])./)
+    !endpoint?.includes('http://10.') &&
+    !endpoint?.includes('http://192.168') &&
+    !endpoint?.match(/http:\/\/172.(1[6-9]|2[0-9]|3[0-1])./)
   ) {
     return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${
       process.env.RPC_PROXY_API_KEY

--- a/src/entries/popup/pages/send/ContactPrompt.tsx
+++ b/src/entries/popup/pages/send/ContactPrompt.tsx
@@ -95,6 +95,8 @@ const SaveOrEditContact = ({
         </Stack>
         <Stack alignHorizontal="center" space="8px">
           <Button
+            symbol="return.left"
+            symbolSide="left"
             width="full"
             color="accent"
             height="36px"
@@ -103,6 +105,8 @@ const SaveOrEditContact = ({
             onClick={onSave}
             tabIndex={2}
             testId="contact-prompt-confirm"
+            autoFocus
+            enterCta
           >
             {i18n.t(
               `contacts.${
@@ -186,6 +190,7 @@ const DeleteContact = ({
             borderRadius="9px"
             onClick={onRemove}
             testId="contact-prompt-delete-confirm"
+            tabIndex={1}
           >
             {i18n.t('contacts.remove_contact_action')}
           </Button>
@@ -196,6 +201,7 @@ const DeleteContact = ({
             variant="raised"
             borderRadius="9px"
             onClick={onCancel}
+            tabIndex={2}
           >
             {i18n.t('contacts.cancel')}
           </Button>


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
Autofocusing save contact cta, added return key symbol, and added keyboard nav to delete form

## Screen recordings / screenshots
PoW: https://recordit.co/0QqjXsPKaO

## What to test
Check that the save contact cta autofocuses and that you can press enter to save
