### PR TITLE
feat: swap contract address search support

### DIFF
--- a/src/entries/popup/hooks/swap/useSwapAssets.ts
+++ b/src/entries/popup/hooks/swap/useSwapAssets.ts
@@ -87,7 +87,10 @@ export const useSwapAssets = ({ bridge }: { bridge: boolean }) => {
       : userAssets;
   }, [debouncedAssetToSellFilter, userAssets]) as ParsedSearchAsset[];
 
-  const { results: searchAssetsToBuySections } = useSearchCurrencyLists({
+  const {
+    searchStatus: searchAssetsToBuyStatus,
+    results: searchAssetsToBuySections,
+  } = useSearchCurrencyLists({
     inputChainId: assetToSell?.chainId,
     outputChainId,
     assetToSell,
@@ -190,6 +193,7 @@ export const useSwapAssets = ({ bridge }: { bridge: boolean }) => {
     assetToSell: parsedAssetToSell,
     assetToBuy: parsedAssetToBuy,
     outputChainId: bridge ? undefined : outputChainId,
+    assetsToBuySearchStatus: searchAssetsToBuyStatus,
     setSortMethod,
     setAssetToSell,
     setAssetToBuy,

--- a/src/entries/popup/hooks/swap/useSwapAssets.ts
+++ b/src/entries/popup/hooks/swap/useSwapAssets.ts
@@ -88,7 +88,7 @@ export const useSwapAssets = ({ bridge }: { bridge: boolean }) => {
   }, [debouncedAssetToSellFilter, userAssets]) as ParsedSearchAsset[];
 
   const {
-    searchStatus: searchAssetsToBuyStatus,
+    networkSearchStatus: searchAssetsToBuyNetworkStatus,
     results: searchAssetsToBuySections,
   } = useSearchCurrencyLists({
     inputChainId: assetToSell?.chainId,
@@ -193,7 +193,7 @@ export const useSwapAssets = ({ bridge }: { bridge: boolean }) => {
     assetToSell: parsedAssetToSell,
     assetToBuy: parsedAssetToBuy,
     outputChainId: bridge ? undefined : outputChainId,
-    assetsToBuySearchStatus: searchAssetsToBuyStatus,
+    assetsToBuySearchNetworkStatus: searchAssetsToBuyNetworkStatus,
     setSortMethod,
     setAssetToSell,
     setAssetToBuy,

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -47,7 +47,7 @@ export interface AssetToBuySection {
   id: AssetToBuySectionId;
 }
 
-export enum AssetToBuySearchStatus {
+export enum AssetToBuyNetworkSearchStatus {
   all = 'all',
   single = 'single',
 }
@@ -107,9 +107,9 @@ export function useSearchCurrencyLists({
 
   const enableAllNetworkTokenSearch = queryIsAddress && !testnetMode && !bridge;
 
-  const searchStatus = enableAllNetworkTokenSearch
-    ? AssetToBuySearchStatus.all
-    : AssetToBuySearchStatus.single;
+  const networkSearchStatus = enableAllNetworkTokenSearch
+    ? AssetToBuyNetworkSearchStatus.all
+    : AssetToBuyNetworkSearchStatus.single;
 
   // static search data
   const {
@@ -567,6 +567,6 @@ export function useSearchCurrencyLists({
   return {
     loading,
     results,
-    searchStatus,
+    networkSearchStatus,
   };
 }

--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -4,6 +4,8 @@ import { useCallback, useMemo } from 'react';
 
 import { SUPPORTED_CHAINS } from '~/core/references/chains';
 import { useTokenSearch } from '~/core/resources/search';
+import { useTokenSearchAllNetworks } from '~/core/resources/search/tokenSearch';
+import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
 import { ParsedSearchAsset } from '~/core/types/assets';
 import { ChainId } from '~/core/types/chains';
 import {
@@ -43,6 +45,11 @@ export type AssetToBuySectionId =
 export interface AssetToBuySection {
   data: SearchAsset[];
   id: AssetToBuySectionId;
+}
+
+export enum AssetToBuySearchStatus {
+  all = 'all',
+  single = 'single',
 }
 
 const filterBridgeAsset = ({
@@ -95,6 +102,14 @@ export function useSearchCurrencyLists({
     () => (queryIsAddress ? 'CASE_SENSITIVE_EQUAL' : 'CONTAINS'),
     [queryIsAddress],
   );
+
+  const { testnetMode } = useTestnetModeStore();
+
+  const enableAllNetworkTokenSearch = queryIsAddress && !testnetMode && !bridge;
+
+  const searchStatus = enableAllNetworkTokenSearch
+    ? AssetToBuySearchStatus.all
+    : AssetToBuySearchStatus.single;
 
   // static search data
   const {
@@ -179,14 +194,19 @@ export function useSearchCurrencyLists({
 
   // current search
   const { data: targetVerifiedAssets, isLoading: targetVerifiedAssetsLoading } =
-    useTokenSearch({
-      chainId: outputChainId,
-      keys,
-      list: 'verifiedAssets',
-      threshold,
-      query,
-      fromChainId,
-    });
+    useTokenSearch(
+      {
+        chainId: outputChainId,
+        keys,
+        list: 'verifiedAssets',
+        threshold,
+        query,
+        fromChainId,
+      },
+      {
+        enabled: !enableAllNetworkTokenSearch,
+      },
+    );
   const {
     data: targetUnverifiedAssets,
     isLoading: targetUnverifiedAssetsLoading,
@@ -200,7 +220,41 @@ export function useSearchCurrencyLists({
       fromChainId,
     },
     {
-      enabled: enableUnverifiedSearch,
+      enabled: enableUnverifiedSearch && !enableAllNetworkTokenSearch,
+    },
+  );
+
+  // All verified assets from all user chains
+  const { data: targetAllNetworksUnverifiedAssets } = useTokenSearchAllNetworks(
+    {
+      keys,
+      list: 'highLiquidityAssets',
+      threshold,
+      query,
+    },
+    {
+      select: (data: SearchAsset[]) => {
+        if (!enableAllNetworkTokenSearch) return [];
+        return data;
+      },
+      enabled: enableAllNetworkTokenSearch,
+    },
+  );
+
+  // All verified assets from all user chains
+  const { data: targetAllNetworksVerifiedAssets } = useTokenSearchAllNetworks(
+    {
+      keys,
+      list: 'verifiedAssets',
+      threshold,
+      query,
+    },
+    {
+      select: (data: SearchAsset[]) => {
+        if (!enableAllNetworkTokenSearch) return [];
+        return data;
+      },
+      enabled: enableAllNetworkTokenSearch,
     },
   );
 
@@ -441,6 +495,26 @@ export function useSearchCurrencyLists({
         ),
         id: 'verified',
       });
+    } else if (enableAllNetworkTokenSearch) {
+      if (targetAllNetworksUnverifiedAssets.length) {
+        sections.push({
+          data: filterAssetsFromFavoritesBridgeAndAssetToSell(
+            targetAllNetworksUnverifiedAssets,
+          ),
+          id: 'unverified',
+        });
+      }
+
+      if (targetAllNetworksVerifiedAssets.length) {
+        sections.push({
+          data: filterAssetsFromFavoritesBridgeAndAssetToSell(
+            targetAllNetworksVerifiedAssets,
+          ),
+          id: 'verified',
+        });
+      }
+
+      return sections;
     } else {
       if (targetVerifiedAssets?.length) {
         sections.push({
@@ -472,23 +546,27 @@ export function useSearchCurrencyLists({
 
     return sections;
   }, [
+    enableAllNetworkTokenSearch,
+    bridge,
     bridgeAsset,
     favoritesList,
     query,
+    bridgeList,
+    targetAllNetworksUnverifiedAssets,
+    targetAllNetworksVerifiedAssets,
     filterAssetsFromBridgeAndAssetToSell,
     filterAssetsFromFavoritesBridgeAndAssetToSell,
     curatedAssets,
     outputChainId,
     targetVerifiedAssets,
     targetUnverifiedAssets,
-    crosschainExactMatches,
-    bridgeList,
-    bridge,
     enableUnverifiedSearch,
+    crosschainExactMatches,
   ]);
 
   return {
     loading,
     results,
+    searchStatus,
   };
 }

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenDropdown/TokenToBuyDropdown.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenDropdown/TokenToBuyDropdown.tsx
@@ -8,7 +8,7 @@ import { Box, Inline, Row, Rows, Stack, Symbol, Text } from '~/design-system';
 import { ButtonOverflow } from '~/design-system/components/Button/ButtonOverflow';
 import { SwitchNetworkMenu } from '~/entries/popup/components/SwitchMenu/SwitchNetworkMenu';
 import {
-  AssetToBuySearchStatus,
+  AssetToBuyNetworkSearchStatus,
   AssetToBuySection,
 } from '~/entries/popup/hooks/useSearchCurrencyLists';
 import { useTranslationContext } from '~/entries/popup/hooks/useTranslationContext';
@@ -22,7 +22,7 @@ export type TokenToBuyDropdownProps = {
   asset: ParsedSearchAsset | null;
   assets?: AssetToBuySection[];
   outputChainId?: ChainId;
-  searchStatus: AssetToBuySearchStatus;
+  networkSearchStatus: AssetToBuyNetworkSearchStatus;
   onSelectAsset?: (asset: ParsedSearchAsset | null) => void;
   setOutputChainId?: (chainId: ChainId) => void;
   onDropdownChange: (open: boolean) => void;
@@ -32,7 +32,7 @@ export const TokenToBuyDropdown = ({
   asset,
   assets,
   outputChainId,
-  searchStatus,
+  networkSearchStatus,
   onSelectAsset,
   setOutputChainId,
   onDropdownChange,
@@ -53,7 +53,7 @@ export const TokenToBuyDropdown = ({
     <Stack space="20px">
       {setOutputChainId &&
         outputChainId &&
-        searchStatus !== AssetToBuySearchStatus.all && (
+        networkSearchStatus !== AssetToBuyNetworkSearchStatus.all && (
           <Box paddingHorizontal="20px">
             <Inline alignHorizontal="justify">
               <Inline space="4px" alignVertical="center">

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenDropdown/TokenToBuyDropdown.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenDropdown/TokenToBuyDropdown.tsx
@@ -7,7 +7,10 @@ import { ChainId } from '~/core/types/chains';
 import { Box, Inline, Row, Rows, Stack, Symbol, Text } from '~/design-system';
 import { ButtonOverflow } from '~/design-system/components/Button/ButtonOverflow';
 import { SwitchNetworkMenu } from '~/entries/popup/components/SwitchMenu/SwitchNetworkMenu';
-import { AssetToBuySection } from '~/entries/popup/hooks/useSearchCurrencyLists';
+import {
+  AssetToBuySearchStatus,
+  AssetToBuySection,
+} from '~/entries/popup/hooks/useSearchCurrencyLists';
 import { useTranslationContext } from '~/entries/popup/hooks/useTranslationContext';
 
 import { dropdownContainerVariant } from '../../../../components/DropdownInputWrapper/DropdownInputWrapper';
@@ -19,6 +22,7 @@ export type TokenToBuyDropdownProps = {
   asset: ParsedSearchAsset | null;
   assets?: AssetToBuySection[];
   outputChainId?: ChainId;
+  searchStatus: AssetToBuySearchStatus;
   onSelectAsset?: (asset: ParsedSearchAsset | null) => void;
   setOutputChainId?: (chainId: ChainId) => void;
   onDropdownChange: (open: boolean) => void;
@@ -28,6 +32,7 @@ export const TokenToBuyDropdown = ({
   asset,
   assets,
   outputChainId,
+  searchStatus,
   onSelectAsset,
   setOutputChainId,
   onDropdownChange,
@@ -46,44 +51,46 @@ export const TokenToBuyDropdown = ({
 
   return (
     <Stack space="20px">
-      {setOutputChainId && outputChainId && (
-        <Box paddingHorizontal="20px">
-          <Inline alignHorizontal="justify">
-            <Inline space="4px" alignVertical="center">
-              <Symbol
-                symbol="network"
-                color="labelTertiary"
-                weight="semibold"
-                size={14}
+      {setOutputChainId &&
+        outputChainId &&
+        searchStatus !== AssetToBuySearchStatus.all && (
+          <Box paddingHorizontal="20px">
+            <Inline alignHorizontal="justify">
+              <Inline space="4px" alignVertical="center">
+                <Symbol
+                  symbol="network"
+                  color="labelTertiary"
+                  weight="semibold"
+                  size={14}
+                />
+                <Text size="14pt" weight="semibold" color="labelTertiary">
+                  {i18n.t('swap.tokens_input.filter_by_network')}
+                </Text>
+              </Inline>
+              <SwitchNetworkMenu
+                onOpenChange={onDropdownChange}
+                marginRight="20px"
+                accentColor={asset?.colors?.primary || asset?.colors?.fallback}
+                type="dropdown"
+                chainId={outputChainId}
+                onChainChanged={(chainId) => {
+                  setOutputChainId(chainId);
+                }}
+                triggerComponent={
+                  <ButtonOverflow testId="token-to-buy-networks-trigger">
+                    <BottomNetwork
+                      selectedChainId={outputChainId}
+                      displaySymbol
+                      symbolSize={12}
+                      symbol="chevron.down"
+                    />
+                  </ButtonOverflow>
+                }
+                onlySwapSupportedNetworks
               />
-              <Text size="14pt" weight="semibold" color="labelTertiary">
-                {i18n.t('swap.tokens_input.filter_by_network')}
-              </Text>
             </Inline>
-            <SwitchNetworkMenu
-              onOpenChange={onDropdownChange}
-              marginRight="20px"
-              accentColor={asset?.colors?.primary || asset?.colors?.fallback}
-              type="dropdown"
-              chainId={outputChainId}
-              onChainChanged={(chainId) => {
-                setOutputChainId(chainId);
-              }}
-              triggerComponent={
-                <ButtonOverflow testId="token-to-buy-networks-trigger">
-                  <BottomNetwork
-                    selectedChainId={outputChainId}
-                    displaySymbol
-                    symbolSize={12}
-                    symbol="chevron.down"
-                  />
-                </ButtonOverflow>
-              }
-              onlySwapSupportedNetworks
-            />
-          </Inline>
-        </Box>
-      )}
+          </Box>
+        )}
 
       <Box
         as={motion.div}

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
@@ -7,7 +7,7 @@ import { IndependentField } from '~/entries/popup/hooks/swap/useSwapInputs';
 import useKeyboardAnalytics from '~/entries/popup/hooks/useKeyboardAnalytics';
 import { useKeyboardShortcut } from '~/entries/popup/hooks/useKeyboardShortcut';
 import {
-  AssetToBuySearchStatus,
+  AssetToBuyNetworkSearchStatus,
   AssetToBuySection,
 } from '~/entries/popup/hooks/useSearchCurrencyLists';
 import { mergeRefs } from '~/entries/popup/utils/mergeRefs';
@@ -33,7 +33,7 @@ interface TokenToBuyProps {
   openDropdownOnMount?: boolean;
   assetToBuyNativeDisplay: { amount: string; display: string } | null;
   assetToSellNativeDisplay: { amount: string; display: string } | null;
-  assetsToBuySearchStatus: AssetToBuySearchStatus;
+  assetsToBuyNetworkSearchStatus: AssetToBuyNetworkSearchStatus;
   onDropdownOpen: (open: boolean) => void;
   setOutputChainId?: (chainId: ChainId) => void;
   selectAsset: (asset: ParsedSearchAsset | null) => void;
@@ -60,7 +60,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
     inputRef,
     inputDisabled,
     openDropdownOnMount,
-    assetsToBuySearchStatus,
+    assetsToBuyNetworkSearchStatus,
     onDropdownOpen,
     selectAsset,
     setAssetFilter,
@@ -121,7 +121,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
           onDropdownChange={onDropdownChange}
           asset={assetToBuy}
           assets={assets}
-          searchStatus={assetsToBuySearchStatus}
+          networkSearchStatus={assetsToBuyNetworkSearchStatus}
           onSelectAsset={onSelectAssetRef?.current}
           outputChainId={outputChainId}
           setOutputChainId={setOutputChainId}

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
@@ -6,7 +6,10 @@ import { ChainId } from '~/core/types/chains';
 import { IndependentField } from '~/entries/popup/hooks/swap/useSwapInputs';
 import useKeyboardAnalytics from '~/entries/popup/hooks/useKeyboardAnalytics';
 import { useKeyboardShortcut } from '~/entries/popup/hooks/useKeyboardShortcut';
-import { AssetToBuySection } from '~/entries/popup/hooks/useSearchCurrencyLists';
+import {
+  AssetToBuySearchStatus,
+  AssetToBuySection,
+} from '~/entries/popup/hooks/useSearchCurrencyLists';
 import { mergeRefs } from '~/entries/popup/utils/mergeRefs';
 
 import { TokenToBuyDropdown } from './TokenDropdown/TokenToBuyDropdown';
@@ -30,6 +33,7 @@ interface TokenToBuyProps {
   openDropdownOnMount?: boolean;
   assetToBuyNativeDisplay: { amount: string; display: string } | null;
   assetToSellNativeDisplay: { amount: string; display: string } | null;
+  assetsToBuySearchStatus: AssetToBuySearchStatus;
   onDropdownOpen: (open: boolean) => void;
   setOutputChainId?: (chainId: ChainId) => void;
   selectAsset: (asset: ParsedSearchAsset | null) => void;
@@ -56,6 +60,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
     inputRef,
     inputDisabled,
     openDropdownOnMount,
+    assetsToBuySearchStatus,
     onDropdownOpen,
     selectAsset,
     setAssetFilter,
@@ -116,6 +121,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
           onDropdownChange={onDropdownChange}
           asset={assetToBuy}
           assets={assets}
+          searchStatus={assetsToBuySearchStatus}
           onSelectAsset={onSelectAssetRef?.current}
           outputChainId={outputChainId}
           setOutputChainId={setOutputChainId}

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -272,7 +272,7 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
     sortMethod,
     assetToBuy,
     assetToSell,
-    assetsToBuySearchStatus,
+    assetsToBuySearchNetworkStatus,
     outputChainId,
     setSortMethod,
     setOutputChainId,
@@ -725,7 +725,9 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                   ref={tokenToBuyInputRef}
                   dropdownHeight={toBuyInputHeight}
                   assetToBuy={assetToBuy}
-                  assetsToBuySearchStatus={assetsToBuySearchStatus}
+                  assetsToBuyNetworkSearchStatus={
+                    assetsToBuySearchNetworkStatus
+                  }
                   assetToSell={assetToSell}
                   assets={unhiddenAssetsToBuy}
                   selectAsset={setAssetToBuy}

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -272,6 +272,7 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
     sortMethod,
     assetToBuy,
     assetToSell,
+    assetsToBuySearchStatus,
     outputChainId,
     setSortMethod,
     setOutputChainId,
@@ -724,6 +725,7 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                   ref={tokenToBuyInputRef}
                   dropdownHeight={toBuyInputHeight}
                   assetToBuy={assetToBuy}
+                  assetsToBuySearchStatus={assetsToBuySearchStatus}
                   assetToSell={assetToSell}
                   assets={unhiddenAssetsToBuy}
                   selectAsset={setAssetToBuy}


### PR DESCRIPTION
Fixes BX-1330

## What changed (plus any additional context for devs)

- Swap page now supports contract address search. It'll also search on all supported networks instead of single choosen network.

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://github.com/rainbow-me/browser-extension/assets/53529533/2f61def6-9a65-4fda-9832-cfee73c18ab4

## What to test
- Go to swap page
- Paste in any token contract address and make sure it searches the token on all supported networks. For example `0x50c5725949a6f0c72e6c4a641f24049a917db0cb` should search for DAI on base and LYRA on optimism.
![image](https://github.com/rainbow-me/browser-extension/assets/53529533/0f727fbe-b99f-42bb-9738-389e61c0dcfe)
- Make sure you don't see "Filter by network" dropdown option because we search for all networks.
- Make sure the swap flow works the same as usual.
