### PR TITLE
combined assets by uniqueId

### DIFF
--- a/src/entries/popup/components/CommandK/useSearchableTokens.ts
+++ b/src/entries/popup/components/CommandK/useSearchableTokens.ts
@@ -57,28 +57,39 @@ export const useSearchableTokens = () => {
     },
   );
 
+  const combinedAssets = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          [...customNetworkAssets, ...assets].map((item) => [
+            item.uniqueId,
+            item,
+          ]),
+        ).values(),
+      ),
+    [assets, customNetworkAssets],
+  );
+
   const searchableTokens = useMemo(() => {
-    return [...assets, ...customNetworkAssets].map<TokenSearchItem>(
-      (asset) => ({
-        action: () => navigate(ROUTES.TOKEN_DETAILS(asset.uniqueId)),
-        actionLabel: actionLabels.open,
-        actionPage: PAGES.TOKEN_DETAIL,
-        asset: asset as ParsedUserAsset,
-        id: asset.uniqueId,
-        name: asset.name,
-        nativeTokenBalance: asset.native.balance.display,
-        network: asset.chainName,
-        page: PAGES.MY_TOKENS,
-        price: asset.price,
-        searchTags: [asset.symbol, asset.chainName],
-        selectedWalletAddress: address,
-        tokenBalanceAmount: asset.balance.amount,
-        tokenBalanceDisplay: asset.balance.display,
-        tokenSymbol: asset.symbol,
-        type: SearchItemType.Token,
-      }),
-    );
-  }, [address, assets, customNetworkAssets, navigate]);
+    return combinedAssets.map<TokenSearchItem>((asset) => ({
+      action: () => navigate(ROUTES.TOKEN_DETAILS(asset.uniqueId)),
+      actionLabel: actionLabels.open,
+      actionPage: PAGES.TOKEN_DETAIL,
+      asset: asset as ParsedUserAsset,
+      id: asset.uniqueId,
+      name: asset.name,
+      nativeTokenBalance: asset.native.balance.display,
+      network: asset.chainName,
+      page: PAGES.MY_TOKENS,
+      price: asset.price,
+      searchTags: [asset.symbol, asset.chainName],
+      selectedWalletAddress: address,
+      tokenBalanceAmount: asset.balance.amount,
+      tokenBalanceDisplay: asset.balance.display,
+      tokenSymbol: asset.symbol,
+      type: SearchItemType.Token,
+    }));
+  }, [address, combinedAssets, navigate]);
 
   return { searchableTokens };
 };

--- a/src/entries/popup/hooks/send/useSendAsset.ts
+++ b/src/entries/popup/hooks/send/useSendAsset.ts
@@ -1,4 +1,3 @@
-import uniqBy from 'lodash/uniqBy';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -65,14 +64,27 @@ export const useSendAsset = () => {
     [],
   );
 
+  const combinedAssets = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          [...customNetworkAssets, ...assets].map((item) => [
+            item.uniqueId,
+            item,
+          ]),
+        ).values(),
+      ),
+    [assets, customNetworkAssets],
+  );
+
   const allAssets = useMemo(
     () =>
-      uniqBy([...assets, ...customNetworkAssets], 'uniqueId').sort(
+      combinedAssets.sort(
         (a: ParsedUserAsset, b: ParsedUserAsset) =>
           parseFloat(b?.native?.balance?.amount) -
           parseFloat(a?.native?.balance?.amount),
       ),
-    [assets, customNetworkAssets],
+    [combinedAssets],
   );
 
   const asset = useMemo(

--- a/src/entries/popup/hooks/useVisibleTokenCount.ts
+++ b/src/entries/popup/hooks/useVisibleTokenCount.ts
@@ -1,4 +1,3 @@
-import uniqBy from 'lodash/uniqBy';
 import { useMemo } from 'react';
 
 import {
@@ -49,14 +48,27 @@ export const useVisibleTokenCount = () => {
     },
   );
 
+  const combinedAssets = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          [...customNetworkAssets, ...assets].map((item) => [
+            item.uniqueId,
+            item,
+          ]),
+        ).values(),
+      ),
+    [assets, customNetworkAssets],
+  );
+
   const allAssets = useMemo(
     () =>
-      uniqBy([...assets, ...customNetworkAssets], 'uniqueId').sort(
+      combinedAssets.sort(
         (a: ParsedUserAsset, b: ParsedUserAsset) =>
           parseFloat(b?.native?.balance?.amount) -
           parseFloat(a?.native?.balance?.amount),
       ),
-    [assets, customNetworkAssets],
+    [combinedAssets],
   );
 
   const visibleTokenCount = useMemo(

--- a/src/entries/popup/pages/home/Tokens.tsx
+++ b/src/entries/popup/pages/home/Tokens.tsx
@@ -164,7 +164,15 @@ export function Tokens() {
   );
 
   const combinedAssets = useMemo(
-    () => [...assets, ...customNetworkAssets],
+    () =>
+      Array.from(
+        new Map(
+          [...customNetworkAssets, ...assets].map((item) => [
+            item.uniqueId,
+            item,
+          ]),
+        ).values(),
+      ),
     [assets, customNetworkAssets],
   );
 


### PR DESCRIPTION
Fixes BX-1421
Figma link (if any):

## What changed (plus any additional context for devs)

details of bug in ticket

maybe this is still happening since we're combining assets in an array directly from assets and customNetworkAssets, with this pr we'll only get one per uniqueId so there won't be duplicates for sure

## Screen recordings / screenshots

<img width="1200" alt="image" src="https://github.com/rainbow-me/browser-extension/assets/12115171/6f21b2d0-82a9-4bda-8780-6815c0e3d032">


<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
