### PR TITLE
fix: cache initial claimable price

### DIFF
--- a/src/entries/popup/pages/home/Points/ClaimSheet.tsx
+++ b/src/entries/popup/pages/home/Points/ClaimSheet.tsx
@@ -59,6 +59,9 @@ export function ClaimSheet() {
   const [bridgeSuccess, setBridgeSuccess] = useState(false);
   const [showSummary, setShowSummary] = useState(false);
 
+  const [initialClaimableAmount, setInitialClaimableAmount] = useState('');
+  const [initialClaimableDisplay, setInitialClaimableDisplay] = useState('');
+
   const { currentAddress: address } = useCurrentAddressStore();
   const { currentCurrency: currency } = useCurrentCurrencyStore();
   const { data, refetch } = usePoints(address);
@@ -144,6 +147,8 @@ export function ClaimSheet() {
     setShowNetworkSelection(false);
     setShowClaimOverview(true);
     setSelectedChainId(chain);
+    setInitialClaimableAmount(claimableBalance.amount);
+    setInitialClaimableDisplay(claimablePriceDisplay.display);
     setTimeout(() => claimRewards(), 500);
   };
 
@@ -174,8 +179,8 @@ export function ClaimSheet() {
         show={showNetworkSelection}
       />
       <ClaimOverview
-        claimableAmount={claimableBalance.amount}
-        claimableDisplay={claimablePriceDisplay.display}
+        claimableAmount={initialClaimableAmount}
+        claimableDisplay={initialClaimableDisplay}
         error={claimError}
         goBack={backToHome}
         preparingClaim={showPreparingClaim}


### PR DESCRIPTION
Fixes BX-1535

## What changed (plus any additional context for devs)
Saving initial claim values for display during confirmation

## Screen recordings / screenshots
https://www.loom.com/share/3356fd33f65c48fbbaa0c293e659b39d

## What to test
Make sure initial claim values appear on the confirmation screen
