### PR TITLE
fix: parse tx to address in activity

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1156,8 +1156,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -173,6 +173,19 @@ const getAssetFromChanges = (
   return changes[0]?.asset;
 };
 
+const getAddressToFromChanges = (
+  changes: {
+    direction: TransactionDirection;
+    asset: ParsedUserAsset;
+    address_to: Address;
+  }[],
+  type: TransactionType,
+) => {
+  if (type === 'sale')
+    return changes?.find((c) => c?.direction === 'out')?.address_to;
+  return changes[0]?.address_to;
+};
+
 const getDescription = (
   asset: ParsedAsset | undefined,
   type: TransactionType,
@@ -253,6 +266,10 @@ export function parseTransaction({
     ? parseAsset({ asset: meta.asset, currency })
     : getAssetFromChanges(changes, type);
 
+  const addressTo = asset
+    ? getAddressToFromChanges(changes, type)
+    : tx.address_to;
+
   const direction = tx.direction || getDirection(type);
 
   const description = getDescription(asset, type, meta);
@@ -285,7 +302,7 @@ export function parseTransaction({
 
   return {
     from: tx.address_from,
-    to: tx.address_to,
+    to: addressTo,
     title: i18n.t(`transactions.${type}.${status}`),
     description,
     hash,


### PR DESCRIPTION
Fixes BX-1483
Figma link (if any):

## What changed (plus any additional context for devs)

we're now showing the correct address

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

check a send tx and see if address is the actual recipient and not the contract address, for tokens and nfts

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
