### PR TITLE
fix: bridge quote not working for some tokens

### DIFF
--- a/src/entries/popup/hooks/useSearchCurrencyLists.ts
+++ b/src/entries/popup/hooks/useSearchCurrencyLists.ts
@@ -15,7 +15,7 @@ import {
   TokenSearchThreshold,
 } from '~/core/types/search';
 import { isSameAsset } from '~/core/utils/assets';
-import { getChain } from '~/core/utils/chains';
+import { getChain, isNativeAsset } from '~/core/utils/chains';
 import { addHexPrefix } from '~/core/utils/hex';
 import { isLowerCaseMatch } from '~/core/utils/strings';
 
@@ -424,6 +424,7 @@ export function useSearchCurrencyLists({
               return;
             return {
               ...assetToSell,
+              isNativeAsset: isNativeAsset(address, chainId),
               chainId,
               chainName: chainName,
               uniqueId: `${address}-${chainId}`,


### PR DESCRIPTION
Fixes BX-1495
Figma link (if any):

## What changed (plus any additional context for devs)

We don't check if the token is native or non native from destination chain. For example when bridging Degen on degen chain to Degen on base chain the quote will fail. It'll search for `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` instead of the Degen token address on base.

## Screen recordings / screenshots

Here is a bug where user can't bridge Degen on degen chain to Degen on base chain

https://github.com/rainbow-me/browser-extension/assets/53529533/96f98e18-7e57-4cc7-b89d-01ccced77831


## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- Make sure you can bridge Degen on degen chain to Degen on base chain