### PR TITLE
fix: deprecate isRainbowCurated for swap assets

### DIFF
--- a/src/core/references/gasUnits.ts
+++ b/src/core/references/gasUnits.ts
@@ -13,6 +13,7 @@ export const gasUnits = {
     [ChainId.bsc]: '600000',
     [ChainId.polygon]: '600000',
     [ChainId.avalanche]: '600000',
+    [ChainId.blast]: '600000',
   },
   basic_swap_permit: '400000',
   ens_register_with_config: '280000',

--- a/src/core/types/search.ts
+++ b/src/core/types/search.ts
@@ -19,7 +19,6 @@ export type SearchAsset = {
   decimals: number;
   highLiquidity: boolean;
   icon_url: string;
-  isRainbowCurated: boolean;
   isNativeAsset: boolean;
   isVerified: boolean;
   mainnetAddress: AddressOrEth;

--- a/src/core/utils/assets.test.ts
+++ b/src/core/utils/assets.test.ts
@@ -61,7 +61,6 @@ const ETH_FROM_SEARCH: SearchAsset = {
   icon_url:
     'https://rainbowme-res.cloudinary.com/image/upload/v1668565116/assets/smartchain/0x2170ed0880ac9a755fd29b2688956bd959f933f8.png',
   rainbowMetadataId: 76174,
-  isRainbowCurated: true,
   isVerified: true,
   networks: {
     '1': { address: 'eth', decimals: 18 },
@@ -221,7 +220,6 @@ const OPTIMISM_USD_FROM_SEARCH = {
   icon_url:
     'https://rainbowme-res.cloudinary.com/image/upload/v1668633498/assets/ethereum/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
   rainbowMetadataId: 1746,
-  isRainbowCurated: true,
   isVerified: true,
   networks: {
     '1': {

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -283,9 +283,10 @@ export function useSearchCurrencyLists({
     ],
   );
 
+  // temporarily limiting the number of assets to display
+  // for performance after deprecating `isRainbowCurated`
   const getVerifiedAssets = useCallback(
-    (chainId: ChainId) =>
-      verifiedAssets[chainId]?.assets?.filter(({ isVerified }) => isVerified),
+    (chainId: ChainId) => verifiedAssets[chainId]?.assets?.slice(0, 50),
     [verifiedAssets],
   );
 

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -170,8 +170,6 @@ export function useSearchCurrencyLists({
       fromChainId,
     });
 
-  console.log('blastVerifiedAssets', blastVerifiedAssets);
-
   // current search
   const { data: targetVerifiedAssets, isLoading: targetVerifiedAssetsLoading } =
     useTokenSearch({

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -170,6 +170,8 @@ export function useSearchCurrencyLists({
       fromChainId,
     });
 
+  console.log('blastVerifiedAssets', blastVerifiedAssets);
+
   // current search
   const { data: targetVerifiedAssets, isLoading: targetVerifiedAssetsLoading } =
     useTokenSearch({
@@ -283,16 +285,14 @@ export function useSearchCurrencyLists({
     ],
   );
 
-  const getCuratedAssets = useCallback(
+  const getVerifiedAssets = useCallback(
     (chainId: ChainId) =>
-      verifiedAssets[chainId]?.assets?.filter(
-        ({ isRainbowCurated }) => isRainbowCurated,
-      ),
+      verifiedAssets[chainId]?.assets?.filter(({ isVerified }) => isVerified),
     [verifiedAssets],
   );
 
   const bridgeAsset = useMemo(() => {
-    const curatedAssets = getCuratedAssets(outputChainId);
+    const curatedAssets = getVerifiedAssets(outputChainId);
     const bridgeAsset = curatedAssets?.find((asset) =>
       isLowerCaseMatch(
         asset.mainnetAddress,
@@ -310,7 +310,7 @@ export function useSearchCurrencyLists({
       ? bridgeAsset
       : null;
     return outputChainId === assetToSell?.chainId ? null : filteredBridgeAsset;
-  }, [assetToSell, getCuratedAssets, outputChainId, query]);
+  }, [assetToSell, getVerifiedAssets, outputChainId, query]);
 
   const loading = useMemo(() => {
     return query === ''
@@ -327,17 +327,17 @@ export function useSearchCurrencyLists({
   // displayed when no search query is present
   const curatedAssets = useMemo(
     () => ({
-      [ChainId.mainnet]: getCuratedAssets(ChainId.mainnet),
-      [ChainId.optimism]: getCuratedAssets(ChainId.optimism),
-      [ChainId.bsc]: getCuratedAssets(ChainId.bsc),
-      [ChainId.polygon]: getCuratedAssets(ChainId.polygon),
-      [ChainId.arbitrum]: getCuratedAssets(ChainId.arbitrum),
-      [ChainId.base]: getCuratedAssets(ChainId.base),
-      [ChainId.zora]: getCuratedAssets(ChainId.zora),
-      [ChainId.avalanche]: getCuratedAssets(ChainId.avalanche),
-      [ChainId.blast]: getCuratedAssets(ChainId.blast),
+      [ChainId.mainnet]: getVerifiedAssets(ChainId.mainnet),
+      [ChainId.optimism]: getVerifiedAssets(ChainId.optimism),
+      [ChainId.bsc]: getVerifiedAssets(ChainId.bsc),
+      [ChainId.polygon]: getVerifiedAssets(ChainId.polygon),
+      [ChainId.arbitrum]: getVerifiedAssets(ChainId.arbitrum),
+      [ChainId.base]: getVerifiedAssets(ChainId.base),
+      [ChainId.zora]: getVerifiedAssets(ChainId.zora),
+      [ChainId.avalanche]: getVerifiedAssets(ChainId.avalanche),
+      [ChainId.blast]: getVerifiedAssets(ChainId.blast),
     }),
-    [getCuratedAssets],
+    [getVerifiedAssets],
   );
 
   const bridgeList = (


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

fixes https://rainbowhaus.slack.com/archives/C02C8JQ313N/p1712086754141749

isRainbowCurated is deprecated so i updated it to use isVerified

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
