### PR TITLE
simulation asset price when is 0

### DIFF
--- a/src/entries/popup/pages/messages/Simulation.tsx
+++ b/src/entries/popup/pages/messages/Simulation.tsx
@@ -83,7 +83,7 @@ function SimulatedChangeRow({
         <Text size="14pt" weight="bold" color="label">
           {label}
         </Text>
-        {quantity !== 'UNLIMITED' && !!assetPrice && (
+        {quantity !== 'UNLIMITED' && !!assetPrice ? (
           <Box marginLeft={'-4px'}>
             <TextOverflow size="12pt" weight="bold" color="labelSecondary">
               {
@@ -96,7 +96,7 @@ function SimulatedChangeRow({
               }
             </TextOverflow>
           </Box>
-        )}
+        ) : null}
       </Inline>
       <Inline wrap={false} space="6px" alignVertical="center">
         {asset?.type === 'nft' ? (

--- a/src/entries/popup/pages/messages/Simulation.tsx
+++ b/src/entries/popup/pages/messages/Simulation.tsx
@@ -83,7 +83,7 @@ function SimulatedChangeRow({
         <Text size="14pt" weight="bold" color="label">
           {label}
         </Text>
-        {quantity !== 'UNLIMITED' && assetPrice && (
+        {quantity !== 'UNLIMITED' && !!assetPrice && (
           <Box marginLeft={'-4px'}>
             <TextOverflow size="12pt" weight="bold" color="labelSecondary">
               {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

i'm seeing this error
![image](https://github.com/rainbow-me/browser-extension/assets/12115171/4bccdda4-14e5-4d4a-b029-999931f78ebb)

there's a `0` value in black when `assetPrice` is 0, so i'm `!!assetPrice`

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
