### PR TITLE
chore: contacts tweaks, send to wallet flow and Cmd+K e2e test coverage

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -476,6 +476,36 @@ export async function performShortcutWithNormalKey(
   }
 }
 
+export async function executeMultipleShortcuts({
+  driver,
+  keyDown,
+  key,
+}: {
+  driver: WebDriver;
+  keyDown: keyof typeof Key | string;
+  key: keyof typeof Key | string;
+}) {
+  try {
+    await delayTime('short');
+    const keyDownAction =
+      keyDown in Key ? (Key[keyDown as keyof typeof Key] as string) : keyDown;
+    const keyAction =
+      key in Key ? (Key[key as keyof typeof Key] as string) : key;
+    await driver
+      .actions()
+      .keyDown(keyDownAction)
+      .sendKeys(keyAction)
+      .keyUp(keyDownAction)
+      .perform();
+  } catch (error) {
+    console.error(
+      `Error occurred while attempting multiple shortcuts with the keydown '${keyDown}' and key '${key}':`,
+      error,
+    );
+    throw error;
+  }
+}
+
 export async function performShortcutWithSpecialKey(
   driver: WebDriver,
   specialKey: keyof typeof Key,

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -83,7 +83,7 @@ describe('Command+K behaviours', () => {
     });
 
     await waitUntilElementByTestIdIsPresent({
-      id: 'command-row-skillet.eth',
+      id: 'command-name-skillet.eth',
       driver,
     });
 

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -54,6 +54,13 @@ describe('Command+K behaviours', () => {
     });
     await executePerformShortcut({ driver, key: 'ENTER' });
 
+    // Select 2nd wallet
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+      timesToPress: 1,
+    });
+
     // Cmd+Enter
     await executeMultipleShortcuts({
       driver,
@@ -61,11 +68,7 @@ describe('Command+K behaviours', () => {
       key: 'ENTER',
     });
 
-    await executePerformShortcut({
-      driver,
-      key: 'ARROW_DOWN',
-    });
-
+    // Send to wallet
     await executePerformShortcut({ driver, key: 'ENTER' });
     await checkExtensionURL(driver, 'send');
   });

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -1,23 +1,18 @@
 import 'chromedriver';
 import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, it } from 'vitest';
 
 import {
   checkExtensionURL,
-  delayTime,
   executeMultipleShortcuts,
   executePerformShortcut,
-  findElementByIdAndClick,
-  findElementByTestIdAndClick,
   getExtensionIdByName,
   getRootUrl,
   goToPopup,
   importWalletFlow,
   initDriverWithOptions,
-  querySelector,
   typeOnTextInput,
-  waitUntilElementByTestIdIsPresent,
 } from '../helpers';
 import { TEST_VARIABLES } from '../walletVariables';
 
@@ -73,109 +68,41 @@ describe('Command+K behaviours', () => {
     await checkExtensionURL(driver, 'send');
   });
 
