### PR TITLE
[BX-1364] fix: support nav restoration for modal with route params

### DIFF
--- a/src/entries/popup/hooks/useRestoreNavigation.ts
+++ b/src/entries/popup/hooks/useRestoreNavigation.ts
@@ -120,6 +120,8 @@ const RESTORE_NAV_MAP: Record<string, string[]> = {
   [ROUTES.WALLET_SWITCHER]: [ROUTES.WALLET_SWITCHER],
 };
 
+const MODAL_ROUTES = ['home/activity-details'];
+
 export default function useRestoreNavigation() {
   const navigate = useRainbowNavigate();
   const {
@@ -131,13 +133,23 @@ export default function useRestoreNavigation() {
   const restoreNavigation = async () => {
     if (lastPage && shouldRestoreNavigation) {
       await setShouldRestoreNavigation(false);
-      if (RESTORE_NAV_MAP[lastPage]) {
-        const navPath = RESTORE_NAV_MAP[lastPage];
-        for (const screen of navPath) {
-          if (navPath.indexOf(screen) === navPath.length - 1) {
-            navigate(screen, { state: lastState });
-          } else {
-            navigate(screen);
+      if (
+        MODAL_ROUTES.some((route) => {
+          return lastPage.includes(route);
+        })
+      ) {
+        setTimeout(() => {
+          navigate(lastPage, { state: { skipTransitionOnRoute: ROUTES.HOME } });
+        }, 200);
+      } else {
+        if (RESTORE_NAV_MAP[lastPage]) {
+          const navPath = RESTORE_NAV_MAP[lastPage];
+          for (const screen of navPath) {
+            if (navPath.indexOf(screen) === navPath.length - 1) {
+              navigate(screen, { state: lastState });
+            } else {
+              navigate(screen);
+            }
           }
         }
       }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Supporting nav restoration for the activity details modal.

## Screen recordings / screenshots
PoW: https://recordit.co/ZZx4o43VCE

## What to test
Test that you are returned back to activity details if you close the popup while it's being presented
