### PR TITLE
[BX-1334] fix: remove l2 check when sending to self

### DIFF
--- a/src/entries/popup/pages/send/ReviewSheet.tsx
+++ b/src/entries/popup/pages/send/ReviewSheet.tsx
@@ -312,8 +312,9 @@ export const ReviewSheet = ({
   );
 
   const sendEnabled = useMemo(
-    () => !notSendingOnEthereum || notSendingOnEthereumChecks,
-    [notSendingOnEthereum, notSendingOnEthereumChecks],
+    () =>
+      !notSendingOnEthereum || notSendingOnEthereumChecks || isToWalletOwner,
+    [isToWalletOwner, notSendingOnEthereum, notSendingOnEthereumChecks],
   );
 
   const handleSend = useCallback(async () => {
@@ -537,14 +538,14 @@ export const ReviewSheet = ({
                     </Columns>
                   </Row>
                 </Rows>
-                {notSendingOnEthereum && (
+                {notSendingOnEthereum && !isToWalletOwner && (
                   <Separator color="separatorTertiary" />
                 )}
               </Stack>
             </Box>
           </Stack>
 
-          {notSendingOnEthereum && (
+          {notSendingOnEthereum && !isToWalletOwner && (
             <Box paddingHorizontal="16px" paddingBottom="20px">
               <Stack space="20px">
                 <Box


### PR DESCRIPTION
## What changed (plus any additional context for devs)
The L2 send checkbox has been removed if you are sending funds to yourself.

## Screen recordings / screenshots
PoW: 
<img width="360" alt="Screen Shot 2024-03-25 at 11 38 31 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/973be79a-3be6-4e34-b074-7a47241a7a7f">
<img width="361" alt="Screen Shot 2024-03-25 at 11 38 16 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/54c18512-5e02-4faa-bd01-39ac3a2f0b7b">


## What to test
Ensure the L2 warning no longer appears when sending to your own wallets.
