### PR TITLE
[BX-1399] fix: tweak border radius on settings list items

### DIFF
--- a/src/entries/popup/pages/settings/settings.tsx
+++ b/src/entries/popup/pages/settings/settings.tsx
@@ -182,7 +182,6 @@ export function Settings() {
           />
           <MenuItem
             testId={'networks-link'}
-            first
             leftComponent={
               <Symbol
                 symbol="network"
@@ -236,6 +235,7 @@ export function Settings() {
         </Menu>
         <Menu>
           <MenuItem
+            first
             testId={'privacy-security-link'}
             leftComponent={
               <Symbol
@@ -291,8 +291,6 @@ export function Settings() {
           <Lens
             style={{
               borderRadius: 6,
-              borderBottomLeftRadius: 15,
-              borderBottomRightRadius: 15,
             }}
             onKeyDown={() => setThemeDropdownOpen(true)}
             onClick={() => setThemeDropdownOpen(true)}
@@ -366,6 +364,7 @@ export function Settings() {
             />
           </Lens>
           <MenuItem
+            last
             titleComponent={<MenuItem.Title text={i18n.t('settings.sounds')} />}
             leftComponent={
               <Symbol
@@ -464,7 +463,6 @@ export function Settings() {
               testId="test-sandbox-background"
             />
             <MenuItem
-              last
               titleComponent={
                 <MenuItem.Title
                   text={
@@ -478,7 +476,6 @@ export function Settings() {
               testId="connect-to-hardhat"
             />
             <MenuItem
-              last
               titleComponent={
                 <MenuItem.Title
                   text={

--- a/src/entries/popup/pages/settings/transactions.tsx
+++ b/src/entries/popup/pages/settings/transactions.tsx
@@ -143,6 +143,7 @@ export function Transactions() {
         </Menu>
         <Menu>
           <MenuItem
+            first
             last
             titleComponent={
               <MenuItem.Title


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We recently changed the order of the settings list items. We need to alter the border radius on a few items to match the design.

## Screen recordings / screenshots
before:
<img width="475" alt="Screen Shot 2024-04-05 at 11 21 58 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/c998d1d4-0cf0-45b9-960e-b4a66f51b49d">
after:
<img width="473" alt="Screen Shot 2024-04-05 at 11 45 06 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/8c3f564d-d661-4355-8d73-64c1c8c37d66">
