### PR TITLE
fix: missing native asset name

### DIFF
--- a/src/entries/popup/hooks/useNativeAsset.ts
+++ b/src/entries/popup/hooks/useNativeAsset.ts
@@ -50,12 +50,10 @@ export const useNativeAsset = ({
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
     chainId: chainId || ChainId.mainnet,
   });
-  console.log('-- nativeAssetUniqueId', nativeAssetUniqueId);
   const { data: userNativeAsset } = useUserAsset(
     nativeAssetUniqueId || '',
     address || currentAddress,
   );
-  console.log('-- userNativeAsset', userNativeAsset);
   const mockNativeAsset = useMockNativeAsset({ chainId });
 
   const { data: testnetNativeAsset } = useUserTestnetNativeAsset({
@@ -81,6 +79,5 @@ export const useNativeAsset = ({
   } else {
     nativeAsset = userNativeAsset || mockNativeAsset;
   }
-  console.log('returning nativeAsset', nativeAsset);
   return { nativeAsset };
 };

--- a/src/entries/popup/hooks/useNativeAsset.ts
+++ b/src/entries/popup/hooks/useNativeAsset.ts
@@ -1,7 +1,6 @@
 import { AddressZero } from '@ethersproject/constants';
 import { Address, useNetwork } from 'wagmi';
 
-import { NATIVE_ASSETS_MAP_PER_CHAIN } from '~/core/references';
 import { useUserTestnetNativeAsset } from '~/core/resources/assets/userTestnetNativeAsset';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { ParsedUserAsset } from '~/core/types/assets';
@@ -9,7 +8,10 @@ import { ChainId } from '~/core/types/chains';
 import { chainNameFromChainId, isCustomChain } from '~/core/utils/chains';
 
 import { useCustomNetworkAsset } from './useCustomNetworkAsset';
-import { getNetworkNativeAssetUniqueId } from './useNativeAssetForNetwork';
+import {
+  getNetworkNativeAssetChainId,
+  getNetworkNativeAssetUniqueId,
+} from './useNativeAssetForNetwork';
 import { useNativeAssets } from './useNativeAssets';
 import { useUserAsset } from './useUserAsset';
 
@@ -22,10 +24,8 @@ const useMockNativeAsset = ({
   const { chains } = useNetwork();
   const chain = chains.find((c) => c.id === chainId);
   if (!nativeAssets || !chain) return null;
-  const assetKey = `${NATIVE_ASSETS_MAP_PER_CHAIN[chain.id]}_${
-    ChainId.mainnet
-  }`;
-  const nativeAsset = nativeAssets[assetKey];
+  const nativeAssetMetadataChainId = getNetworkNativeAssetChainId({ chainId });
+  const nativeAsset = nativeAssets?.[nativeAssetMetadataChainId];
   return {
     ...nativeAsset,
     chainId: chain.id,
@@ -50,10 +50,12 @@ export const useNativeAsset = ({
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
     chainId: chainId || ChainId.mainnet,
   });
+  console.log('-- nativeAssetUniqueId', nativeAssetUniqueId);
   const { data: userNativeAsset } = useUserAsset(
     nativeAssetUniqueId || '',
     address || currentAddress,
   );
+  console.log('-- userNativeAsset', userNativeAsset);
   const mockNativeAsset = useMockNativeAsset({ chainId });
 
   const { data: testnetNativeAsset } = useUserTestnetNativeAsset({
@@ -79,5 +81,6 @@ export const useNativeAsset = ({
   } else {
     nativeAsset = userNativeAsset || mockNativeAsset;
   }
+  console.log('returning nativeAsset', nativeAsset);
   return { nativeAsset };
 };

--- a/src/entries/popup/hooks/useNativeAssetForNetwork.ts
+++ b/src/entries/popup/hooks/useNativeAssetForNetwork.ts
@@ -15,7 +15,7 @@ import { chainNameFromChainId } from '~/core/utils/chains';
 
 import { getNativeAssets, useNativeAssets } from './useNativeAssets';
 
-const getNetworkNativeAssetChainId = ({
+export const getNetworkNativeAssetChainId = ({
   chainId,
 }: {
   chainId: ChainId;

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -626,7 +626,7 @@ export function SendTransactionInfo({
         )}
       </AnimatePresence>
 
-      {!hasEnoughGas ? (
+      {hasEnoughGas ? (
         <TransactionInfo
           request={txRequest}
           dappMetadata={dappMetadata}

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -626,7 +626,7 @@ export function SendTransactionInfo({
         )}
       </AnimatePresence>
 
-      {hasEnoughGas ? (
+      {!hasEnoughGas ? (
         <TransactionInfo
           request={txRequest}
           dappMetadata={dappMetadata}


### PR DESCRIPTION
Fixes BX-1450
Fixes BX-1451

Figma link (if any):

## What changed (plus any additional context for devs)

updated the way we get native assets from `useNativeAsset`

check ticket for more details

![image](https://github.com/rainbow-me/browser-extension/assets/12115171/9e1be2bd-cf50-407b-a2d8-8ccb630b9b03)


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
