### PR TITLE
changelog: v1.4.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Resolved an issue where pending transactions could visually overlap in Activity #1532
 - Blocking auto-translation attempts in some browsers while interacting with your Secret Recovery Phrase #1544
-- Fixed an issue with `ESC` keyboard dismissals for the Token Details card
+- Fixed an issue with `ESC` keyboard dismissals for the Token Details card #1521
 - Fixed an issue for some dApps like Etherscan that required triggering a connection request upon switching networks #1536
 - Resolved interaction consistency with right-click menus and action menus in NFT Details #1425
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Testing
 
+## [v1.4.97](https://github.com/rainbow-me/browser-extension/releases/tag/v1.4.97)
+
+### Added
+
+- You can now add, remove, and manage Contacts in the Magic Menu with Cmd+K #1526 #1539 #1542 #1543
+- Instant bridging routes are now available in Rainbow for many core tokens and networks via the Relay Protocol #1531
+
+### Changed
+
+- Search result priority ordering improvements in the Magic Menu for commands, tokens, and more #1543
+- Improved translation coverage for the Magic Menu #1537
+
+### Fixed
+
+- Resolved an issue where pending transactions could visually overlap in Activity #1532
+- Blocking auto-translation attempts in some browsers while interacting with your Secret Recovery Phrase #1544
+- Fixed an issue with `ESC` keyboard dismissals for the Token Details card
+- Fixed an issue for some dApps like Etherscan that required triggering a connection request upon switching networks #1536
+- Resolved interaction consistency with right-click menus and action menus in NFT Details #1425
+
+### Internal
+
+- Optimized home screen renders with wrapper component for listeners #1535
+- Optimized Zustand selector use to improve performance #1513
+
 ## [v1.4.84](https://github.com/rainbow-me/browser-extension/releases/tag/v1.4.84)
 
 ### Fixed


### PR DESCRIPTION
## [v1.4.97](https://github.com/rainbow-me/browser-extension/releases/tag/v1.4.97)

### Added

- You can now add, remove, and manage Contacts in the Magic Menu with Cmd+K #1526 #1539 #1542 #1543
- Instant bridging routes are now available in Rainbow for many core tokens and networks via the Relay Protocol #1531

### Changed

- Search result priority ordering improvements in the Magic Menu for commands, tokens, and more #1543
- Improved translation coverage for the Magic Menu #1537

### Fixed

- Resolved an issue where pending transactions could visually overlap in Activity #1532
- Blocking auto-translation attempts in some browsers while interacting with your Secret Recovery Phrase #1544
- Fixed an issue with `ESC` keyboard dismissals for the Token Details card
- Fixed an issue for some dApps like Etherscan that required triggering a connection request upon switching networks #1536
- Resolved interaction consistency with right-click menus and action menus in NFT Details #1425

### Internal

- Optimized home screen renders with wrapper component for listeners #1535
- Optimized Zustand selector use to improve performance #1513