### PR TITLE
fix: testnet gas

### DIFF
--- a/src/core/resources/gas/meteorology.ts
+++ b/src/core/resources/gas/meteorology.ts
@@ -50,7 +50,7 @@ export type MeteorologyResponse = {
       '3': string;
       '4': string;
     };
-    confirmationTimeByPriorityFee: {
+    confirmationTimeByPriorityFee?: {
       '15': string;
       '30': string;
       '45': string;

--- a/src/core/resources/gas/providerGas.ts
+++ b/src/core/resources/gas/providerGas.ts
@@ -9,9 +9,18 @@ import {
 } from '~/core/react-query';
 import { ChainId } from '~/core/types/chains';
 import { weiToGwei } from '~/core/utils/ethereum';
+import { multiply } from '~/core/utils/numbers';
 import { getProvider } from '~/core/wagmi/clientToProvider';
 
-import { MeteorologyLegacyResponse } from './meteorology';
+import { MeteorologyLegacyResponse, MeteorologyResponse } from './meteorology';
+
+export const BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS = {
+  120: 0.75,
+  240: 0.72,
+  4: 0.92,
+  40: 0.79,
+  8: 0.88,
+};
 
 // ///////////////////////////////////////////////
 // Query Types
@@ -35,25 +44,79 @@ async function providerGasQueryFunction({
   queryKey: [{ chainId }],
 }: QueryFunctionArgs<typeof providerGasQueryKey>) {
   const provider = getProvider({ chainId });
-  const gasPrice = await provider.getGasPrice();
-  const gweiGasPrice = weiToGwei(gasPrice.toString());
-
-  const parsedResponse = {
-    data: {
-      legacy: {
-        fastGasPrice: gweiGasPrice,
-        proposeGasPrice: gweiGasPrice,
-        safeGasPrice: gweiGasPrice,
+  try {
+    const feeData = await provider.getFeeData();
+    const parsedResponse = {
+      data: {
+        currentBaseFee: feeData.lastBaseFeePerGas?._hex,
+        baseFeeSuggestion: feeData.maxFeePerGas?._hex,
+        baseFeeTrend: 0,
+        blocksToConfirmationByBaseFee: {
+          '120': multiply(
+            feeData.maxFeePerGas?._hex || '0',
+            BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS[120],
+          ),
+          '240': multiply(
+            feeData.maxFeePerGas?._hex || '0',
+            BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS[240],
+          ),
+          '4': multiply(
+            feeData.maxFeePerGas?._hex || '0',
+            BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS[4],
+          ),
+          '40': multiply(
+            feeData.maxFeePerGas?._hex || '0',
+            BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS[40],
+          ),
+          '8': multiply(
+            feeData.maxFeePerGas?._hex || '0',
+            BASE_FEE_BLOCKS_TO_CONFIRMATION_MULTIPLIERS[8],
+          ),
+        },
+        blocksToConfirmationByPriorityFee: {
+          '1': '1000000000',
+          '2': '1000000000',
+          '3': '1000000000',
+          '4': '1000000000',
+        },
+        maxPriorityFeeSuggestions: {
+          fast: '1000000000',
+          lowest: '1000000000',
+          normal: '1000000000',
+          urgent: '1000000000',
+        },
+        secondsPerNewBlock: 12,
+        meta: {
+          feeType: 'eip1559',
+          blockNumber: 0,
+          provider: 'rpc',
+        },
       },
-      meta: {
-        blockNumber: 0,
-        provider: 'provider',
-      },
-    },
-  };
+    };
 
-  const providerGasData = parsedResponse as MeteorologyLegacyResponse;
-  return providerGasData;
+    const providerGasData = parsedResponse as MeteorologyResponse;
+    return providerGasData;
+  } catch (e) {
+    const gasPrice = await provider.getGasPrice();
+    const gweiGasPrice = weiToGwei(gasPrice.toString());
+
+    const parsedResponse = {
+      data: {
+        legacy: {
+          fastGasPrice: gweiGasPrice,
+          proposeGasPrice: gweiGasPrice,
+          safeGasPrice: gweiGasPrice,
+        },
+        meta: {
+          blockNumber: 0,
+          provider: 'provider',
+        },
+      },
+    };
+
+    const providerGasData = parsedResponse as MeteorologyLegacyResponse;
+    return providerGasData;
+  }
 }
 
 type ProviderGasResult = QueryFunctionResult<typeof providerGasQueryFunction>;

--- a/src/core/utils/gas.ts
+++ b/src/core/utils/gas.ts
@@ -363,12 +363,12 @@ export const getBaseFeeMultiplier = (speed: GasSpeed) => {
   switch (speed) {
     case 'urgent':
     case 'custom':
-      return 1.1;
+      return 1.2;
     case 'fast':
-      return 1.05;
+      return 1.15;
     case 'normal':
     default:
-      return 1;
+      return 1.1;
   }
 };
 
@@ -536,8 +536,6 @@ export const calculateL1FeeOptimism = async ({
 export const meteorologySupportsChain = (chainId: ChainId) =>
   [
     ChainId.bsc,
-    ChainId.sepolia,
-    ChainId.holesky,
     ChainId.mainnet,
     ChainId.polygon,
     ChainId.base,
@@ -550,8 +548,6 @@ export const meteorologySupportsChain = (chainId: ChainId) =>
 export const meteorologySupportsType2ForChain = (chainId: ChainId) =>
   [
     ChainId.mainnet,
-    ChainId.sepolia,
-    ChainId.holesky,
     ChainId.base,
     ChainId.arbitrum,
     ChainId.optimism,

--- a/src/core/utils/gas.ts
+++ b/src/core/utils/gas.ts
@@ -543,6 +543,8 @@ export const meteorologySupportsChain = (chainId: ChainId) =>
     ChainId.optimism,
     ChainId.zora,
     ChainId.avalanche,
+    ChainId.blast,
+    ChainId.degen,
   ].includes(chainId);
 
 export const chainNeedsL1SecurityFee = (chainId: ChainId) =>

--- a/src/core/utils/gas.ts
+++ b/src/core/utils/gas.ts
@@ -545,16 +545,6 @@ export const meteorologySupportsChain = (chainId: ChainId) =>
     ChainId.avalanche,
   ].includes(chainId);
 
-export const meteorologySupportsType2ForChain = (chainId: ChainId) =>
-  [
-    ChainId.mainnet,
-    ChainId.base,
-    ChainId.arbitrum,
-    ChainId.optimism,
-    ChainId.zora,
-    ChainId.avalanche,
-  ].includes(chainId);
-
 export const chainNeedsL1SecurityFee = (chainId: ChainId) =>
   [ChainId.base, ChainId.optimism, ChainId.zora].includes(chainId);
 
@@ -577,7 +567,7 @@ export const parseGasFeeParamsBySpeed = ({
   flashbotsEnabled?: boolean;
   additionalTime?: number;
 }) => {
-  if (meteorologySupportsType2ForChain(chainId)) {
+  if ((data as MeteorologyResponse)?.data?.currentBaseFee) {
     const response = data as MeteorologyResponse;
     const {
       data: {


### PR DESCRIPTION
Fixes BX-1457
Figma link (if any):

## What changed (plus any additional context for devs)

original sepolia issue was happening because we were using mainnet gas prices from meteorology, instead we should get gas fees from provider,
so

- testnets are now getting fees directly from provider since they're not supported by meterology
- testnets and custom networks where we don't have meteorology support will get gas fees from provide (which is the case in prod rn) with the difference that now we're getting eip1559 gas fees from network if supported for better gas fees


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