-  it('should be able to add a new wallet via watch', async () => {
+  it('should be able to add a searched wallet as contact and send it using my contacts section', async () => {
     await goToPopup(driver, rootURL);
-    await findElementByIdAndClick({
-      id: 'header-account-name-shuffle',
-      driver,
-    });
-    await findElementByTestIdAndClick({ id: 'add-wallet-button', driver });
 
-    await findElementByTestIdAndClick({
-      id: 'watch-wallets-button',
-      driver,
-    });
+    // cmd k
+    await executePerformShortcut({ driver, key: 'k' });
 
+    // search for wallet
     await typeOnTextInput({
-      id: 'secret-text-area-watch',
+      id: 'command-k-input',
       driver,
-      text: TEST_VARIABLES.WATCHED_WALLET.SECONDARY_ADDRESS,
+      text: 'skillet.eth',
     });
 
-    await waitUntilElementByTestIdIsPresent({
-      id: 'watch-wallets-button-ready',
-      driver,
-    });
-
-    await findElementByTestIdAndClick({
-      id: 'watch-wallets-button-ready',
-      driver,
-    });
-
-    await delayTime('medium');
-
-    await goToPopup(driver, rootURL);
-    const label = await querySelector(
-      driver,
-      '[data-testid="header"] [data-testid="account-name"]',
-    );
-
-    const actual = await label.getText();
-    const expected = [
-      '0x089b...be9E',
-      TEST_VARIABLES.WATCHED_WALLET.SECONDARY_ADDRESS,
-    ];
-    expect(expected.includes(actual)).toEqual(true);
-  });
-
-  it('should be able to add a watched wallet as contact and send it using my contacts section', async () => {
-    await findElementByIdAndClick({
-      id: 'header-account-name-shuffle',
-      driver,
-    });
-
-    // Seed phrase wallet
-    await findElementByTestIdAndClick({ id: 'wallet-account-1', driver });
-
-    await executePerformShortcut({ driver, key: 'k' });
-
+    // select wallet and add as contact
+    await executePerformShortcut({ driver, key: 'ENTER' });
     await executePerformShortcut({
       driver,
       key: 'ARROW_DOWN',
-      timesToPress: 2,
+      timesToPress: 1,
     });
-
     await executePerformShortcut({ driver, key: 'ENTER' });
 
-    await executePerformShortcut({
-      driver,
-      key: 'ARROW_DOWN',
-    });
-
-    // Cmd+Enter
-    await executeMultipleShortcuts({
-      driver,
-      keyDown: 'COMMAND',
-      key: 'ENTER',
-    });
-
-    await executePerformShortcut({
-      driver,
-      key: 'ARROW_DOWN',
-      timesToPress: 2,
-    });
-
-    await executePerformShortcut({ driver, key: 'ENTER' });
-
+    // cmd k
     await executePerformShortcut({ driver, key: 'k' });
 
+    // select contact from my contacts
     await executePerformShortcut({
       driver,
       key: 'ARROW_DOWN',
       timesToPress: 3,
     });
-
+    await executePerformShortcut({ driver, key: 'ENTER' });
     await executePerformShortcut({ driver, key: 'ENTER' });
 
-    // Cmd+Enter
-    await executeMultipleShortcuts({
-      driver,
-      keyDown: 'COMMAND',
-      key: 'ENTER',
-    });
-
-    await executePerformShortcut({ driver, key: 'ENTER' });
-
+    // should be on send flow
     await checkExtensionURL(driver, 'send');
   });
 });

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -1,0 +1,178 @@
+import 'chromedriver';
+import 'geckodriver';
+import { WebDriver } from 'selenium-webdriver';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  checkExtensionURL,
+  delayTime,
+  executeMultipleShortcuts,
+  executePerformShortcut,
+  findElementByIdAndClick,
+  findElementByTestIdAndClick,
+  getExtensionIdByName,
+  getRootUrl,
+  goToPopup,
+  importWalletFlow,
+  initDriverWithOptions,
+  querySelector,
+  typeOnTextInput,
+  waitUntilElementByTestIdIsPresent,
+} from '../helpers';
+import { TEST_VARIABLES } from '../walletVariables';
+
+let rootURL = getRootUrl();
+let driver: WebDriver;
+
+const browser = process.env.BROWSER || 'chrome';
+const os = process.env.OS || 'mac';
+
+describe('Command+K behaviours', () => {
+  beforeAll(async () => {
+    driver = await initDriverWithOptions({
+      browser,
+      os,
+    });
+    const extensionId = await getExtensionIdByName(driver, 'Rainbow');
+    if (!extensionId) throw new Error('Extension not found');
+    rootURL += extensionId;
+  });
+  afterAll(async () => driver.quit());
+
+  it('should be able import a wallet via seed', async () => {
+    await importWalletFlow(driver, rootURL, TEST_VARIABLES.EMPTY_WALLET.SECRET);
+  });
+
+  it('should send to an owned wallet in my wallets menu', async () => {
+    await goToPopup(driver, rootURL);
+
+    await executePerformShortcut({ driver, key: 'k' });
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+      timesToPress: 2,
+    });
+    await executePerformShortcut({ driver, key: 'ENTER' });
+
+    // Cmd+Enter
+    await executeMultipleShortcuts({
+      driver,
+      keyDown: 'COMMAND',
+      key: 'ENTER',
+    });
+
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+    });
+
+    await executePerformShortcut({ driver, key: 'ENTER' });
+    await checkExtensionURL(driver, 'send');
+  });
+
+  it('should be able to add a new wallet via watch', async () => {
+    await goToPopup(driver, rootURL);
+    await findElementByIdAndClick({
+      id: 'header-account-name-shuffle',
+      driver,
+    });
+    await findElementByTestIdAndClick({ id: 'add-wallet-button', driver });
+
+    await findElementByTestIdAndClick({
+      id: 'watch-wallets-button',
+      driver,
+    });
+
+    await typeOnTextInput({
+      id: 'secret-text-area-watch',
+      driver,
+      text: TEST_VARIABLES.WATCHED_WALLET.SECONDARY_ADDRESS,
+    });
+
+    await waitUntilElementByTestIdIsPresent({
+      id: 'watch-wallets-button-ready',
+      driver,
+    });
+
+    await findElementByTestIdAndClick({
+      id: 'watch-wallets-button-ready',
+      driver,
+    });
+
+    await delayTime('medium');
+
+    await goToPopup(driver, rootURL);
+    const label = await querySelector(
+      driver,
+      '[data-testid="header"] [data-testid="account-name"]',
+    );
+
+    const actual = await label.getText();
+    const expected = [
+      '0x089b...be9E',
+      TEST_VARIABLES.WATCHED_WALLET.SECONDARY_ADDRESS,
+    ];
+    expect(expected.includes(actual)).toEqual(true);
+  });
+
+  it('should be able to add a watched wallet as contact and send it using my contacts section', async () => {
+    await findElementByIdAndClick({
+      id: 'header-account-name-shuffle',
+      driver,
+    });
+
+    // Seed phrase wallet
+    await findElementByTestIdAndClick({ id: 'wallet-account-1', driver });
+
+    await executePerformShortcut({ driver, key: 'k' });
+
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+      timesToPress: 2,
+    });
+
+    await executePerformShortcut({ driver, key: 'ENTER' });
+
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+    });
+
+    // Cmd+Enter
+    await executeMultipleShortcuts({
+      driver,
+      keyDown: 'COMMAND',
+      key: 'ENTER',
+    });
+
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+      timesToPress: 2,
+    });
+
+    await executePerformShortcut({ driver, key: 'ENTER' });
+
+    await executePerformShortcut({ driver, key: 'k' });
+
+    await executePerformShortcut({
+      driver,
+      key: 'ARROW_DOWN',
+      timesToPress: 3,
+    });
+
+    await executePerformShortcut({ driver, key: 'ENTER' });
+
+    // Cmd+Enter
+    await executeMultipleShortcuts({
+      driver,
+      keyDown: 'COMMAND',
+      key: 'ENTER',
+    });
+
+    await executePerformShortcut({ driver, key: 'ENTER' });
+
+    await checkExtensionURL(driver, 'send');
+  });
+});

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -13,6 +13,7 @@ import {
   importWalletFlow,
   initDriverWithOptions,
   typeOnTextInput,
+  waitUntilElementByTestIdIsPresent,
 } from '../helpers';
 import { TEST_VARIABLES } from '../walletVariables';
 
