### PR TITLE
[BX-1367] Right-click accidental pass-through actions

### DIFF
--- a/e2e/serial/send/2_shortcuts-sendFlow.test.ts
+++ b/e2e/serial/send/2_shortcuts-sendFlow.test.ts
@@ -216,6 +216,7 @@ describe('Complete send flow via shortcuts and keyboard navigation', () => {
       await executePerformShortcut({ driver, key: 'ARROW_LEFT' });
       await executePerformShortcut({ driver, key: 'TAB', timesToPress: 8 });
       await executePerformShortcut({ driver, key: 'SPACE' });
+      await delayTime('long');
       await executePerformShortcut({ driver, key: 'ARROW_DOWN' });
       await executePerformShortcut({ driver, key: 'ENTER' });
       await checkExtensionURL(driver, 'send');

--- a/src/entries/popup/components/ContextMenu/ContextMenu.tsx
+++ b/src/entries/popup/components/ContextMenu/ContextMenu.tsx
@@ -2,7 +2,13 @@ import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { DismissableLayerProps } from '@radix-ui/react-tooltip';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
-import React, { CSSProperties, ReactNode, useRef } from 'react';
+import React, {
+  CSSProperties,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useAccount } from 'wagmi';
 
 import { shortcuts } from '~/core/references/shortcuts';
@@ -247,6 +253,10 @@ export const ContextMenuItem = ({
   disabled,
   testId,
 }: ContextMenuItemProps) => {
+  const [isMounting, setIsMounting] = useState(true);
+  useEffect(() => {
+    setTimeout(() => setIsMounting(false), 400);
+  }, []);
   // eslint-disable-next-line no-param-reassign
   if (disabled) color = 'labelTertiary';
   return (
@@ -269,8 +279,8 @@ export const ContextMenuItem = ({
         default: 'transparent',
         hover: disabled ? 'transparent' : 'surfaceSecondary',
       }}
-      disabled={disabled}
       tabIndex={disabled ? -1 : 0}
+      disabled={disabled || isMounting}
     >
       <Inline alignVertical="center" space="8px" wrap={false}>
         {isSymbol(symbolLeft) ? (

--- a/src/entries/popup/components/ContextMenu/ContextMenu.tsx
+++ b/src/entries/popup/components/ContextMenu/ContextMenu.tsx
@@ -257,8 +257,7 @@ export const ContextMenuItem = ({
   useEffect(() => {
     setTimeout(() => setIsMounting(false), 400);
   }, []);
-  // eslint-disable-next-line no-param-reassign
-  if (disabled) color = 'labelTertiary';
+  const conditionalColor = disabled ? 'labelTertiary' : color;
   return (
     <Box
       testId={testId}
@@ -288,15 +287,15 @@ export const ContextMenuItem = ({
             size={16}
             symbol={symbolLeft}
             weight="semibold"
-            color={color}
+            color={conditionalColor}
           />
         ) : (
-          <Text color={color} weight="semibold" size="14pt">
+          <Text color={conditionalColor} weight="semibold" size="14pt">
             {symbolLeft}
           </Text>
         )}
         {typeof children === 'string' ? (
-          <TextOverflow size="14pt" weight="semibold" color={color}>
+          <TextOverflow size="14pt" weight="semibold" color={conditionalColor}>
             {children}
           </TextOverflow>
         ) : (


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Preventing radix from calling onSelect when a context click overlaps with the incoming menu.

## Screen recordings / screenshots
https://www.loom.com/share/6e85c73529e54aa884bd9db6b0ea16bb

## What to test
Make sure to use the popup. I don't think this is a reproducible issue in fullscreen. Just click a bunch in an area that you know will overlap with the incoming context menu.
