### PR TITLE
fix: BX-1358

### DIFF
--- a/src/design-system/components/Box/ColorContext.tsx
+++ b/src/design-system/components/Box/ColorContext.tsx
@@ -167,9 +167,11 @@ const RawAccentColorProvider = createColorProvider(
 
 export const AccentColorProvider = ({
   color,
+  respectColor,
   children,
 }: {
   color?: string;
+  respectColor?: boolean;
   children: AccentColorContextProviderProps['children'];
 }) => {
   const { currentTheme } = useCurrentThemeStore();
@@ -179,7 +181,11 @@ export const AccentColorProvider = ({
       : foregroundColors.labelQuaternary.light;
   return (
     <RawAccentColorProvider
-      color={handleAccentColor(currentTheme, color || defaultColor)}
+      color={
+        respectColor
+          ? color || defaultColor
+          : handleAccentColor(currentTheme, color || defaultColor)
+      }
     >
       {children}
     </RawAccentColorProvider>

--- a/src/entries/popup/components/AppConnection/AppConnectionNudgeBanner.tsx
+++ b/src/entries/popup/components/AppConnection/AppConnectionNudgeBanner.tsx
@@ -151,6 +151,7 @@ export const AppConnectionNudgeBanner = ({
                           ? globalColors.grey100
                           : globalColors.white100
                       }
+                      respectColor
                     >
                       <Box
                         style={{ opacity: useDarkForegroundColor ? 0.65 : 1 }}


### PR DESCRIPTION
Fixes BX-1358
Figma link (if any):

## What changed (plus any additional context for devs)

change introduced here https://github.com/rainbow-me/browser-extension/pull/1003 was making the black color to adjust to a gray since the contract with dark theme was low, which makes sense but here we're using it with avatar color as background

so i added a flag `respectColor` to skip that color treatment if is present

## Screen recordings / screenshots

<img width="647" alt="image" src="https://github.com/rainbow-me/browser-extension/assets/12115171/ac213817-134a-4245-8b7e-135fe80e4d50">


<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
