### PR TITLE
e2e: devedition browsers for local testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           path: build/
       - name: Remove old screenshots
         run: rm -rf screenshots/*
+
   # FIREFOX TESTS
   firefox-e2e-parallel:
     runs-on: ubuntu-latest
@@ -100,40 +101,6 @@ jobs:
       - name: Fail if any tests failed
         if: steps.FFE2eParallel.outcome == 'failure'
         run: exit 1
-  # firefox-e2e-swap:
-  #   runs-on: swaps-runner-bx
-  #   timeout-minutes: 25
-  #   needs: [build]
-  #   env:
-  #     DISPLAY: :0
-  #     VITEST_SEGFAULT_RETRY: 4
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: ./.github/actions/firefoxTestsSetup
-  #       with:
-  #         gh-access-token: ${{ secrets.DOTENV_GITHUB_ACCESS_TOKEN }}
-  #     - name: Run e2e Swap (Firefox)
-  #       id: FFE2eSwap
-  #       continue-on-error: true
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 25
-  #         max_attempts: 2
-  #         command: |
-  #           export BROWSER=firefox
-  #           export OS=linux
-  #           export FIREFOX_BIN="$(pwd)/firefox/firefox"
-  #           yarn firefox:manifest && yarn firefox:zip
-  #           yarn vitest:swap --retry=5
-  #     - name: Upload deps artifacts
-  #       if: steps.FFE2eSwap.outcome == 'failure'
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: screenshots
-  #         path: screenshots/
-  #     - name: Fail if any tests failed
-  #       if: steps.FFE2eSwap.outcome == 'failure'
-  #       run: exit 1
   firefox-e2e-send:
     runs-on: send-runner-bx
     timeout-minutes: 16
@@ -202,6 +169,7 @@ jobs:
       - name: Fail if any tests failed
         if: steps.FFE2eDappInteractions.outcome == 'failure'
         run: exit 1
+
   # CHROME TESTS
   chrome-e2e-parallel:
     runs-on: ubuntu-latest
@@ -364,63 +332,7 @@ jobs:
       - name: Fail if any tests failed
         if: steps.ChromeE2EDappInteractions.outcome == 'failure'
         run: exit 1
-  # BRAVE TESTS
-  # brave-e2e:
-  #   needs: [build]
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #   env:
-  #     DISPLAY: :0
-  #     VITEST_SEGFAULT_RETRY: 3
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: "18.18.0"
-  #     - name: Download deps cache artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: node_modules.tar.gz
-  #     - name: Unzip node_modules
-  #       run: tar xzvf node_modules.tar.gz
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: rainbowbx-${{ github.sha }}.zip
-  #         path: build
-  #     - name: Setup xvfb
-  #       run: |
-  #         sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
-  #         # start xvfb in the background
-  #         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
-  #     - name: Setup Brave browser
-  #       run: |
-  #         sudo apt install apt-transport-https curl
-  #         sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-  #         echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"|sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-  #         sudo apt update
-  #         sudo apt install brave-browser
-  #     - name: Install Anvil
-  #       uses: foundry-rs/foundry-toolchain@v1
-  #       with:
-  #         version: nightly
-  #     - uses: actions/checkout@v3
-  #       with:
-  #           repository: 'rainbow-me/browser-extension-env'
-  #           token: ${{ secrets.DOTENV_GITHUB_ACCESS_TOKEN }}
-  #           path: tmp
-  #     - name: Copy dotenv
-  #       run: cat tmp/dotenv >> .env && rm -rf tmp
-  #     - name: Run e2e (Brave)
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 18
-  #         max_attempts: 3
-  #         command:  |
-  #           export BROWSER=brave
-  #           export OS=linux
-  #           export BRAVE_BIN='/usr/bin/brave-browser-stable'
-  #           yarn vitest:parallel && yarn vitest:serial
+
   # UNIT TESTS
   unit-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -124,11 +124,15 @@ You can run a development build as a "playground". The following playgrounds are
 Run `curl -L https://foundry.paradigm.xyz | bash` to install foundry.
 You'll need to restart the terminal.
 
-### 2. Run the tests
+### 2. Install browsers
+
+Reference and install [supported browsers](./e2e/README.md) for testing. The test suite relies on fixed browser versions, so we rely on each browser's developer edition without auto-updates for local testing.
+
+### 3. Run the tests
 
 To run the Browser Extension test suites:
 
-- `yarn e2e` – runs end-to-end tests against Chrome for Testing browser.
+- `yarn e2e` – runs end-to-end tests against Chrome.
 - `yarn test` – runs unit/integration tests.
   - `yarn test:watch` – run tests in watch mode.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You'll need to restart the terminal.
 
 To run the Browser Extension test suites:
 
-- `yarn e2e` – runs end-to-end tests against Chrome & Brave browsers.
+- `yarn e2e` – runs end-to-end tests against Chrome for Testing browser.
 - `yarn test` – runs unit/integration tests.
   - `yarn test:watch` – run tests in watch mode.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,20 @@
+
+## E2E Testing
+
+### Supported browsers
+
+#### Chrome
+Chrome for Testing v121
+```bash
+npx @puppeteer/browsers install chrome@121
+```
+
+#### Firefox
+Firefox Developer Edition v122.0b9
+```bash
+curl -O https://ftp.mozilla.org/pub/devedition/releases/122.0b9/mac/en-US/Firefox%20122.0b9.dmg
+```
+
+#### Brave
+Beta v1.65.89 (Chromium 123.0.6312.58)
+[https://github.com/brave/brave-browser/releases/tag/v1.65.89](https://github.com/brave/brave-browser/releases/tag/v1.65.89)

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -32,8 +32,10 @@ const waitUntilTime = 20_000;
 const testPassword = 'test1234';
 const BINARY_PATHS = {
   mac: {
-    chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    brave: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+    chrome:
+      '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+    brave:
+      '/Applications/Brave Browser Beta.app/Contents/MacOS/Brave Browser Beta',
     firefox:
       '/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox',
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "e2e:mac:chrome": "BROWSER=chrome OS=mac yarn vitest:parallel && yarn vitest:serial",
     "e2e:mac:brave": "BROWSER=brave OS=mac yarn vitest:parallel && yarn vitest:serial",
     "e2e:mac:firefox": "yarn firefox:zip && BROWSER=firefox OS=mac yarn vitest:parallel && yarn vitest:serial",
-    "e2e:mac": "yarn e2e:mac:chrome && yarn e2e:mac:brave",
+    "e2e:mac": "yarn e2e:mac:chrome",
     "e2e": "yarn e2e:mac",
     "firefox:manifest": "node scripts/firefox-manifest.js",
     "firefox:build": "yarn build && yarn firefox:manifest",


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- using fixed browser versions and devedition browsers for local testing (i.e. Chrome for Testing)
- added readme to `./e2e/` and updated testing readme
- only running chrome e2e on `yarn run e2e:mac` 

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
