### PR TITLE
update migrations

### DIFF
--- a/src/core/state/favorites/index.ts
+++ b/src/core/state/favorites/index.ts
@@ -122,6 +122,17 @@ const mergeNewOfficiallySupportedChainsState = (
   return state;
 };
 
+const migrations: ((s: FavoritesState) => FavoritesState)[] = [
+  // version 1 didn't need a migration
+  (state: FavoritesState) => state,
+  // version 2 added avalanche
+  (state) => mergeNewOfficiallySupportedChainsState(state, [ChainId.avalanche]),
+  // version 3 added blast
+  (state) => mergeNewOfficiallySupportedChainsState(state, [ChainId.blast]),
+  // version 4 added degen
+  (state) => mergeNewOfficiallySupportedChainsState(state, [ChainId.degen]),
+];
+
 export const favoritesStore = createStore<FavoritesState>(
   (set, get) => ({
     favorites: defaultFavorites,
@@ -151,20 +162,8 @@ export const favoritesStore = createStore<FavoritesState>(
   {
     persist: {
       name: 'favorites',
-      version: 4,
-      migrate: migrate(
-        // version 1 didn't need a migration
-        (state: FavoritesState) => state,
-        // version 2 added avalanche
-        (state) =>
-          mergeNewOfficiallySupportedChainsState(state, [ChainId.avalanche]),
-        // version 3 added blast
-        (state) =>
-          mergeNewOfficiallySupportedChainsState(state, [ChainId.blast]),
-        // version 4 added degen
-        (state) =>
-          mergeNewOfficiallySupportedChainsState(state, [ChainId.degen]),
-      ),
+      version: migrations.length - 1,
+      migrate: migrate(migrations),
     },
   },
 );

--- a/src/core/state/favorites/index.ts
+++ b/src/core/state/favorites/index.ts
@@ -162,7 +162,7 @@ export const favoritesStore = createStore<FavoritesState>(
   {
     persist: {
       name: 'favorites',
-      version: migrations.length - 1,
+      version: migrations.length,
       migrate: migrate(migrations),
     },
   },

--- a/src/core/state/rainbowChains/index.ts
+++ b/src/core/state/rainbowChains/index.ts
@@ -148,9 +148,10 @@ const migrations: ((s: RainbowChainsState) => RainbowChainsState)[] = [
       ChainId.avalanche,
       ChainId.avalancheFuji,
     ]),
-  // version 2 added support for Blast
+  // version 3 added support for Blast
   (state: RainbowChainsState) =>
     mergeNewOfficiallySupportedChainsState(state, [ChainId.blast]),
+  // version 4
   (state) =>
     removeCustomRPC({
       state,
@@ -160,6 +161,7 @@ const migrations: ((s: RainbowChainsState) => RainbowChainsState)[] = [
   // version 5 added support for Degen
   (state: RainbowChainsState) =>
     mergeNewOfficiallySupportedChainsState(state, [ChainId.degen]),
+  // version 6
   (state: RainbowChainsState) => {
     if (
       !state.rainbowChains[zora.id] ||
@@ -169,6 +171,11 @@ const migrations: ((s: RainbowChainsState) => RainbowChainsState)[] = [
     }
     return state;
   },
+  // version 7, check https://github.com/rainbow-me/browser-extension/pull/1520 we had to
+  // add dumb migrations
+  (state: RainbowChainsState) => state,
+  (state: RainbowChainsState) => state,
+  // version 8
   (state: RainbowChainsState) => {
     if (
       !state.rainbowChains[chainDegen.id] ||
@@ -267,7 +274,7 @@ export const rainbowChainsStore = createStore<RainbowChainsState>(
   {
     persist: {
       name: 'rainbowChains',
-      version: migrations.length - 1,
+      version: 8,
       migrate: migrate(migrations),
     },
   },

--- a/src/core/state/rainbowChains/index.ts
+++ b/src/core/state/rainbowChains/index.ts
@@ -274,7 +274,7 @@ export const rainbowChainsStore = createStore<RainbowChainsState>(
   {
     persist: {
       name: 'rainbowChains',
-      version: 8,
+      version: migrations.length,
       migrate: migrate(migrations),
     },
   },

--- a/src/core/utils/migrate.ts
+++ b/src/core/utils/migrate.ts
@@ -16,7 +16,7 @@ interface Migrator {
 export const migrate: Migrator = (migrations: ((s: any) => any)[]) => {
   return (persistedState: any, version: number) => {
     return migrations
-      .slice(0, version) // Use slice to select up to the specified version
+      .toSpliced(0, version)
       .reduce((acc, fn) => fn(acc), persistedState);
   };
 };

--- a/src/core/utils/migrate.ts
+++ b/src/core/utils/migrate.ts
@@ -3,31 +3,7 @@
 type R<T> = (persistedState: unknown, version: number) => T;
 
 interface Migrator {
-  <A>(m1: (s: any) => A): R<A>;
-  <A, B>(m1: (s: any) => A, m2: (s: A) => B): R<B>;
-  <A, B, C>(m1: (s: any) => A, m2: (s: A) => B, m3: (s: B) => C): R<C>;
-  <A, B, C, D>(
-    m1: (s: any) => A,
-    m2: (s: A) => B,
-    m3: (s: B) => C,
-    m4: (s: C) => D,
-  ): R<D>;
-  <A, B, C, D, E>(
-    m1: (s: any) => A,
-    m2: (s: A) => B,
-    m3: (s: B) => C,
-    m4: (s: C) => D,
-    m5: (s: D) => E,
-  ): R<E>;
-  <A, B, C, D, E, F>(
-    m1: (s: any) => A,
-    m2: (s: A) => B,
-    m3: (s: B) => C,
-    m4: (s: C) => D,
-    m5: (s: D) => E,
-    m6: (s: E) => F,
-  ): R<F>;
-  // if you need more migrations, add more overloads here
+  <T>(migrations: ((s: any) => any)[]): R<T>;
 }
 
 /**
@@ -37,11 +13,10 @@ interface Migrator {
  * - migrations must be in order
  * - zustand persister version must be an integer
  */
-export const migrate: Migrator = (
-  ...migrations: ((s: unknown) => unknown)[]
-) => {
-  return (persistedState: unknown, version: number) =>
-    migrations
-      .toSpliced(0, version)
+export const migrate: Migrator = (migrations: ((s: any) => any)[]) => {
+  return (persistedState: any, version: number) => {
+    return migrations
+      .slice(0, version) // Use slice to select up to the specified version
       .reduce((acc, fn) => fn(acc), persistedState);
+  };
 };

--- a/src/core/utils/userChains.ts
+++ b/src/core/utils/userChains.ts
@@ -80,7 +80,7 @@ export const chainLabelMap: Record<
   [ChainId.zora]: [ChainNameDisplay[zoraSepolia.id]],
   [ChainId.avalanche]: [ChainNameDisplay[avalancheFuji.id]],
   [ChainId.blast]: [ChainNameDisplay[chainBlastSepolia.id]],
-  [ChainId.degen]: [ChainNameDisplay[chainDegen.id]],
+  [ChainId.degen]: [],
 };
 
 export const sortNetworks = (order: ChainId[], chains: Chain[]) => {


### PR DESCRIPTION
Fixes BX-1443
Figma link (if any):

## What changed (plus any additional context for devs)

new method `migrate` is working fine but we were using it wrongly together with version number for state slices

for rainbowChains we had version 7, with 6 migrations

`migrate` applies the migration functions one by one removing the ones from 0 to `version` (.toSliced(0,version)`) so if you were in version 6, all of the migrations would be removed since the migrations were 6, so none of the migrations were being executed 

we have to have this in mind for the next time we use this method

I updated `migrate` to accept any arbitrary number of elements in an array param since it was annoying to add a new interface for each element in the array


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
