### PR TITLE
[BX-1349] chore: avoid signing nft thumbnail img src when possible

### DIFF
--- a/src/entries/popup/components/ExternalImage/ExternalImage.tsx
+++ b/src/entries/popup/components/ExternalImage/ExternalImage.tsx
@@ -7,6 +7,8 @@ import { SymbolName } from '~/design-system/styles/designTokens';
 
 import { maybeSignUri } from '../../handlers/imgix';
 
+const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
+
 type ExternalImageProps = JSX.IntrinsicAttributes &
   React.ClassAttributes<HTMLImageElement> &
   React.ImgHTMLAttributes<HTMLImageElement> & {
@@ -17,10 +19,14 @@ type ExternalImageProps = JSX.IntrinsicAttributes &
     mask?: string;
     resizeMode?: 'contain' | 'cover';
     placeholderSrc?: string;
+    avoidImgix?: boolean;
   };
 
 const ExternalImage = (props: ExternalImageProps) => {
   const signedUrl = React.useMemo(() => {
+    if (props.avoidImgix && props.src?.startsWith(GOOGLE_USER_CONTENT_URL)) {
+      return props.src;
+    }
     return maybeSignUri(props.src, {
       h: Number(props.height),
       w: Number(props.width),
@@ -28,6 +34,12 @@ const ExternalImage = (props: ExternalImageProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.src]);
   const signedPlaceholderUrl = React.useMemo(() => {
+    if (
+      props.avoidImgix &&
+      props.placeholderSrc?.startsWith(GOOGLE_USER_CONTENT_URL)
+    ) {
+      return props.placeholderSrc;
+    }
     return maybeSignUri(props.placeholderSrc, {
       h: Number(props.height),
       w: Number(props.width),

--- a/src/entries/popup/pages/home/NFTs/NFTThumbnail.tsx
+++ b/src/entries/popup/pages/home/NFTs/NFTThumbnail.tsx
@@ -33,6 +33,7 @@ export const NFTThumbnail = memo(function NftThumbnail({
         placeholderSrc={placeholderSrc}
         height={size}
         width={size}
+        avoidImgix
       />
     </Lens>
   );


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Reducing Imgix usage among trusted sources for NFT Thumbnails.

## Screen recordings / screenshots
<img width="441" alt="Screen Shot 2024-03-25 at 11 16 46 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/6dfa0052-23ab-4ade-97b7-6a31bc9bf725">

## What to test
Ensure we have no image regressions.
