### PR TITLE
fix: connection banner visible when on lock screen

### DIFF
--- a/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
+++ b/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
@@ -110,6 +110,7 @@ export const AppConnectionWatcher = () => {
   }, []);
 
   const checkAndDisplayBanner = useCallback(() => {
+    console.log('- checkAndDisplayBanner');
     // Clear existing timeouts
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -150,9 +151,9 @@ export const AppConnectionWatcher = () => {
   useLayoutEffect(() => {
     if (
       !!prevCurrentAddress &&
-      (!isLowerCaseMatch(currentAddress, prevCurrentAddress) ||
-        (firstLoad && location.pathname !== ROUTES.HOME)) &&
-      (!checkAndDisplayBanner() || !differentActiveSession)
+      (!isLowerCaseMatch(currentAddress, prevCurrentAddress) || firstLoad) &&
+      ((location.pathname === ROUTES.HOME && !checkAndDisplayBanner()) ||
+        !differentActiveSession)
     ) {
       shouldAnimateOut.current = false;
       hide();
@@ -168,11 +169,17 @@ export const AppConnectionWatcher = () => {
   ]);
 
   useLayoutEffect(() => {
+    console.log('-- location', location);
+    console.log(
+      '-- location !== home',
+      location.pathname,
+      location.pathname !== ROUTES.HOME,
+    );
     if (location.pathname !== ROUTES.HOME) {
       shouldAnimateOut.current = true;
       hide();
     }
-  }, [hide, location.pathname]);
+  }, [hide, location, location.pathname]);
 
   useLayoutEffect(() => {
     if (

--- a/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
+++ b/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
@@ -110,7 +110,6 @@ export const AppConnectionWatcher = () => {
   }, []);
 
   const checkAndDisplayBanner = useCallback(() => {
-    console.log('- checkAndDisplayBanner');
     // Clear existing timeouts
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -169,12 +168,6 @@ export const AppConnectionWatcher = () => {
   ]);
 
   useLayoutEffect(() => {
-    console.log('-- location', location);
-    console.log(
-      '-- location !== home',
-      location.pathname,
-      location.pathname !== ROUTES.HOME,
-    );
     if (location.pathname !== ROUTES.HOME) {
       shouldAnimateOut.current = true;
       hide();

--- a/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
+++ b/src/entries/popup/components/AppConnection/AppConnectionWatcher.tsx
@@ -150,7 +150,8 @@ export const AppConnectionWatcher = () => {
   useLayoutEffect(() => {
     if (
       !!prevCurrentAddress &&
-      (!isLowerCaseMatch(currentAddress, prevCurrentAddress) || firstLoad) &&
+      (!isLowerCaseMatch(currentAddress, prevCurrentAddress) ||
+        (firstLoad && location.pathname !== ROUTES.HOME)) &&
       (!checkAndDisplayBanner() || !differentActiveSession)
     ) {
       shouldAnimateOut.current = false;
@@ -163,6 +164,7 @@ export const AppConnectionWatcher = () => {
     checkAndDisplayBanner,
     differentActiveSession,
     firstLoad,
+    location.pathname,
   ]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)


found this issue introduced here https://github.com/rainbow-me/browser-extension/pull/1404/files


https://github.com/rainbow-me/browser-extension/assets/12115171/2f02ba34-8d13-4a47-8b63-1a5d4437d260


you can see the connection banner for a second while the login screen is showing up

now is fixed, it doesn't appear

https://github.com/rainbow-me/browser-extension/assets/12115171/e409dd5d-9166-4ed2-96d6-5df0f58a9f22



## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
