### PR TITLE
fix: airdrop tx detail crash

### DIFF
--- a/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
@@ -234,7 +234,7 @@ function NetworkData({ transaction: tx }: { transaction: RainbowTransaction }) {
         <InfoRow
           symbol="dollarsign.square"
           label={i18n.t('activity_details.value')}
-          value={`${formatEther(value)} ${chain.nativeCurrency.symbol}`}
+          value={`${formatEther(+value)} ${chain.nativeCurrency.symbol}`}
         />
       )}
       <InfoRow


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

`formatEther('0x0')` was causing the crash

https://rainbowhaus.slack.com/archives/C04M9BUPQP6/p1710725711853419

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
