### PR TITLE
chore: amend `rewards_enabled` default

### DIFF
--- a/src/core/firebase/remoteConfig.ts
+++ b/src/core/firebase/remoteConfig.ts
@@ -53,7 +53,7 @@ const DEFAULT_CONFIG = {
   rpc_proxy_enabled: true,
   points_enabled: true,
   defi_positions_enabled: false,
-  rewards_enabled: false,
+  rewards_enabled: true,
   rewards_bridging_enabled: true,
   // SWAPS
   default_slippage_bips: {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- turned `rewards_enabled` on by default to mitigate issues for users with VPNs that block Firebase APIs

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
