### PR TITLE
Fix <ExternalImage />

### DIFF
--- a/src/entries/popup/components/ExternalImage/ExternalImage.tsx
+++ b/src/entries/popup/components/ExternalImage/ExternalImage.tsx
@@ -63,7 +63,7 @@ const ExternalImage = (props: ExternalImageProps) => {
       if (img) {
         return img;
       }
-      return undefined;
+      throw new Error(`couldn't load image`);
     },
   });
 
@@ -155,8 +155,8 @@ const ExternalImage = (props: ExternalImageProps) => {
           : {}),
         boxShadow: isLoading || error ? undefined : props.boxShadow,
         overflow: error ? 'visible' : 'clip',
-        height: props.height && (Number(props.height) ?? props.height),
-        width: props.width && (Number(props.width) ?? props.width),
+        height: props.height && (Number(props.height) || props.height),
+        width: props.width && (Number(props.width) || props.width),
       }}
     >
       {renderContent()}

--- a/src/entries/popup/pages/home/Activity/ActivityIcon.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityIcon.tsx
@@ -15,7 +15,7 @@ export const ActivityIcon = ({
   badge?: boolean;
   size?: 36 | 20 | 14 | 16;
 }) => {
-  if (['wrap', 'undwrap', 'swap'].includes(type)) {
+  if (['wrap', 'unwrap', 'swap'].includes(type)) {
     const inAsset = changes?.find((a) => a?.direction === 'in')?.asset;
     const outAsset = changes?.find((a) => a?.direction === 'out')?.asset;
 


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

I tested and the [bx-1380](https://linear.app/rainbow/issue/BX-1380/externalimage-undefined-fetching-error) keeps being fixed with these changes :)

## Screen recordings / screenshots

before/after 
some fallbacks didn't show

<img width="370" alt="Screenshot 2024-04-05 at 15 20 44" src="https://github.com/rainbow-me/browser-extension/assets/6232729/6105204d-0721-4aa9-916e-021a88bd1da0">

<img width="366" alt="Screenshot 2024-04-05 at 15 21 18" src="https://github.com/rainbow-me/browser-extension/assets/6232729/a5818209-1062-4505-b866-d84b02fae5a3">


<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
