### PR TITLE
chore: subtracting token balance if token is hidden

### DIFF
--- a/src/core/resources/_selectors/assets.ts
+++ b/src/core/resources/_selectors/assets.ts
@@ -104,10 +104,15 @@ export function selectUserAssetWithUniqueId(uniqueId: UniqueId) {
   };
 }
 
-export function selectUserAssetsBalance(assets: ParsedAssetsDictByChain) {
+export function selectUserAssetsBalance(
+  assets: ParsedAssetsDictByChain,
+  hidden: (asset: ParsedUserAsset) => boolean,
+) {
   const networksTotalBalance = Object.values(assets).map((assetsOnject) => {
     const assetsNetwork = Object.values(assetsOnject);
+
     const networkBalance = assetsNetwork
+      .filter((asset) => !hidden(asset))
       .map((asset) => asset.native.balance.amount)
       .reduce((prevBalance, currBalance) => add(prevBalance, currBalance), '0');
     return networkBalance;

--- a/src/entries/popup/hooks/useUserAssetsBalance.ts
+++ b/src/entries/popup/hooks/useUserAssetsBalance.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Address } from 'wagmi';
 
 import {
@@ -7,11 +8,26 @@ import {
 import { useUserAssets } from '~/core/resources/assets';
 import { useCustomNetworkAssets } from '~/core/resources/assets/customNetworkAssets';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
+import {
+  computeUniqueIdForHiddenAsset,
+  useHiddenAssetStore,
+} from '~/core/state/hiddenAssets/hiddenAssets';
+import { ParsedUserAsset } from '~/core/types/assets';
 import { add, convertAmountToNativeDisplay } from '~/core/utils/numbers';
 
 export function useUserAssetsBalance() {
   const { currentAddress: address } = useCurrentAddressStore();
   const { currentCurrency: currency } = useCurrentCurrencyStore();
+  const { hiddenAssets } = useHiddenAssetStore();
+
+  const isHidden = useCallback(
+    (asset: ParsedUserAsset) =>
+      hiddenAssets.some(
+        (uniqueId) => uniqueId === computeUniqueIdForHiddenAsset(asset),
+      ),
+    [hiddenAssets],
+  );
+
   const { data: totalAssetsBalanceKnownNetworks } = useUserAssets(
     {
       address,
@@ -19,7 +35,12 @@ export function useUserAssetsBalance() {
     },
     {
       select: (data) =>
-        selectorFilterByUserChains({ data, selector: selectUserAssetsBalance }),
+        selectorFilterByUserChains({
+          data,
+          selector: (assetsByChain) => {
+            return selectUserAssetsBalance(assetsByChain, isHidden);
+          },
+        }),
     },
   );
 
@@ -33,7 +54,9 @@ export function useUserAssetsBalance() {
         select: (data) =>
           selectorFilterByUserChains({
             data,
-            selector: selectUserAssetsBalance,
+            selector: (assetsByChain) => {
+              return selectUserAssetsBalance(assetsByChain, isHidden);
+            },
           }),
       },
     );

--- a/src/entries/popup/hooks/useUserAssetsBalance.ts
+++ b/src/entries/popup/hooks/useUserAssetsBalance.ts
@@ -19,7 +19,6 @@ export function useUserAssetsBalance() {
   const { currentAddress: address } = useCurrentAddressStore();
   const { currentCurrency: currency } = useCurrentCurrencyStore();
   const { hiddenAssets } = useHiddenAssetStore();
-
   const isHidden = useCallback(
     (asset: ParsedUserAsset) =>
       hiddenAssets.some(


### PR DESCRIPTION
Fixes BX-1384
Figma link (if any):

## What changed (plus any additional context for devs)

## Screen recordings / screenshots

https://github.com/rainbow-me/browser-extension/assets/53529533/cd4a431b-a5cf-484b-abef-2262ab930c4c

## What to test

- Make sure token balance is subtracting when hiding them. You should see that in homepage, change wallet page and switch wallet popup (all of them are shown in video)
- Make sure to test with custom assets too
