### PR TITLE
fix: native asset strings for non eth gas tokens (MATIC + BNB)

### DIFF
--- a/src/entries/popup/hooks/useNativeAssetForNetwork.ts
+++ b/src/entries/popup/hooks/useNativeAssetForNetwork.ts
@@ -2,9 +2,11 @@ import { AddressZero } from '@ethersproject/constants';
 import { Address } from 'wagmi';
 
 import {
+  BNB_BSC_ADDRESS,
   BNB_MAINNET_ADDRESS,
   ETH_ADDRESS,
   MATIC_MAINNET_ADDRESS,
+  MATIC_POLYGON_ADDRESS,
   NATIVE_ASSETS_PER_CHAIN,
 } from '~/core/references';
 import { ParsedAsset, UniqueId } from '~/core/types/assets';
@@ -50,9 +52,9 @@ export const getNetworkNativeAssetUniqueId = ({
     case ChainId.avalanche:
       return `${AddressZero}_${chainId}` as UniqueId;
     case ChainId.bsc:
-      return `${BNB_MAINNET_ADDRESS}_${chainId}` as UniqueId;
+      return `${BNB_BSC_ADDRESS}_${chainId}` as UniqueId;
     case ChainId.polygon:
-      return `${MATIC_MAINNET_ADDRESS}_${chainId}` as UniqueId;
+      return `${MATIC_POLYGON_ADDRESS}_${chainId}` as UniqueId;
     default:
       return `${AddressZero}_${chainId}` as UniqueId;
   }


### PR DESCRIPTION
BX-1401
## What changed (plus any additional context for devs)
Grabbing correct unique id strings for BNB and MATIC

## Screen recordings / screenshots
PoW:
https://polygonscan.com/tx/0x9b246c5ecfcb6169e1ee5d903b1216b0722a9a1cc1e42a5f1fa0647045103d6d
https://bscscan.com/tx/0xbfe6f0db3625f655a2730ac4f71dc29171a68d823f90ae3d3261f741ebc78e0f

## What to Test
Make sure polygon and bsc sends work
