### PR TITLE
fix: home shortcuts not unregistered in token details

### DIFF
--- a/src/entries/popup/hooks/useHomeShortcuts.ts
+++ b/src/entries/popup/hooks/useHomeShortcuts.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useEnsName } from 'wagmi';
 
 import { i18n } from '~/core/languages';
@@ -56,10 +57,16 @@ export function useHomeShortcuts() {
   const { testnetMode, setTestnetMode } = useTestnetModeStore();
   const { developerToolsEnabled } = useDeveloperToolsEnabledStore();
   const { selectedNft } = useSelectedNftStore();
+  const location = useLocation();
 
   const allowSend = useMemo(
     () => !isWatchingWallet || featureFlags.full_watching_wallets,
     [featureFlags.full_watching_wallets, isWatchingWallet],
+  );
+
+  const isTokenDetailsPage = useMemo(
+    () => location.pathname.startsWith('/home/token-details'),
+    [location],
   );
 
   const alertWatchingWallet = useCallback(() => {
@@ -118,7 +125,7 @@ export function useHomeShortcuts() {
           navigate(ROUTES.BUY);
           break;
         case shortcuts.home.COPY_ADDRESS.key:
-          if (!selectedNft && !selectedToken) {
+          if (!selectedNft && !selectedToken && !isTokenDetailsPage) {
             trackShortcut({
               key: shortcuts.home.COPY_ADDRESS.display,
               type: 'home.copyAddress',
@@ -159,7 +166,7 @@ export function useHomeShortcuts() {
           navigateToSwaps();
           break;
         case shortcuts.home.GO_TO_PROFILE.key:
-          if (!selectedToken) {
+          if (!selectedToken && !isTokenDetailsPage) {
             trackShortcut({
               key: shortcuts.home.GO_TO_PROFILE.display,
               type: 'home.goToProfile',
@@ -229,6 +236,7 @@ export function useHomeShortcuts() {
       }
     },
     [
+      isTokenDetailsPage,
       trackShortcut,
       navigate,
       selectedNft,

--- a/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
@@ -304,18 +304,9 @@ function MoreOptions({
 
   const { pinned: pinnedStore, togglePinAsset } = usePinnedAssetStore();
 
-  const { selectedToken, setSelectedToken } = useSelectedTokenStore();
+  const { setSelectedToken } = useSelectedTokenStore();
 
   const { isWatchingWallet } = useWallets();
-
-  const resetSelectedToken = useCallback(() => {
-    if (selectedToken) setSelectedToken();
-  }, [setSelectedToken, selectedToken]);
-
-  useEffect(() => {
-    // When component unmounts reset the selectedToken
-    return resetSelectedToken;
-  }, [resetSelectedToken]);
 
   const isHidden = useCallback(
     (asset: ParsedUserAsset | SearchAsset) => {
@@ -349,6 +340,7 @@ function MoreOptions({
   }, [token, hidden, pinned, togglePinAsset, toggleHideAsset, address]);
 
   const togglePinToken = useCallback(() => {
+    if (hidden) return;
     togglePinAsset(address, token.uniqueId);
     if (pinned) {
       triggerToast({
@@ -363,7 +355,7 @@ function MoreOptions({
         name: token.symbol,
       }),
     });
-  }, [token.uniqueId, token.symbol, togglePinAsset, address, pinned]);
+  }, [token.uniqueId, token.symbol, togglePinAsset, hidden, address, pinned]);
 
   const copyTokenAddress = useCallback(() => {
     copyAddress(token.address);


### PR DESCRIPTION
Fixes BX-1486
Figma link (if any):

- Home shortcuts weren't unregistered in token details page. Technically it should be unregistered since token details  page is a whole new route / component, but we used token details page as a child route of the home route which didn't unmount the home shortcut listener.

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

- Make sure when you land in token details page you can copy address by pressing `C` shortcut and same with `P` for pin.