### PR TITLE
fix: dont use custom_rpc param

### DIFF
--- a/src/core/providers/proxy.ts
+++ b/src/core/providers/proxy.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_CHAIN_IDS } from '../references';
+import { getDefaultRPC } from '../references';
 import { ChainId } from '../types/chains';
 
 export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
@@ -9,7 +9,7 @@ export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
     !endpoint.includes('http://192.168') &&
     !endpoint.match(/http:\/\/172.(1[6-9]|2[0-9]|3[0-1])./)
   ) {
-    if (SUPPORTED_CHAIN_IDS.includes(chainId)) {
+    if (getDefaultRPC(chainId)?.http === endpoint) {
       return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${process.env.RPC_PROXY_API_KEY}`;
     }
     return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${

--- a/src/core/providers/proxy.ts
+++ b/src/core/providers/proxy.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_CHAIN_IDS } from '../references';
 import { ChainId } from '../types/chains';
 
 export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
@@ -8,6 +9,9 @@ export const proxyRpcEndpoint = (endpoint: string, chainId: ChainId) => {
     !endpoint.includes('http://192.168') &&
     !endpoint.match(/http:\/\/172.(1[6-9]|2[0-9]|3[0-1])./)
   ) {
+    if (SUPPORTED_CHAIN_IDS.includes(chainId)) {
+      return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${process.env.RPC_PROXY_API_KEY}`;
+    }
     return `${process.env.RPC_PROXY_BASE_URL}/${chainId}/${
       process.env.RPC_PROXY_API_KEY
     }?custom_rpc=${encodeURIComponent(endpoint)}`;


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

backend request to only pass custom_rpc for not supported networks

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
