### PR TITLE
Activity details loading

### DIFF
--- a/src/core/resources/transactions/consolidatedTransactions.ts
+++ b/src/core/resources/transactions/consolidatedTransactions.ts
@@ -27,7 +27,6 @@ const CONSOLIDATED_TRANSACTIONS_TIMEOUT = 20000;
 export type ConsolidatedTransactionsArgs = {
   address: Address;
   currency: SupportedCurrencyKey;
-  testnetMode: boolean;
   userChainIds: number[];
 };
 
@@ -37,12 +36,11 @@ export type ConsolidatedTransactionsArgs = {
 export const consolidatedTransactionsQueryKey = ({
   address,
   currency,
-  testnetMode,
   userChainIds,
 }: ConsolidatedTransactionsArgs) =>
   createQueryKey(
     'consolidatedTransactions',
-    { address, currency, testnetMode, userChainIds },
+    { address, currency, userChainIds },
     { persisterVersion: 1 },
   );
 
@@ -56,12 +54,7 @@ type ConsolidatedTransactionsQueryKey = ReturnType<
 export async function fetchConsolidatedTransactions<
   TSelectData = ConsolidatedTransactionsResult,
 >(
-  {
-    address,
-    currency,
-    testnetMode,
-    userChainIds,
-  }: ConsolidatedTransactionsArgs,
+  { address, currency, userChainIds }: ConsolidatedTransactionsArgs,
   config: QueryConfig<
     ConsolidatedTransactionsResult,
     Error,
@@ -73,7 +66,6 @@ export async function fetchConsolidatedTransactions<
     consolidatedTransactionsQueryKey({
       address,
       currency,
-      testnetMode,
       userChainIds,
     }),
     consolidatedTransactionsQueryFunction,
@@ -153,12 +145,7 @@ async function parseConsolidatedTransactions(
 export function useConsolidatedTransactions<
   TSelectData = ConsolidatedTransactionsResult,
 >(
-  {
-    address,
-    currency,
-    userChainIds,
-    testnetMode,
-  }: ConsolidatedTransactionsArgs,
+  { address, currency, userChainIds }: ConsolidatedTransactionsArgs,
   config: InfiniteQueryConfig<
     ConsolidatedTransactionsResult,
     Error,
@@ -169,7 +156,6 @@ export function useConsolidatedTransactions<
     consolidatedTransactionsQueryKey({
       address,
       currency,
-      testnetMode,
       userChainIds,
     }),
     consolidatedTransactionsQueryFunction,

--- a/src/core/resources/transactions/transaction.ts
+++ b/src/core/resources/transactions/transaction.ts
@@ -1,3 +1,4 @@
+import { Provider, TransactionResponse } from '@ethersproject/providers';
 import { formatUnits } from '@ethersproject/units';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Hash, getProvider } from '@wagmi/core';
@@ -6,7 +7,7 @@ import { Address } from 'wagmi';
 import { i18n } from '~/core/languages';
 import { addysHttp } from '~/core/network/addys';
 import { QueryFunctionResult, createQueryKey } from '~/core/react-query';
-import { SupportedCurrencyKey } from '~/core/references';
+import { SUPPORTED_CHAIN_IDS, SupportedCurrencyKey } from '~/core/references';
 import {
   consolidatedTransactionsQueryFunction,
   consolidatedTransactionsQueryKey,
@@ -16,15 +17,13 @@ import {
   useCurrentAddressStore,
   useCurrentCurrencyStore,
 } from '~/core/state';
-import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
+import { customNetworkTransactionsStore } from '~/core/state/transactions/customNetworkTransactions';
 import { ChainId } from '~/core/types/chains';
 import {
-  MinedTransaction,
-  PendingTransaction,
+  RainbowTransaction,
   TransactionApiResponse,
   TxHash,
 } from '~/core/types/transactions';
-import { isCustomChain } from '~/core/utils/chains';
 import { parseTransaction } from '~/core/utils/transactions';
 import { useUserChains } from '~/entries/popup/hooks/useUserChains';
 import { RainbowError, logger } from '~/logger';
@@ -52,6 +51,14 @@ export const fetchTransaction = async ({
   currency: SupportedCurrencyKey;
   chainId: ChainId;
 }) => {
+  if (!SUPPORTED_CHAIN_IDS.includes(chainId)) {
+    return fetchTransactionDataFromProvider({
+      chainId,
+      hash,
+      account: address,
+    });
+  }
+
   try {
     const response = await addysHttp.get<{
       payload: { transaction: TransactionApiResponse };
@@ -64,7 +71,11 @@ export const fetchTransaction = async ({
       const localPendingTx = searchInLocalPendingTransactions(address, hash);
       if (localPendingTx) return localPendingTx;
 
-      const providerTx = await getCustomChainTransaction({ chainId, hash });
+      const providerTx = await fetchTransactionDataFromProvider({
+        chainId,
+        hash,
+        account: address,
+      });
       return providerTx;
     }
     const parsedTx = parseTransaction({ tx, currency, chainId });
@@ -83,133 +94,93 @@ export const fetchTransaction = async ({
   }
 };
 
-type PaginatedTransactions = { pages: ConsolidatedTransactionsResult[] };
+async function guessTransactionType(
+  provider: Provider,
+  transaction: TransactionResponse,
+) {
+  if (!transaction.to) return 'deployment';
 
-export function useBackendTransaction({
-  hash,
-  chainId,
-  enabled,
-}: {
-  hash?: TxHash;
-  chainId?: ChainId;
-  enabled: boolean;
-}) {
-  const queryClient = useQueryClient();
-  const { currentAddress: address } = useCurrentAddressStore();
-  const { currentCurrency: currency } = useCurrentCurrencyStore();
-  const { testnetMode } = useTestnetModeStore();
-  const { chains } = useUserChains();
+  const code = await provider.getCode(transaction.to);
+  if (code && code !== '0x') return 'contract_interaction';
 
-  const paginatedTransactionsKey = consolidatedTransactionsQueryKey({
-    address,
-    currency,
-    testnetMode,
-    userChainIds: chains.map((chain) => chain.id),
-  });
-
-  const params = {
-    hash: hash!,
-    address,
-    currency,
-    chainId,
-  };
-
-  return useQuery({
-    queryKey: createQueryKey('transaction', params),
-    queryFn: () =>
-      fetchTransaction({
-        hash: params.hash,
-        address: params.address,
-        currency: params.currency,
-        chainId: params.chainId!,
-      }),
-    enabled: !!hash && !!address && !!chainId && enabled,
-    initialData: () => {
-      const queryData = queryClient.getQueryData<PaginatedTransactions>(
-        paginatedTransactionsKey,
-      );
-      const pages = queryData?.pages || [];
-      for (const page of pages) {
-        const tx = page.transactions.find((tx) => tx.hash === hash);
-        if (tx) return tx;
-      }
-    },
-    initialDataUpdatedAt: () =>
-      queryClient.getQueryState(paginatedTransactionsKey)?.dataUpdatedAt,
-  });
+  return 'send';
 }
 
-const getCustomChainTransaction = async ({
+const fetchTransactionDataFromProvider = async ({
   chainId,
   hash,
+  account,
 }: {
   chainId: number;
   hash: Hash;
-}) => {
+  account: Address;
+}): Promise<RainbowTransaction> => {
   const provider = getProvider({ chainId });
   const transaction = await provider.getTransaction(hash);
+
   if (!transaction)
     throw `getCustomChainTransaction: couldn't find transaction`;
-
-  const block = transaction?.blockHash
-    ? await provider.getBlock(transaction?.blockHash)
-    : undefined;
 
   const decimals = 18; // assuming every chain uses 18 decimals
   const value = formatUnits(transaction.value, decimals);
 
-  const parsedTransaction = transaction.blockNumber
-    ? ({
-        status: 'confirmed',
-        blockNumber: transaction.blockNumber || 0,
-        minedAt: block?.timestamp || 0,
-        confirmations: transaction.confirmations,
-        gasUsed: transaction.gasLimit.toString(),
-        hash: transaction.hash as Hash,
-        nonce: transaction.nonce,
-        chainId: transaction.chainId,
-        from: transaction.from as Address,
-        to: transaction.to as Address,
-        data: transaction.data,
-        value,
-        type: 'send',
-        title: i18n.t('transactions.send.confirmed'),
-        baseFee: block?.baseFeePerGas?.toString(),
-        maxFeePerGas: transaction.maxFeePerGas?.toString(),
-        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas?.toString(),
-        gasPrice: transaction.gasPrice?.toString(),
-      } satisfies MinedTransaction)
-    : ({
-        status: 'pending',
-        hash: transaction.hash as Hash,
-        nonce: transaction.nonce,
-        chainId: transaction.chainId,
-        from: transaction.from as Address,
-        to: transaction.to as Address,
-        data: transaction.data,
-        value,
-        type: 'send',
-        title: i18n.t('transactions.send.pending'),
-      } satisfies PendingTransaction);
-  return parsedTransaction;
+  const direction =
+    transaction.from === account ? ('out' as const) : ('in' as const);
+
+  const baseTransaction = {
+    hash: transaction.hash as Hash,
+    nonce: transaction.nonce,
+    chainId: transaction.chainId,
+    from: transaction.from as Address,
+    to: transaction.to as Address,
+    data: transaction.data,
+    value,
+    direction,
+
+    feeType: !transaction.maxFeePerGas ? 'legacy' : 'eip-1559',
+    gasLimit: transaction.gasLimit.toString(),
+    maxFeePerGas: transaction.maxFeePerGas?.toString(),
+    maxPriorityFeePerGas: transaction.maxPriorityFeePerGas?.toString(),
+    gasPrice: transaction.gasPrice?.toString(),
+  } as const;
+
+  if (transaction.blockNumber !== undefined) {
+    const [receipt, block, type] = await Promise.all([
+      provider.getTransactionReceipt(transaction.hash),
+      provider.getBlock(transaction.blockNumber),
+      guessTransactionType(provider, transaction),
+    ]);
+    const status = receipt.status === 1 ? 'confirmed' : 'failed';
+
+    return {
+      ...baseTransaction,
+      status,
+      type,
+      title: i18n.t(`transactions.${type}.${status}`),
+
+      blockNumber: transaction.blockNumber,
+      minedAt: transaction.timestamp!,
+      confirmations: transaction.confirmations,
+
+      gasUsed: receipt.gasUsed.toString(),
+
+      feeType: !block.baseFeePerGas ? 'legacy' : 'eip-1559',
+      fee: receipt.cumulativeGasUsed.mul(receipt.effectiveGasPrice).toString(),
+      baseFee: block.baseFeePerGas?.toString(),
+    };
+  }
+
+  const type = await guessTransactionType(provider, transaction);
+
+  return {
+    ...baseTransaction,
+    status: 'pending',
+    type,
+    title: i18n.t(`transactions.${type}.pending`),
+  };
 };
 
-export function useCustomNetworkTransaction({
-  hash,
-  chainId,
-  enabled,
-}: {
-  hash?: TxHash;
-  chainId?: ChainId;
-  enabled: boolean;
-}) {
-  return useQuery({
-    queryKey: createQueryKey('providerTransaction', { chainId, hash }),
-    queryFn: () =>
-      getCustomChainTransaction({ chainId: chainId!, hash: hash! }),
-    enabled: !!hash && !!chainId && enabled,
-  });
-}
+type PaginatedTransactions = { pages: ConsolidatedTransactionsResult[] };
 
 export const useTransaction = ({
   chainId,
@@ -218,32 +189,53 @@ export const useTransaction = ({
   chainId?: number;
   hash?: `0x${string}`;
 }) => {
-  const customChain = !!chainId && isCustomChain(chainId);
-  const {
-    data: backendTransaction,
-    isLoading: backendTransactionIsLoading,
-    isFetched: backendTransactionIsFetched,
-  } = useBackendTransaction({
-    hash,
-    chainId,
-    enabled: !customChain && !!hash && !!chainId,
-  });
-  const {
-    data: providerTransaction,
-    isLoading: providerTransactionIsLoading,
-    isFetched: providerTransactionIsFetched,
-  } = useCustomNetworkTransaction({
-    hash,
-    chainId,
-    enabled: customChain,
-  });
-  return {
-    data: customChain ? providerTransaction : backendTransaction,
-    isLoading: customChain
-      ? providerTransactionIsLoading
-      : backendTransactionIsLoading,
-    isFetched: customChain
-      ? providerTransactionIsFetched
-      : backendTransactionIsFetched,
+  const queryClient = useQueryClient();
+
+  const { currentAddress: address } = useCurrentAddressStore();
+  const { currentCurrency: currency } = useCurrentCurrencyStore();
+  const { chains } = useUserChains();
+
+  const params = {
+    hash: hash!,
+    address,
+    currency,
+    chainId: chainId!,
   };
+
+  const consolidatedTransactionsKey = consolidatedTransactionsQueryKey({
+    address,
+    currency,
+    userChainIds: chains.map((chain) => chain.id),
+  });
+
+  return useQuery({
+    queryKey: createQueryKey('transaction', params),
+    queryFn: () => fetchTransaction(params),
+    enabled: !!hash && !!address && !!chainId,
+    initialData: () => {
+      // consolidatedTransactions is only for BE supported chains
+      const queryData = queryClient.getQueryData<PaginatedTransactions>(
+        consolidatedTransactionsKey,
+      );
+      const pages = queryData?.pages || [];
+      for (const page of pages) {
+        const tx = page.transactions.find(
+          (tx) => tx.hash === hash && tx.chainId === chainId,
+        );
+        if (tx) return tx;
+      }
+
+      // try to find in custom network transactions store
+      const { getCustomNetworkTransactions } =
+        customNetworkTransactionsStore.getState();
+      return getCustomNetworkTransactions({ address }).find(
+        (tx) => tx.hash === hash && tx.chainId === chainId,
+      );
+    },
+    initialDataUpdatedAt: () => {
+      if (!chainId || !SUPPORTED_CHAIN_IDS.includes(chainId)) return undefined;
+      return queryClient.getQueryState(consolidatedTransactionsKey)
+        ?.dataUpdatedAt;
+    },
+  });
 };

--- a/src/core/state/transactions/customNetworkTransactions/index.ts
+++ b/src/core/state/transactions/customNetworkTransactions/index.ts
@@ -1,20 +1,20 @@
 import { Address } from 'wagmi';
 import create from 'zustand';
 
-import { MinedTransaction } from '~/core/types/transactions';
+import { RainbowTransaction } from '~/core/types/transactions';
 
 import { createStore } from '../../internal/createStore';
 
 export interface CustomNetworkTransactionsState {
   customNetworkTransactions: Record<
     Address,
-    Record<number, MinedTransaction[]>
+    Record<number, RainbowTransaction[]>
   >;
   getCustomNetworkTransactions: ({
     address,
   }: {
     address: Address;
-  }) => MinedTransaction[];
+  }) => RainbowTransaction[];
   addCustomNetworkTransactions: ({
     address,
     chainId,
@@ -22,7 +22,7 @@ export interface CustomNetworkTransactionsState {
   }: {
     address: Address;
     chainId: number;
-    transaction: MinedTransaction;
+    transaction: RainbowTransaction;
   }) => void;
   clearCustomNetworkTransactions: ({
     address,

--- a/src/design-system/components/BottomSheet/BottomSheet.tsx
+++ b/src/design-system/components/BottomSheet/BottomSheet.tsx
@@ -70,7 +70,7 @@ export const BottomSheet = ({
             exit={{ opacity: 1, y: 800 }}
             key="bottom"
             transition={{ duration: transition_duration_s }}
-            layout
+            layout="preserve-aspect"
             isModal
           >
             <Box

--- a/src/entries/popup/hooks/useInfiniteTransactionList.ts
+++ b/src/entries/popup/hooks/useInfiniteTransactionList.ts
@@ -67,7 +67,6 @@ export const useInfiniteTransactionList = ({
     address,
     currency,
     userChainIds: supportedChainIds,
-    testnetMode,
   });
 
   const pages = data?.pages;
@@ -122,7 +121,6 @@ export const useInfiniteTransactionList = ({
           address,
           currency,
           userChainIds: supportedChainIds,
-          testnetMode,
         }),
         {
           ...data,
@@ -130,7 +128,7 @@ export const useInfiniteTransactionList = ({
         },
       );
     }
-  }, [address, currency, data, testnetMode, supportedChainIds]);
+  }, [address, currency, data, supportedChainIds]);
 
   useComponentWillUnmount(cleanupPages);
 

--- a/src/entries/popup/hooks/useTransactionListForPendingTxs.ts
+++ b/src/entries/popup/hooks/useTransactionListForPendingTxs.ts
@@ -30,7 +30,6 @@ export const useTransactionListForPendingTxs = () => {
     address,
     currency,
     userChainIds: supportedChainIds,
-    testnetMode,
   });
 
   useEffect(() => {

--- a/src/entries/popup/hooks/useWatchPendingTransactions.ts
+++ b/src/entries/popup/hooks/useWatchPendingTransactions.ts
@@ -11,7 +11,6 @@ import {
   useNonceStore,
   usePendingTransactionsStore,
 } from '~/core/state';
-import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
 import { useCustomNetworkTransactionsStore } from '~/core/state/transactions/customNetworkTransactions';
 import { useUserChainsStore } from '~/core/state/userChains';
 import {
@@ -42,7 +41,6 @@ export const useWatchPendingTransactions = ({
   const { currentCurrency } = useCurrentCurrencyStore();
   const { addCustomNetworkTransactions } = useCustomNetworkTransactionsStore();
   const { userChains } = useUserChainsStore();
-  const { testnetMode } = useTestnetModeStore();
 
   const pendingTransactions = useMemo(
     () => storePendingTransactions[address] || [],
@@ -249,7 +247,6 @@ export const useWatchPendingTransactions = ({
         queryKey: consolidatedTransactionsQueryKey({
           address,
           currency: currentCurrency,
-          testnetMode,
           userChainIds: Object.keys(userChains).map(Number),
         }),
       });
@@ -277,7 +274,6 @@ export const useWatchPendingTransactions = ({
     processNonces,
     processPendingTransaction,
     setPendingTransactions,
-    testnetMode,
     userChains,
   ]);
 

--- a/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { motion } from 'framer-motion';
 import { useMemo } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { Navigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { i18n } from '~/core/languages';
 import { useApprovals } from '~/core/resources/approvals/approvals';
@@ -539,7 +539,7 @@ export function ActivityDetails() {
   const { hash, chainId } = useParams<{ hash: TxHash; chainId: string }>();
   const { isWatchingWallet } = useWallets();
 
-  const { data: transaction, isLoading } = useTransaction({
+  const { data: transaction } = useTransaction({
     hash,
     chainId: Number(chainId),
   });
@@ -581,49 +581,45 @@ export function ActivityDetails() {
 
   const backToHome = () =>
     navigate(ROUTES.HOME, {
-      state: { skipTransitionOnRoute: ROUTES.HOME },
+      state: { skipTransitionOnRoute: ROUTES.HOME, tab: 'activity' },
     });
 
   const onRevoke = () => {
     triggerRevokeApproval({ show: true, approval: approvalToRevoke });
   };
 
-  return (
-    <BottomSheet zIndex={zIndexes.ACTIVITY_DETAILS} show={!!transaction}>
-      {!isLoading && !!transaction && (
-        <>
-          <Navbar
-            leftComponent={
-              <Navbar.CloseButton onClick={backToHome} withinModal />
-            }
-            titleComponent={<ActivityPill transaction={transaction} />}
-            rightComponent={
-              <MoreOptions
-                transaction={transaction}
-                revoke={!!approvalToRevoke && !isWatchingWallet}
-                onRevoke={onRevoke}
-              />
-            }
-          />
-          <Separator color="separatorTertiary" />
+  if (!transaction) {
+    return <Navigate to={ROUTES.HOME} state={{ tab: 'activity' }} />;
+  }
 
-          <Stack
-            separator={<Separator color="separatorTertiary" />}
-            padding="20px"
-            gap="20px"
-          >
-            <ToFrom transaction={transaction} />
-            {additionalDetails && (
-              <AdditionalDetails details={additionalDetails} />
-            )}
-            <ConfirmationData transaction={transaction} />
-            <NetworkData transaction={transaction} />
-            {transaction.status === 'pending' && (
-              <SpeedUpOrCancel transaction={transaction} />
-            )}
-          </Stack>
-        </>
-      )}
+  return (
+    <BottomSheet zIndex={zIndexes.ACTIVITY_DETAILS} show>
+      <Navbar
+        leftComponent={<Navbar.CloseButton onClick={backToHome} withinModal />}
+        titleComponent={<ActivityPill transaction={transaction} />}
+        rightComponent={
+          <MoreOptions
+            transaction={transaction}
+            revoke={!!approvalToRevoke && !isWatchingWallet}
+            onRevoke={onRevoke}
+          />
+        }
+      />
+      <Separator color="separatorTertiary" />
+
+      <Stack
+        separator={<Separator color="separatorTertiary" />}
+        padding="20px"
+        gap="20px"
+      >
+        <ToFrom transaction={transaction} />
+        {additionalDetails && <AdditionalDetails details={additionalDetails} />}
+        <ConfirmationData transaction={transaction} />
+        <NetworkData transaction={transaction} />
+        {transaction.status === 'pending' && (
+          <SpeedUpOrCancel transaction={transaction} />
+        )}
+      </Stack>
     </BottomSheet>
   );
 }

--- a/src/entries/popup/pages/home/Approvals/Approvals.tsx
+++ b/src/entries/popup/pages/home/Approvals/Approvals.tsx
@@ -13,7 +13,6 @@ import {
 import { useConsolidatedTransactions } from '~/core/resources/transactions/consolidatedTransactions';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { useCurrentThemeStore } from '~/core/state/currentSettings/currentTheme';
-import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
 import { useUserChainsStore } from '~/core/state/userChains';
 import { ChainId } from '~/core/types/chains';
 import { RainbowTransaction, TxHash } from '~/core/types/transactions';
@@ -331,7 +330,6 @@ export const Approvals = () => {
     approval: Approval | null;
     spender: ApprovalSpender | null;
   }>({ approval: null, spender: null });
-  const { testnetMode } = useTestnetModeStore();
   const supportedMainnetIds = SUPPORTED_MAINNET_CHAINS.map((c: Chain) => c.id);
   const [sort, setSort] = useState<SortType>('recent');
   const [activeTab, setActiveTab] = useState<Tab>('tokens');
@@ -340,7 +338,6 @@ export const Approvals = () => {
     address: currentAddress,
     currency: currentCurrency,
     userChainIds: supportedMainnetIds,
-    testnetMode,
   });
 
   const revokeTransactions = useMemo(


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

- activity details sheet insta shows on clicking an activity (before was waiting for loading), now it shows with the data we got and updates as more data comes
- removed `testnetMode` from the consolidatedTransactionsQueryKey as it was not used in the query itself and I didn't find a reason to have it in the query key lmk if Im mistaken
- refactored a lil bit the `useTransaction` hook, aggregated into a single useQuery for either supported or unsupported BE networks and added some more info we could find when fetching the tx data from the provider

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