@@ -79,6 +80,11 @@ describe('Command+K behaviours', () => {
       id: 'command-k-input',
       driver,
       text: 'skillet.eth',
+    });
+
+    await waitUntilElementByTestIdIsPresent({
+      id: 'command-row-skillet.eth',
+      driver,
     });
 
     // select wallet and add as contact

--- a/src/design-system/components/TextOverflow/TextOverflow.tsx
+++ b/src/design-system/components/TextOverflow/TextOverflow.tsx
@@ -48,7 +48,6 @@ export function TextOverflow({
           whiteSpace: 'nowrap',
           textShadow,
         })}
-        testId={testId}
       >
         <Inset vertical="8px">
           <Box
@@ -58,6 +57,7 @@ export function TextOverflow({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
             }}
+            testId={testId}
           >
             {children}
           </Box>

--- a/src/design-system/components/TextOverflow/TextOverflow.tsx
+++ b/src/design-system/components/TextOverflow/TextOverflow.tsx
@@ -48,6 +48,7 @@ export function TextOverflow({
           whiteSpace: 'nowrap',
           textShadow,
         })}
+        testId={testId}
       >
         <Inset vertical="8px">
           <Box
@@ -57,7 +58,6 @@ export function TextOverflow({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
             }}
-            testId={testId}
           >
             {children}
           </Box>

