### PR TITLE
fix: memoize rainbow text in claim

### DIFF
--- a/src/core/raps/actions/claim.ts
+++ b/src/core/raps/actions/claim.ts
@@ -22,7 +22,7 @@ export async function claim({
       ? CLAIM_MOCK_DATA
       : await metadataPostClient.claimUserRewards({ address });
 
-  // Checking ig we got the tx hash
+  // Checking if we got the tx hash
   const txHash = claimInfo.claimUserRewards?.txHash;
   if (!txHash) {
     // If there's no transaction hash the relayer didn't submit the transaction

--- a/src/entries/popup/pages/home/Points/ClaimOverview.tsx
+++ b/src/entries/popup/pages/home/Points/ClaimOverview.tsx
@@ -47,7 +47,7 @@ export function ClaimOverview({
   const showSuccess = !waitToDisplay && success && preparingClaim && !error;
 
   useEffect(() => {
-    setTimeout(() => setWaitToDisplay(false), 3000);
+    setTimeout(() => setWaitToDisplay(false), 4000);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/entries/popup/pages/home/Points/ClaimOverview.tsx
+++ b/src/entries/popup/pages/home/Points/ClaimOverview.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import { PointsErrorType } from '~/core/graphql/__generated__/metadata';
 import { i18n } from '~/core/languages';
@@ -186,7 +186,7 @@ function ErrorText({ error }: { error?: string }) {
   );
 }
 
-function RainbowSlant() {
+const RainbowSlant = memo(function () {
   return (
     <Box paddingTop="30px">
       <Stack space="12px">
@@ -208,7 +208,8 @@ function RainbowSlant() {
       </Stack>
     </Box>
   );
-}
+});
+RainbowSlant.displayName = 'RainbowSlant';
 
 function ClaimSummary({ amount, price }: { amount: string; price: string }) {
   return (

--- a/src/entries/popup/pages/home/Points/ClaimSheet.tsx
+++ b/src/entries/popup/pages/home/Points/ClaimSheet.tsx
@@ -149,7 +149,7 @@ export function ClaimSheet() {
     setSelectedChainId(chain);
     setInitialClaimableAmount(claimableBalance.amount);
     setInitialClaimableDisplay(claimablePriceDisplay.display);
-    setTimeout(() => claimRewards(), 500);
+    claimRewards();
   };
 
   const baseInfo = {
@@ -170,7 +170,7 @@ export function ClaimSheet() {
 
   useEffect(() => {
     if (showSuccess && !showSummary) {
-      setTimeout(() => setShowSummary(true), 5000);
+      setTimeout(() => setShowSummary(true), 7000);
     }
   }, [showSuccess, showSummary]);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Prevent `<RainbowSlant />` from rerenders in claim overview and tweak console text timing slightly