### PR TITLE
fix: app connection header badge

### DIFF
--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -188,7 +188,7 @@ it('should be able to add a custom token', async () => {
   });
 
   // needs a couple seconds to validate
-  await delayTime('medium');
+  await delayTime('very-long');
 
   const tokenName = await findElementByTestId({
     id: 'token-name-field',

--- a/src/entries/popup/pages/home/NetworkMenu.tsx
+++ b/src/entries/popup/pages/home/NetworkMenu.tsx
@@ -98,7 +98,7 @@ export const AppConnection = () => {
                     position="relative"
                     style={{
                       marginRight: 16,
-                      marginTop: 8,
+                      marginTop: 1,
                     }}
                   >
                     <Inline


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

fixing badge, not sure when it broke

before

<img width="368" alt="image" src="https://github.com/rainbow-me/browser-extension/assets/12115171/8f0f9c9c-579e-4119-99ca-355531ed91b8">


now

<img width="368" alt="image" src="https://github.com/rainbow-me/browser-extension/assets/12115171/e07809f5-780c-406b-895b-00f41f0733d1">


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
