### PR TITLE
fix: `useKeyboardShortcut` not working with Cmd+K backspace shortcut

### DIFF
--- a/e2e/parallel/shortcuts-home.test.ts
+++ b/e2e/parallel/shortcuts-home.test.ts
@@ -216,6 +216,27 @@ describe.runIf(browser !== 'firefox')(
       expect(txHash).toBe(false);
     });
 
+    it('should navigate to send page using Cmd+K', async () => {
+      await executePerformShortcut({ driver, key: 'k' });
+      await executePerformShortcut({ driver, key: 'ENTER' });
+      await checkExtensionURL(driver, 'send');
+    });
+
+    it('should navigate to my wallets section in Cmd+K', async () => {
+      await goToPopup(driver, rootURL);
+      await executePerformShortcut({ driver, key: 'k' });
+      await executePerformShortcut({
+        driver,
+        key: 'ARROW_DOWN',
+        timesToPress: 2,
+      });
+      await executePerformShortcut({ driver, key: 'ENTER' });
+      await findElementByText(driver, 'Switch to Wallet');
+      await executePerformShortcut({ driver, key: 'BACK_SPACE' });
+      await findElementByText(driver, 'Suggestions');
+      await executePerformShortcut({ driver, key: 'ESCAPE' });
+    });
+
     it('should be able to lock extension with keyboard', async () => {
       await executePerformShortcut({ driver, key: 'DECIMAL' });
       await executePerformShortcut({ driver, key: 'l' });

--- a/src/entries/popup/hooks/useActivityShortcuts.ts
+++ b/src/entries/popup/hooks/useActivityShortcuts.ts
@@ -8,8 +8,10 @@ import { useSelectedTransactionStore } from '~/core/state/selectedTransaction';
 import { truncateAddress } from '~/core/utils/address';
 import { goToNewTab } from '~/core/utils/tabs';
 import { getTransactionBlockExplorer } from '~/core/utils/transactions';
+import { useContainerRef } from '~/design-system/components/AnimatedRoute/AnimatedRoute';
 
 import { triggerToast } from '../components/Toast/Toast';
+import { simulateClick } from '../utils/simulateClick';
 
 import useKeyboardAnalytics from './useKeyboardAnalytics';
 import { useKeyboardShortcut } from './useKeyboardShortcut';
@@ -23,6 +25,7 @@ export function useActivityShortcuts() {
     [selectedTransaction],
   );
 
+  const containerRef = useContainerRef();
   const trimmedHash = selectedTransaction?.hash?.replace(/-.*/g, '') || '';
   const truncatedAddress = truncateAddress(trimmedHash as Address);
   const handleCopy = useCallback(() => {
@@ -61,6 +64,7 @@ export function useActivityShortcuts() {
         }
       }
       if (e.key === shortcuts.activity.COPY_TRANSACTION.key) {
+        simulateClick(containerRef.current);
         trackShortcut({
           key: shortcuts.activity.COPY_TRANSACTION.display,
           type: 'activity.copyTransactionAddress',
@@ -68,6 +72,7 @@ export function useActivityShortcuts() {
         handleCopy();
       }
       if (e.key === shortcuts.activity.VIEW_TRANSACTION.key) {
+        simulateClick(containerRef.current);
         trackShortcut({
           key: shortcuts.activity.VIEW_TRANSACTION.display,
           type: 'activity.viewTransactionOnExplorer',
@@ -76,6 +81,7 @@ export function useActivityShortcuts() {
       }
     },
     [
+      containerRef,
       handleCopy,
       selectedTransaction,
       setCurrentHomeSheet,

--- a/src/entries/popup/hooks/useKeyboardShortcut.ts
+++ b/src/entries/popup/hooks/useKeyboardShortcut.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useCommandKStatus } from '../components/CommandK/useCommandKStatus';
 
@@ -27,21 +27,12 @@ export function useKeyboardShortcut({
 }: KeyboardShortcutConfig) {
   const isCommandKVisible = useCommandKStatus((s) => s.isCommandKVisible);
 
-  // "latest ref pattern" so we don't have to worry about stabilizing the callbacks
-  const handlerRef = useRef(handler);
-  const conditionRef = useRef(condition);
-  useLayoutEffect(() => {
-    handlerRef.current = handler;
-    conditionRef.current = condition;
-  });
-
   const shouldListen = useMemo(() => {
-    const condition = conditionRef.current;
     if (!isCommandKVisible || enableWithinCommandK) {
       return condition?.() || condition === undefined;
     }
     return false;
-  }, [enableWithinCommandK, isCommandKVisible]);
+  }, [condition, enableWithinCommandK, isCommandKVisible]);
 
   useEffect(() => {
     const systemSpecificModifierKey = getSystemSpecificModifierKey(modifierKey);
@@ -50,7 +41,7 @@ export function useKeyboardShortcut({
       if (systemSpecificModifierKey && !e[systemSpecificModifierKey]) {
         return;
       }
-      handlerRef.current(e);
+      handler(e);
     };
 
     const addHandler = () =>
@@ -67,5 +58,5 @@ export function useKeyboardShortcut({
     return () => {
       removeHandler();
     };
-  }, [modifierKey, shouldListen]);
+  }, [handler, modifierKey, shouldListen]);
 }


### PR DESCRIPTION
Fixes BX-1465

If you try to go to different menus in Cmd+K and then click backspace shortcut you won't get navigated back to where you was. There is also a bug where you can't copy NFT token id using `c` shortcut.

## What to test

Open Cmd+K menu -> navigate to "My Wallets" -> hit backspace shortcut and you should be able to get navigated back to the default Cmd+K view