### PR TITLE
[BX-1434] feat: add keyboard navigation to the points dashboard

### DIFF
--- a/src/entries/popup/pages/home/Points/WeeklyPointsOverview.tsx
+++ b/src/entries/popup/pages/home/Points/WeeklyPointsOverview.tsx
@@ -217,6 +217,7 @@ export function PointsWeeklyOverview() {
           borderRadius="12px"
           height="36px"
           variant="shadow"
+          tabIndex={0}
         >
           {i18n.t('close')}
         </Button>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Keyboard navigation added to the points dashboard and the weekly earnings modal

## Screen recordings / screenshots
https://www.loom.com/share/41a8d23a3c0a4827937a62d5f528906e

## What to test
Traverse the points screen with the keyboard. Cards with onClick/onTap handlers should work when pressing ENTER.
