### PR TITLE
probably fix overlapping activities

### DIFF
--- a/src/entries/popup/pages/home/Activity/ActivitiesList.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivitiesList.tsx
@@ -131,9 +131,9 @@ export function Activities() {
       >
         <Box
           width="full"
+          position="relative"
           style={{
             height: activityRowVirtualizer.getTotalSize(),
-            position: 'relative',
           }}
         >
           {rows.map((virtualItem) => {
@@ -145,11 +145,9 @@ export function Activities() {
                 key={key}
                 data-index={index}
                 as={motion.div}
-                layoutId={`list-${index}`}
-                layoutScroll
-                layout="position"
-                initial={{ opacity: isLabel ? 0 : 1 }}
-                animate={{ opacity: 1 }}
+                initial={{ opacity: isLabel ? 0 : 1, x: -4 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ opacity: { duration: 0.3 } }}
                 position="absolute"
                 width="full"
                 style={{ height: size, y: start }}

--- a/src/entries/popup/pages/home/Tokens.tsx
+++ b/src/entries/popup/pages/home/Tokens.tsx
@@ -303,10 +303,11 @@ export function Tokens() {
             return (
               <Box
                 key={`${token.uniqueId}-${key}`}
-                layoutId={`list-${index}`}
                 as={motion.div}
                 position="absolute"
                 width="full"
+                initial={{ x: 4 }}
+                animate={{ x: 0 }}
                 style={{ height: size, y: start }}
               >
                 {pinned && <TokenMarkedHighlighter />}


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

pretty sure the bug was in the way we were using framer motion `layoutId` to transition between lists, the idea was set `layoutId` to the list row index so when we change tabs between activities and tokens, the same index rows would transition smoothly
the issue is when we are adding or reordering stuff in each list, like tx A is index 1 in the list, a new pending tx B is added, now B is index 1, so framer motion is trying to animate tx row A to B but it shouldn't!! 
that's the reason we don't use index as the `key` in react, we shouldn't use as `layoutId` either

to replace the previous transition I added this one

https://github.com/rainbow-me/browser-extension/assets/6232729/670ca442-776b-4228-a48f-d29e4e7b01d3


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
