### PR TITLE
[BX-1321] feat: show warning when asset price unknown

### DIFF
--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -161,6 +161,58 @@ const SwapWarning = ({
   );
 };
 
+const MissingPriceExplanation = ({
+  assetToBuy,
+  assetToSell,
+}: {
+  assetToBuy: ParsedSearchAsset | null;
+  assetToSell: ParsedSearchAsset | null;
+}) => {
+  const missingPriceSymbols = [assetToBuy, assetToSell].reduce(
+    (symbols, asset) => {
+      if (asset?.price?.value === undefined && asset?.symbol) {
+        return [...symbols, asset?.symbol];
+      }
+      return symbols;
+    },
+    [] as string[],
+  );
+  if (!missingPriceSymbols?.length) return null;
+  return (
+    <ButtonOverflow>
+      <Box paddingHorizontal="20px">
+        <Box paddingVertical="10px" paddingHorizontal="12px">
+          <Inline space="8px" alignVertical="center" alignHorizontal="center">
+            <Inline space="4px" alignVertical="center">
+              <Symbol
+                symbol="exclamationmark.triangle.fill"
+                size={16}
+                color={'orange'}
+                weight="bold"
+              />
+              <Text color="label" size="14pt" weight="bold">
+                {i18n.t('swap.warnings.unknown_price.title', {
+                  symbol: missingPriceSymbols.join('/'),
+                })}
+              </Text>
+            </Inline>
+            <Box paddingHorizontal="12px" paddingBottom="6px" paddingTop="4px">
+              <Text
+                color="labelTertiary"
+                size="12pt"
+                weight="semibold"
+                align="center"
+              >
+                {i18n.t('swap.warnings.unknown_price.description')}
+              </Text>
+            </Box>
+          </Inline>
+        </Box>
+      </Box>
+    </ButtonOverflow>
+  );
+};
+
 export function Swap({ bridge = false }: { bridge?: boolean }) {
   const [showSwapSettings, setShowSwapSettings] = useState(false);
   const [showSwapReview, setShowSwapReview] = useState(false);
@@ -679,6 +731,10 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
               <SwapWarning
                 timeEstimate={timeEstimate}
                 priceImpact={priceImpact}
+              />
+              <MissingPriceExplanation
+                assetToBuy={assetToBuy}
+                assetToSell={assetToSell}
               />
             </Stack>
           </Row>

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -696,6 +696,10 @@
       "price_impact": {
         "title": "Small market",
         "description": "Losing %{impactAmount}"
+      },
+      "unknown_price": {
+        "title": "%{symbol} Market Value Unknown",
+        "description": "If you decide to continue, be sure that you are satisfied receiving the quoted amount."
       }
     },
     "aggregators": {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Added a warning whenever we do not receive a price for an asset being swapped. I based the copy and design on the app's work [here](https://linear.app/rainbow/issue/APP-1295/update-slippage-warning-we-show-when-swapping-tokens-without-price).

## Screen recordings / screenshots
<img width="474" alt="Screen Shot 2024-04-15 at 7 22 06 PM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/9b63166e-b541-4a45-b94b-443253953d41">

## What to test
Ensure that the warning appears when setting up a swap including an asset with no reported price.
