### PR TITLE
[BX-1371] fix: increase cta width when waiting for device

### DIFF
--- a/src/entries/popup/pages/messages/BottomActions/index.tsx
+++ b/src/entries/popup/pages/messages/BottomActions/index.tsx
@@ -390,6 +390,7 @@ export const AcceptRequestButton = ({
       testId="accept-request-button"
       disabled={disabled}
       tabIndex={0}
+      paddingHorizontal={waitingForDevice ? '16px' : '24px'}
       shortcut={
         !disabled && !waitingForDevice && !isScamDapp
           ? { ...shortcuts.transaction_request.ACCEPT, type: 'request.accept' }
@@ -400,7 +401,7 @@ export const AcceptRequestButton = ({
     >
       <TextOverflow weight="bold" size="16pt" color={textColor}>
         {loading || waitingForDevice ? (
-          <Inline space="4px" alignVertical="center">
+          <Inline space="4px" alignVertical="center" wrap={false}>
             <Spinner size={16} color="label" />
             {waitingForDevice && i18n.t('approve_request.confirm_hw')}
           </Inline>
@@ -416,10 +417,12 @@ export const RejectRequestButton = ({
   onClick,
   label,
   dappStatus,
+  waitingForDevice,
 }: {
   onClick: () => void;
   label: string;
   dappStatus?: DAppStatus;
+  waitingForDevice?: boolean;
 }) => {
   const isScamDapp = dappStatus === DAppStatus.Scam;
 
@@ -428,9 +431,9 @@ export const RejectRequestButton = ({
       color={isScamDapp ? 'red' : 'separatorSecondary'}
       variant="flat"
       height="44px"
-      width="full"
       onClick={onClick}
       testId="reject-request-button"
+      width={waitingForDevice ? 'fit' : 'full'}
       tabIndex={0}
       shortcut={{
         ...shortcuts.transaction_request.CANCEL,

--- a/src/entries/popup/pages/messages/SignMessage/SignMessageActions.tsx
+++ b/src/entries/popup/pages/messages/SignMessage/SignMessageActions.tsx
@@ -24,6 +24,7 @@ export const SignMessageActions = ({
         dappStatus={dappStatus}
         onClick={onRejectRequest}
         label={i18n.t('common_actions.cancel')}
+        waitingForDevice={waitingForDevice}
       />
       <AcceptRequestButton
         dappStatus={dappStatus}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Shrinking cancel button and letting confirmation CTA grow when waiting for hw wallet.

## Screen recordings / screenshots
<img width="357" alt="Screen Shot 2024-04-29 at 11 17 38 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/05f1eb47-a2ed-4433-afc7-6b6e196333bd">
<img width="356" alt="Screen Shot 2024-04-29 at 11 17 52 AM" src="https://github.com/rainbow-me/browser-extension/assets/14877580/d30378b6-18c1-4f9d-97d5-e15f39c2660b">


## What to test
Make sure the confirm button grows to display the waiting for device copy when signing with hardware wallet
