### PR TITLE
fix: BX-1350

### DIFF
--- a/src/core/resources/assets/customNetworkAssets.ts
+++ b/src/core/resources/assets/customNetworkAssets.ts
@@ -12,6 +12,7 @@ import {
   queryClient,
 } from '~/core/react-query';
 import {
+  ETH_ADDRESS,
   SUPPORTED_MAINNET_CHAINS,
   SupportedCurrencyKey,
 } from '~/core/references';
@@ -38,7 +39,6 @@ import {
 import { getRainbowChains } from '~/core/utils/chains';
 import { convertDecimalFormatToRawAmount, isZero } from '~/core/utils/numbers';
 import { RainbowError, logger } from '~/logger';
-import { ETH_MAINNET_ASSET } from '~/test/utils';
 
 import { ASSETS_TIMEOUT_DURATION } from './assets';
 
@@ -202,10 +202,6 @@ async function customNetworkAssetsFunction({
       )
       .map(async (chain) => {
         const provider = getProvider({ chainId: chain.id });
-        const nativeAssetAddress =
-          chain.id === ChainId.mainnet
-            ? ETH_MAINNET_ASSET.address
-            : AddressZero;
         const nativeAssetBalance = (
           await provider.getBalance(address)
         )?.toString();
@@ -214,19 +210,19 @@ async function customNetworkAssetsFunction({
           (filterZeroBalance ? !isZero(nativeAssetBalance) : true)
             ? parseUserAssetBalances({
                 asset: {
-                  address: nativeAssetAddress,
+                  address: AddressZero,
                   chainId: chain.id,
                   chainName: chain.name as ChainName,
                   isNativeAsset: true,
                   name: chain.nativeCurrency.symbol,
                   symbol: chain.nativeCurrency.symbol,
-                  uniqueId: `${'eth'}_${chain.id}`,
+                  uniqueId: `${ETH_ADDRESS}_${chain.id}`,
                   decimals: 18,
                   native: { price: undefined },
                   price: { value: 0 },
                   bridging: { isBridgeable: false, networks: [] },
-                  mainnetAddress: nativeAssetAddress as AddressOrEth,
-                  icon_url: getCustomChainIconUrl(chain.id, nativeAssetAddress),
+                  mainnetAddress: ETH_ADDRESS as AddressOrEth,
+                  icon_url: getCustomChainIconUrl(chain.id, ETH_ADDRESS),
                 },
                 currency,
                 balance: nativeAssetBalance,

--- a/src/entries/popup/hooks/useNativeAsset.ts
+++ b/src/entries/popup/hooks/useNativeAsset.ts
@@ -1,7 +1,6 @@
-import { AddressZero } from '@ethersproject/constants';
 import { Address, useNetwork } from 'wagmi';
 
-import { NATIVE_ASSETS_MAP_PER_CHAIN } from '~/core/references';
+import { ETH_ADDRESS, NATIVE_ASSETS_MAP_PER_CHAIN } from '~/core/references';
 import { useUserTestnetNativeAsset } from '~/core/resources/assets/userTestnetNativeAsset';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { ParsedUserAsset } from '~/core/types/assets';
@@ -63,7 +62,7 @@ export const useNativeAsset = ({
   });
 
   const { data: customNetworkNativeAsset } = useCustomNetworkAsset({
-    uniqueId: `${AddressZero}_${chainId}`,
+    uniqueId: `${ETH_ADDRESS}_${chainId}`,
     filterZeroBalance: false,
   });
 

--- a/src/entries/popup/hooks/useVisibleTokenCount.ts
+++ b/src/entries/popup/hooks/useVisibleTokenCount.ts
@@ -49,6 +49,9 @@ export const useVisibleTokenCount = () => {
     },
   );
 
+  console.log('assets', assets);
+  console.log('customNetworkAssets', customNetworkAssets);
+
   const allAssets = useMemo(
     () =>
       uniqBy(

--- a/src/entries/popup/hooks/useVisibleTokenCount.ts
+++ b/src/entries/popup/hooks/useVisibleTokenCount.ts
@@ -49,9 +49,6 @@ export const useVisibleTokenCount = () => {
     },
   );
 
-  console.log('assets', assets);
-  console.log('customNetworkAssets', customNetworkAssets);
-
   const allAssets = useMemo(
     () =>
       uniqBy(


### PR DESCRIPTION
Fixes BX-1350
Figma link (if any):

## What changed (plus any additional context for devs)

last week fixing blast i made this change https://github.com/rainbow-me/browser-extension/pull/1383/files#diff-3b6eb6e4c37dcc8c725f157d7953e3de4245db86d2724ccd45939fba1793bd62R223 to emulate what backend returns as uniqueId for native asset

that was correct but i didn't change it in the method that gives us the native asset while estimating gas https://github.com/rainbow-me/browser-extension/pull/1405/files#diff-4fd4cdb2833891791c48304800a1085b7c1c170b44e79c2121a5e3d701f7ce65R65 so native asset was undefined for custom networks, causing the issue

I updated all instances of this to have custom native tokens in the same format as backend


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