--- a/src/entries/popup/components/CommandK/CommandRows.tsx
+++ b/src/entries/popup/components/CommandK/CommandRows.tsx
@@ -112,7 +112,12 @@ export const CommandRow = ({
             >
               <Inline alignVertical="center" space="8px" wrap={false}>
                 <Inline alignVertical="bottom" space="8px" wrap={false}>
-                  <TextOverflow color="label" size="14pt" weight="semibold">
+                  <TextOverflow
+                    color="label"
+                    size="14pt"
+                    weight="semibold"
+                    testId={`command-row-${name || command.name}`}
+                  >
                     {name || command.name}
                   </TextOverflow>
                   {description && (

--- a/src/entries/popup/components/CommandK/CommandRows.tsx
+++ b/src/entries/popup/components/CommandK/CommandRows.tsx
@@ -116,7 +116,7 @@ export const CommandRow = ({
                     color="label"
                     size="14pt"
                     weight="semibold"
-                    testId={`command-row-${name || command.name}`}
+                    testId={`command-name-${name || command.name}`}
                   >
                     {name || command.name}
                   </TextOverflow>

--- a/src/entries/popup/components/CommandK/CommandRows.tsx
+++ b/src/entries/popup/components/CommandK/CommandRows.tsx
@@ -210,7 +210,7 @@ export const ShortcutRow = ({
   selected,
 }: ShortcutRowProps) => {
   const isAddAsWatchedWalletRow =
-    command.address && command.id === 'addAsWatchedWallet';
+    command.address && command.id === 'watchUnownedWallet';
   const isSwitchToWalletRow =
     command.address && command.id === 'switchToWallet';
   const isContactWalletRow = command.address && command.id === 'contactWallet';

--- a/src/entries/popup/components/CommandK/references.ts
+++ b/src/entries/popup/components/CommandK/references.ts
@@ -6,7 +6,6 @@ export const actionLabels = {
   openInNewTab: () => i18n.t('command_k.action_labels.open_in_new_tab'),
   switchToWallet: () => i18n.t('command_k.action_labels.switch_to_wallet'),
   sendToWallet: () => i18n.t('command_k.action_labels.send_to_wallet'),
-  addContact: () => i18n.t('command_k.action_labels.add_contact'),
   view: () => i18n.t('command_k.action_labels.view'),
 };
 

--- a/src/entries/popup/components/CommandK/references.ts
+++ b/src/entries/popup/components/CommandK/references.ts
@@ -5,7 +5,7 @@ export const actionLabels = {
   open: () => i18n.t('command_k.action_labels.open'),
   openInNewTab: () => i18n.t('command_k.action_labels.open_in_new_tab'),
   switchToWallet: () => i18n.t('command_k.action_labels.switch_to_wallet'),
-  sendToWallet: () => i18n.t('command_k.action_labels.send_to_wallet'),
+  sendToContact: () => i18n.t('command_k.action_labels.send_to_contact'),
   view: () => i18n.t('command_k.action_labels.view'),
 };
 

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -790,14 +790,25 @@ export const useCommands = (
   );
 
   const handleAddContact = React.useCallback(
-    (address: Address, walletName?: string, ensName?: string | null) => {
-      saveContact({ contact: { address, name: walletName || ensName || '' } });
+    (address: Address, ensName?: string | null) => {
+      saveContact({ contact: { address, name: ensName || '' } });
       triggerToast({
         title: i18n.t(`command_k.contact_toast.title_added`),
-        description: truncateAddress(address),
+        description: ensName || truncateAddress(address),
       });
     },
     [saveContact],
+  );
+
+  const handleRemoveContact = React.useCallback(
+    (address: Address, ensName?: string | null) => {
+      deleteContact({ address });
+      triggerToast({
+        title: i18n.t(`command_k.contact_toast.title_removed`),
+        description: ensName || truncateAddress(address),
+      });
+    },
+    [deleteContact],
   );
 
   const commandOverrides: CommandOverride = React.useMemo(
@@ -984,10 +995,9 @@ export const useCommands = (
       },
       addUnownedWalletContact: {
         action: () =>
-          isWalletCommand(previousPageState.selectedCommand) &&
+          isENSOrAddressCommand(previousPageState.selectedCommand) &&
           handleAddContact(
             previousPageState.selectedCommand.address,
-            previousPageState.selectedCommand.walletName,
             previousPageState.selectedCommand.ensName,
           ),
         hidden:
@@ -996,8 +1006,11 @@ export const useCommands = (
       },
       removeUnownedWalletContact: {
         action: () =>
-          isContactCommand(previousPageState.selectedCommand) &&
-          deleteContact({ address: previousPageState.selectedCommand.address }),
+          isENSOrAddressCommand(previousPageState.selectedCommand) &&
+          handleRemoveContact(
+            previousPageState.selectedCommand.address,
+            previousPageState.selectedCommand.ensName,
+          ),
         hidden:
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           !isContactAdded(previousPageState.selectedCommand.address),
@@ -1079,7 +1092,10 @@ export const useCommands = (
       removeContact: {
         action: () =>
           isContactCommand(previousPageState.selectedCommand) &&
-          deleteContact({ address: previousPageState.selectedCommand.address }),
+          handleRemoveContact(
+            previousPageState.selectedCommand.address,
+            previousPageState.selectedCommand.ensName,
+          ),
         hidden:
           isContactCommand(previousPageState.selectedCommand) &&
           currentAddress === previousPageState.selectedCommand.address,
@@ -1131,9 +1147,9 @@ export const useCommands = (
       openENSApp,
       handleSelectAddress,
       handleAddContact,
+      handleRemoveContact,
       handleSendToWallet,
       currentAddress,
-      deleteContact,
     ],
   );
 

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -803,6 +803,9 @@ export const useCommands = (
         searchTags: isWatchingWallet ? getSearchTags('my_tokens_watched') : [],
         selectedWallet: ensName || truncateAddress(address),
       },
+      myContacts: {
+        hidden: contacts && Object.keys(contacts).length === 0,
+      },
       myNFTs: {
         name: isWatchingWallet
           ? getCommandName('my_nfts_watched')
@@ -1099,6 +1102,7 @@ export const useCommands = (
       isContactAdded,
       handleCopy,
       sortedAccounts,
+      contacts,
       navigate,
       setFlashbotsEnabled,
       isFirefox,

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -1029,9 +1029,8 @@ export const useCommands = (
             previousPageState.selectedCommand.ensName,
           ),
         hidden:
-          isWatchingWallet ||
-          (isWalletCommand(previousPageState.selectedCommand) &&
-            isContactAdded(previousPageState.selectedCommand.address)),
+          isWalletCommand(previousPageState.selectedCommand) &&
+          isContactAdded(previousPageState.selectedCommand.address),
       },
       viewOnENS: {
         action: () =>

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -1065,15 +1065,15 @@ export const useCommands = (
           isContactCommand(previousPageState.selectedCommand) &&
           handleCopy(previousPageState.selectedCommand.address),
       },
-      viewContactProfile: {
-        action: () =>
-          isContactCommand(previousPageState.selectedCommand) &&
-          openProfile(previousPageState.selectedCommand),
-      },
       viewContactOnEtherscan: {
         action: () =>
           isContactCommand(previousPageState.selectedCommand) &&
           viewWalletOnEtherscan(previousPageState.selectedCommand.address),
+      },
+      viewContactProfile: {
+        action: () =>
+          isContactCommand(previousPageState.selectedCommand) &&
+          openProfile(previousPageState.selectedCommand),
       },
     }),
     [

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -510,6 +510,7 @@ export const getStaticCommandInfo = (): CommandInfo => {
       type: SearchItemType.Shortcut,
     },
     copyContactAddress: {
+      hideFromMainSearch: true,
       name: getCommandName('copy_address'),
       page: PAGES.CONTACT_DETAIL,
       shortcut: shortcuts.home.COPY_ADDRESS,

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -403,7 +403,7 @@ export const getStaticCommandInfo = (): CommandInfo => {
       symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
-    viewUnownedWalletNFTs: {
+    viewUnownedWalletProfile: {
       actionLabel: actionLabels.openInNewTab,
       hideFromMainSearch: true,
       name: getCommandName('view_profile'),
@@ -977,7 +977,7 @@ export const useCommands = (
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           !previousPageState.selectedCommand?.ensName,
       },
-      viewUnownedWalletNFTs: {
+      viewUnownedWalletProfile: {
         action: () =>
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           openProfile(previousPageState.selectedCommand),

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -517,15 +517,6 @@ export const getStaticCommandInfo = (): CommandInfo => {
       symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
-    viewContactProfile: {
-      actionLabel: actionLabels.openInNewTab,
-      hideFromMainSearch: true,
-      name: getCommandName('view_profile'),
-      page: PAGES.CONTACT_DETAIL,
-      symbol: 'sparkle',
-      symbolSize: 15,
-      type: SearchItemType.Shortcut,
-    },
     viewContactOnEtherscan: {
       actionLabel: actionLabels.openInNewTab,
       hideFromMainSearch: true,
@@ -533,6 +524,15 @@ export const getStaticCommandInfo = (): CommandInfo => {
       page: PAGES.CONTACT_DETAIL,
       symbol: 'magnifyingglass',
       symbolSize: 14.5,
+      type: SearchItemType.Shortcut,
+    },
+    viewContactProfile: {
+      actionLabel: actionLabels.openInNewTab,
+      hideFromMainSearch: true,
+      name: getCommandName('view_profile'),
+      page: PAGES.CONTACT_DETAIL,
+      symbol: 'sparkle',
+      symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
   };

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -1058,9 +1058,8 @@ export const useCommands = (
           isContactCommand(previousPageState.selectedCommand) &&
           deleteContact({ address: previousPageState.selectedCommand.address }),
         hidden:
-          isWatchingWallet ||
-          (isContactCommand(previousPageState.selectedCommand) &&
-            currentAddress === previousPageState.selectedCommand.address),
+          isContactCommand(previousPageState.selectedCommand) &&
+          currentAddress === previousPageState.selectedCommand.address,
       },
       copyContactAddress: {
         action: () =>

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -544,11 +544,11 @@ const compileCommandList = (
   isWatchedWallet: boolean,
   overrides: CommandOverride,
   staticInfo: CommandInfo,
-  tokens: TokenSearchItem[],
-  nfts: NFTSearchItem[],
-  walletSearchResult: ENSOrAddressSearchItem[],
   wallets: WalletSearchItem[],
   contacts: ContactSearchItem[],
+  walletSearchResult: ENSOrAddressSearchItem[],
+  tokens: TokenSearchItem[],
+  nfts: NFTSearchItem[],
 ): SearchItem[] => {
   const shortcuts = Object.keys(staticInfo)
     .filter((key) => {
@@ -571,11 +571,11 @@ const compileCommandList = (
 
   return [
     ...shortcuts,
-    ...tokens,
-    ...nfts,
-    ...walletSearchResult,
     ...wallets,
     ...contacts,
+    ...walletSearchResult,
+    ...tokens,
+    ...nfts,
   ];
 };
 
@@ -1122,11 +1122,11 @@ export const useCommands = (
         (isWatchingWallet ?? false) && !featureFlags.full_watching_wallets,
         commandOverrides,
         getStaticCommandInfo(),
-        searchableTokens,
-        searchableNFTs,
-        searchableENSOrAddress,
         searchableWallets,
         searchableContacts,
+        searchableENSOrAddress,
+        searchableTokens,
+        searchableNFTs,
       ),
     [
       isFullScreen,

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -279,7 +279,6 @@ export const getStaticCommandInfo = (): CommandInfo => {
     },
     flashbots: {
       actionLabel: actionLabels.activateCommand,
-      hideForWatchedWallets: true,
       shouldRemainOnActiveRoute: true,
       name: getCommandName('enable_flashbots'),
       symbol: 'bolt.shield.fill',

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -403,6 +403,15 @@ export const getStaticCommandInfo = (): CommandInfo => {
       symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
+    viewUnownedWalletOnEtherscan: {
+      actionLabel: actionLabels.openInNewTab,
+      hideFromMainSearch: true,
+      name: getCommandName('view_wallet_on_etherscan'),
+      page: PAGES.UNOWNED_WALLET_DETAIL,
+      symbol: 'magnifyingglass',
+      symbolSize: 14.5,
+      type: SearchItemType.Shortcut,
+    },
     viewUnownedWalletProfile: {
       actionLabel: actionLabels.openInNewTab,
       hideFromMainSearch: true,
@@ -412,15 +421,6 @@ export const getStaticCommandInfo = (): CommandInfo => {
       shouldRemainOnActiveRoute: true,
       symbol: 'sparkle',
       symbolSize: 15,
-      type: SearchItemType.Shortcut,
-    },
-    viewUnownedWalletOnEtherscan: {
-      actionLabel: actionLabels.openInNewTab,
-      hideFromMainSearch: true,
-      name: getCommandName('view_wallet_on_etherscan'),
-      page: PAGES.UNOWNED_WALLET_DETAIL,
-      symbol: 'magnifyingglass',
-      symbolSize: 14.5,
       type: SearchItemType.Shortcut,
     },
     viewUnownedWalletOnENS: {
@@ -977,15 +977,15 @@ export const useCommands = (
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           !previousPageState.selectedCommand?.ensName,
       },
-      viewUnownedWalletProfile: {
-        action: () =>
-          isENSOrAddressCommand(previousPageState.selectedCommand) &&
-          openProfile(previousPageState.selectedCommand),
-      },
       viewUnownedWalletOnEtherscan: {
         action: () =>
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           viewWalletOnEtherscan(previousPageState.selectedCommand.address),
+      },
+      viewUnownedWalletProfile: {
+        action: () =>
+          isENSOrAddressCommand(previousPageState.selectedCommand) &&
+          openProfile(previousPageState.selectedCommand),
       },
       viewUnownedWalletOnENS: {
         action: () =>

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -446,6 +446,7 @@ export const getStaticCommandInfo = (): CommandInfo => {
     sendToWallet: {
       actionLabel: actionLabels.activateCommand,
       hideFromMainSearch: true,
+      hideForWatchedWallets: true,
       name: getCommandName('send_to_wallet'),
       page: PAGES.WALLET_DETAIL,
       symbol: 'paperplane.fill',
@@ -492,6 +493,7 @@ export const getStaticCommandInfo = (): CommandInfo => {
     sendToContact: {
       actionLabel: actionLabels.activateCommand,
       hideFromMainSearch: true,
+      hideForWatchedWallets: true,
       name: getCommandName('send_contact'),
       page: PAGES.CONTACT_DETAIL,
       symbol: 'paperplane.fill',

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -387,12 +387,30 @@ export const getStaticCommandInfo = (): CommandInfo => {
     },
 
     // PAGE: UNOWNED_WALLET_DETAIL
-    addAsWatchedWallet: {
+    watchUnownedWallet: {
       hideFromMainSearch: true,
       name: getCommandName('add_as_watched_wallet'),
       page: PAGES.UNOWNED_WALLET_DETAIL,
       symbol: 'eyes.inverse',
       symbolSize: 16,
+      type: SearchItemType.Shortcut,
+    },
+    addUnownedWalletContact: {
+      actionLabel: actionLabels.activateCommand,
+      hideFromMainSearch: true,
+      name: getCommandName('add_contact'),
+      page: PAGES.UNOWNED_WALLET_DETAIL,
+      symbol: 'plus.app.fill',
+      symbolSize: 14.5,
+      type: SearchItemType.Shortcut,
+    },
+    removeUnownedWalletContact: {
+      actionLabel: actionLabels.activateCommand,
+      hideFromMainSearch: true,
+      name: getCommandName('remove_contact'),
+      page: PAGES.UNOWNED_WALLET_DETAIL,
+      symbol: 'trash.fill',
+      symbolSize: 14.5,
       type: SearchItemType.Shortcut,
     },
     copyUnownedWalletAddress: {
@@ -450,15 +468,6 @@ export const getStaticCommandInfo = (): CommandInfo => {
       name: getCommandName('send_to_wallet'),
       page: PAGES.WALLET_DETAIL,
       symbol: 'paperplane.fill',
-      symbolSize: 14.5,
-      type: SearchItemType.Shortcut,
-    },
-    addContact: {
-      actionLabel: actionLabels.activateCommand,
-      hideFromMainSearch: true,
-      name: getCommandName('add_contact'),
-      page: PAGES.WALLET_DETAIL,
-      symbol: 'plus.app.fill',
       symbolSize: 14.5,
       type: SearchItemType.Shortcut,
     },
@@ -964,7 +973,7 @@ export const useCommands = (
       },
 
       // PAGE: UNOWNED_WALLET_DETAIL
-      addAsWatchedWallet: {
+      watchUnownedWallet: {
         action: () =>
           isENSOrAddressCommand(previousPageState.selectedCommand) &&
           handleWatchWallet(previousPageState.selectedCommand),
@@ -972,6 +981,26 @@ export const useCommands = (
           ? previousPageState.selectedCommand?.address
           : undefined,
         symbol: currentTheme === 'dark' ? 'eyes.inverse' : 'eyes',
+      },
+      addUnownedWalletContact: {
+        action: () =>
+          isWalletCommand(previousPageState.selectedCommand) &&
+          handleAddContact(
+            previousPageState.selectedCommand.address,
+            previousPageState.selectedCommand.walletName,
+            previousPageState.selectedCommand.ensName,
+          ),
+        hidden:
+          isENSOrAddressCommand(previousPageState.selectedCommand) &&
+          isContactAdded(previousPageState.selectedCommand.address),
+      },
+      removeUnownedWalletContact: {
+        action: () =>
+          isContactCommand(previousPageState.selectedCommand) &&
+          deleteContact({ address: previousPageState.selectedCommand.address }),
+        hidden:
+          isENSOrAddressCommand(previousPageState.selectedCommand) &&
+          !isContactAdded(previousPageState.selectedCommand.address),
       },
       copyUnownedWalletAddress: {
         action: () =>
@@ -1026,18 +1055,6 @@ export const useCommands = (
         action: () =>
           isWalletCommand(previousPageState.selectedCommand) &&
           viewWalletOnEtherscan(previousPageState.selectedCommand.address),
-      },
-      addContact: {
-        action: () =>
-          isWalletCommand(previousPageState.selectedCommand) &&
-          handleAddContact(
-            previousPageState.selectedCommand.address,
-            previousPageState.selectedCommand.walletName,
-            previousPageState.selectedCommand.ensName,
-          ),
-        hidden:
-          isWalletCommand(previousPageState.selectedCommand) &&
-          isContactAdded(previousPageState.selectedCommand.address),
       },
       viewOnENS: {
         action: () =>

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -1003,6 +1003,9 @@ export const useCommands = (
         address: isWalletCommand(previousPageState.selectedCommand)
           ? previousPageState.selectedCommand?.address
           : undefined,
+        hidden:
+          isWalletCommand(previousPageState.selectedCommand) &&
+          currentAddress === previousPageState.selectedCommand?.address,
       },
       sendToWallet: {
         action: () =>

--- a/src/entries/popup/components/CommandK/useSearchableContacts.ts
+++ b/src/entries/popup/components/CommandK/useSearchableContacts.ts
@@ -84,7 +84,7 @@ export const useSearchableContacts = ({
           ? () => handleSelectAddress(account.address)
           : undefined,
         actionLabel: !hideAction
-          ? actionLabels.sendToWallet
+          ? actionLabels.sendToContact
           : actionLabels.view,
         toPage: hideAction ? PAGES.CONTACT_DETAIL : undefined,
         actionPage: !hideAction ? PAGES.CONTACT_DETAIL : undefined,

--- a/src/entries/popup/components/CommandK/useSearchableContacts.ts
+++ b/src/entries/popup/components/CommandK/useSearchableContacts.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { Address } from 'wagmi';
 
 import { i18n } from '~/core/languages';
+import { useCurrentAddressStore } from '~/core/state';
 import { useFeatureFlagsStore } from '~/core/state/currentSettings/featureFlags';
 import { KeychainType } from '~/core/types/keychainTypes';
 import { truncateAddress } from '~/core/utils/address';
@@ -35,6 +36,8 @@ export const useSearchableContacts = ({
   const isFullScreen = useIsFullScreen();
 
   const { type, vendor } = useCurrentWalletTypeAndVendor();
+
+  const { currentAddress } = useCurrentAddressStore();
 
   const isTrezor =
     type === KeychainType.HardwareWalletKeychain && vendor === 'Trezor';
@@ -73,21 +76,37 @@ export const useSearchableContacts = ({
   );
 
   const searchableContacts = useMemo(() => {
-    return contacts.map<ContactSearchItem>((account) => ({
-      action: () => handleSelectAddress(account.address),
-      actionLabel: actionLabels.sendToWallet,
-      actionPage: PAGES.CONTACT_DETAIL,
-      address: account.address,
-      ensName: account.ensName,
-      id: `contact-${account.address}`,
-      walletName: account.name,
-      name: account.name || account.ensName || truncateAddress(account.address),
-      page: PAGES.MY_CONTACTS,
-      truncatedName: truncateName(account.name || account.ensName),
-      label: showLabel ? 'contact' : undefined,
-      type: SearchItemType.Contact,
-    }));
-  }, [showLabel, contacts, handleSelectAddress]);
+    return contacts.map<ContactSearchItem>((account) => {
+      const hideAction = isWatchingWallet || currentAddress === account.address;
+
+      return {
+        action: !hideAction
+          ? () => handleSelectAddress(account.address)
+          : undefined,
+        actionLabel: !hideAction
+          ? actionLabels.sendToWallet
+          : actionLabels.view,
+        toPage: hideAction ? PAGES.CONTACT_DETAIL : undefined,
+        actionPage: !hideAction ? PAGES.CONTACT_DETAIL : undefined,
+        address: account.address,
+        ensName: account.ensName,
+        id: `contact-${account.address}`,
+        walletName: account.name,
+        name:
+          account.name || account.ensName || truncateAddress(account.address),
+        page: PAGES.MY_CONTACTS,
+        truncatedName: truncateName(account.name || account.ensName),
+        label: showLabel ? 'contact' : undefined,
+        type: SearchItemType.Contact,
+      };
+    });
+  }, [
+    contacts,
+    isWatchingWallet,
+    currentAddress,
+    showLabel,
+    handleSelectAddress,
+  ]);
 
   return { searchableContacts };
 };

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -480,7 +480,7 @@
         "add_as_watched_wallet": "Watch This Wallet",
         "view_on_ens": "View on ENS",
         "switch_to_wallet": "Switch to This Wallet",
-        "send_to_wallet": "Send to this Wallet",
+        "send_to_wallet": "Send to This Wallet",
         "add_contact": "Add Contacts",
         "remove_contact": "Remove Contact",
         "copy_wallet_address": "Copy Address",

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -560,7 +560,7 @@
         "section_title": "My Wallets"
       },
       "my_contacts": {
-        "search_placeholder": "Select a your contact wallet",
+        "search_placeholder": "Select a contact to send to…",
         "section_title": "My Contacts"
       },
       "token_detail": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -532,8 +532,8 @@
       "title_revealed": "Showing Small Balances"
     },
     "contact_toast": {
-      "title_added": "Added Contact",
-      "title_removed": "Removed Contact"
+      "title_added": "Contact Added",
+      "title_removed": "Contact Removed"
     },
     "no_results": "No results",
     "pages": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -481,7 +481,7 @@
         "view_on_ens": "View on ENS",
         "switch_to_wallet": "Switch to This Wallet",
         "send_to_wallet": "Send to This Wallet",
-        "add_contact": "Add Contacts",
+        "add_contact": "Add Contact",
         "remove_contact": "Remove Contact",
         "copy_wallet_address": "Copy Address",
         "view_wallet_on_etherscan": "View on Etherscan",

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -481,7 +481,7 @@
         "view_on_ens": "View on ENS",
         "switch_to_wallet": "Switch to This Wallet",
         "send_to_wallet": "Send to This Wallet",
-        "add_contact": "Add Contact",
+        "add_contact": "Add as Contact",
         "remove_contact": "Remove Contact",
         "copy_wallet_address": "Copy Address",
         "view_wallet_on_etherscan": "View on Etherscan",

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -433,7 +433,6 @@
       "open_in_new_tab": "Open in New Tab",
       "switch_to_wallet": "Switch to Wallet",
       "send_to_wallet": "Send to Wallet",
-      "add_contact": "Add Contact",
       "view": "View"
     },
     "commands": {
@@ -481,7 +480,8 @@
         "add_as_watched_wallet": "Watch This Wallet",
         "view_on_ens": "View on ENS",
         "switch_to_wallet": "Switch to This Wallet",
-        "add_contact": "Add Contact",
+        "send_to_wallet": "Send to this Wallet",
+        "add_contact": "Add Contacts",
         "remove_contact": "Remove Contact",
         "copy_wallet_address": "Copy Address",
         "view_wallet_on_etherscan": "View on Etherscan",

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -432,7 +432,7 @@
       "open": "Open",
       "open_in_new_tab": "Open in New Tab",
       "switch_to_wallet": "Switch to Wallet",
-      "send_to_wallet": "Send to Wallet",
+      "send_to_contact": "Send to Contact",
       "view": "View"
     },
     "commands": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -532,7 +532,8 @@
       "title_revealed": "Showing Small Balances"
     },
     "contact_toast": {
-      "title_added": "Added to Contacts"
+      "title_added": "Added Contact",
+      "title_removed": "Removed Contact"
     },
     "no_results": "No results",
     "pages": {


### PR DESCRIPTION
Fixes BX-1469, BX-1467, BX-1462, BX-1461, BX-1460, BX-1459, BX-1458
Figma link (if any):

- "Send to this wallet" is added in "My Wallets". You can now send tokens to your owned / imported wallets with Cmd+K.
- Removed "Watch this wallet" for contacts so there is less confusion between "Contacts" and "Watched wallets" are.
- Tweak command activation sub-titles to contacts menus in Cmd+K
- If you are on a watched wallet or if the contact wallet has the same wallet as your current connected wallet then we'll display a "View" shortcut instead of redirecting to send page when selecting a contact in Cmd+K.
- Hide "Add contacts" if you're on a watched wallet