### PR TITLE
fix: promotion banner text overflow (i18n)

### DIFF
--- a/src/entries/popup/components/QuickPromo/QuickPromo.tsx
+++ b/src/entries/popup/components/QuickPromo/QuickPromo.tsx
@@ -6,9 +6,8 @@ import {
   ButtonSymbol,
   Column,
   Columns,
-  Inline,
   Symbol,
-  Text,
+  textStyles,
 } from '~/design-system';
 import { SymbolProps } from '~/design-system/components/Symbol/Symbol';
 
@@ -45,24 +44,41 @@ export const QuickPromo = ({
         paddingVertical="10px"
         borderRadius="round"
         boxShadow="12px"
-        style={{ height: 36 }}
+        paddingTop="10px"
+        paddingBottom="10px"
       >
         <Box width="full">
           <Columns alignHorizontal="justify" alignVertical="center" space="4px">
-            <Inline space="4px" alignVertical="center">
+            <Column width="content">
               <Symbol
                 size={12}
                 weight="bold"
                 color={symbolColor || 'blue'}
                 symbol={symbol}
               />
-              <Text color="label" size="12pt" weight="bold">
+            </Column>
+
+            <Box>
+              <Box
+                as="span"
+                className={textStyles({
+                  fontWeight: 'bold',
+                  color: 'label',
+                })}
+              >
                 {textBold}
-              </Text>
-              <Text color="labelSecondary" size="12pt" weight="semibold">
+              </Box>
+              &nbsp;
+              <Box
+                as="span"
+                className={textStyles({
+                  fontWeight: 'semibold',
+                  color: 'labelSecondary',
+                })}
+              >
                 {text}
-              </Text>
-            </Inline>
+              </Box>
+            </Box>
             <Column width="content">
               <Box marginVertical="-4px">
                 <ButtonSymbol


### PR DESCRIPTION
Fixes BX-1456
Figma link (if any):

## What changed (plus any additional context for devs)

- Some languages like Russian had text overflow issues on promotion banners. The pages that were impacted were home, switch wallet and networks page.

## Screen recordings / screenshots

**Before:**

![after](https://github.com/rainbow-me/browser-extension/assets/53529533/bba5e67f-a168-4374-a45d-b7cd38190dab)

**After:**

![before](https://github.com/rainbow-me/browser-extension/assets/53529533/c1528061-ce99-4aba-a988-d1c327eab198)

## What to test

- Make sure the banner doesn't cause text overflow issues on different languages
