### PR TITLE
fix: `NaN` shown in tokens tab bar

### DIFF
--- a/src/entries/popup/hooks/useUserAssetsBalance.ts
+++ b/src/entries/popup/hooks/useUserAssetsBalance.ts
@@ -46,7 +46,7 @@ export function useUserAssetsBalance() {
   );
 
   const {
-    data: totalAssetsBalanceCustomNetworks = [],
+    data: totalAssetsBalanceCustomNetworks,
     isLoading: customNetworksIsLoading,
   } = useCustomNetworkAssets(
     {
@@ -65,8 +65,8 @@ export function useUserAssetsBalance() {
   );
 
   const totalAssetsBalance = add(
-    totalAssetsBalanceKnownNetworks as string,
-    totalAssetsBalanceCustomNetworks as string,
+    totalAssetsBalanceKnownNetworks ?? '0',
+    totalAssetsBalanceCustomNetworks ?? '0',
   );
 
   return {

--- a/src/entries/popup/hooks/useUserAssetsBalance.ts
+++ b/src/entries/popup/hooks/useUserAssetsBalance.ts
@@ -64,14 +64,16 @@ export function useUserAssetsBalance() {
     },
   );
 
-  const totalAssetsBalance = add(
-    totalAssetsBalanceKnownNetworks ?? '0',
-    totalAssetsBalanceCustomNetworks ?? '0',
-  );
+  const totalAssetsBalance =
+    totalAssetsBalanceKnownNetworks && totalAssetsBalanceCustomNetworks
+      ? add(totalAssetsBalanceKnownNetworks, totalAssetsBalanceCustomNetworks)
+      : undefined;
 
   return {
     amount: totalAssetsBalance,
-    display: convertAmountToNativeDisplay(totalAssetsBalance || 0, currency),
+    display: totalAssetsBalance
+      ? convertAmountToNativeDisplay(totalAssetsBalance || 0, currency)
+      : undefined,
     isLoading: knownNetworksIsLoading || customNetworksIsLoading,
   };
 }

--- a/src/entries/popup/hooks/useUserAssetsBalance.ts
+++ b/src/entries/popup/hooks/useUserAssetsBalance.ts
@@ -72,7 +72,7 @@ export function useUserAssetsBalance() {
   return {
     amount: totalAssetsBalance,
     display: totalAssetsBalance
-      ? convertAmountToNativeDisplay(totalAssetsBalance || 0, currency)
+      ? convertAmountToNativeDisplay(totalAssetsBalance, currency)
       : undefined,
     isLoading: knownNetworksIsLoading || customNetworksIsLoading,
   };


### PR DESCRIPTION
Fixes BX-1490

## What changed (plus any additional context for devs)

- Fixed an issue where `NaN` would show up in tab bar from home page

## Screen recordings / screenshots

**Before:**

![before](https://github.com/rainbow-me/browser-extension/assets/53529533/5dccc886-ccdf-4000-a115-9e8be84039db)

**After:**

![after](https://github.com/rainbow-me/browser-extension/assets/53529533/34b71e4b-8e0a-47ba-b4f8-ef9445c6363d)

