### PR TITLE
fix: wrap unwrap in different chains than mainnet

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1156,8 +1156,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/src/core/raps/unlockAndCrosschainSwap.ts
+++ b/src/core/raps/unlockAndCrosschainSwap.ts
@@ -109,8 +109,7 @@ export const createUnlockAndCrosschainSwapRap = async (
 
   const isNativeAssetUnwrapping =
     isLowerCaseMatch(sellTokenAddress, WRAPPED_ASSET[`${chainId}`]) &&
-    isLowerCaseMatch(buyTokenAddress, ETH_ADDRESS) &&
-    chainId === ChainId.mainnet;
+    isLowerCaseMatch(buyTokenAddress, ETH_ADDRESS);
 
   // Aggregators represent native asset as 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
   const nativeAsset =

--- a/src/core/raps/unlockAndSwap.test.ts
+++ b/src/core/raps/unlockAndSwap.test.ts
@@ -237,6 +237,7 @@ test('[rap/unlockAndSwap] :: create unwrap eth rap', async () => {
     assetToSell: WETH_MAINNET_ASSET,
     assetToBuy: ETH_MAINNET_ASSET,
   });
+  console.log('-- rap.actions', rap.actions);
   expect(rap.actions.length).toBe(1);
 });
 

--- a/src/core/raps/unlockAndSwap.ts
+++ b/src/core/raps/unlockAndSwap.ts
@@ -120,9 +120,11 @@ export const createUnlockAndSwapRap = async (
     buyTokenAddress: Address;
   };
 
-  const isNativeAssetUnwrapping =
-    isUnwrapEth({ buyTokenAddress, chainId, sellTokenAddress }) &&
-    chainId === ChainId.mainnet;
+  const isNativeAssetUnwrapping = isUnwrapEth({
+    buyTokenAddress,
+    chainId,
+    sellTokenAddress,
+  });
 
   // Aggregators represent native asset as 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
   const nativeAsset =

--- a/src/core/utils/swaps.ts
+++ b/src/core/utils/swaps.ts
@@ -6,6 +6,7 @@ import {
 } from '@rainbow-me/swaps';
 
 import { i18n } from '../languages';
+import { chainsNativeAsset } from '../references/chains';
 import { useConnectedToHardhatStore } from '../state/currentSettings/connectedToHardhat';
 import { ChainId } from '../types/chains';
 
@@ -68,7 +69,7 @@ export const isUnwrapEth = ({
     isLowerCaseMatch(
       sellTokenAddress,
       WRAPPED_ASSET[connectedToHardhat ? ChainId.mainnet : chainId],
-    ) && isLowerCaseMatch(buyTokenAddress, ETH_ADDRESS)
+    ) && isLowerCaseMatch(buyTokenAddress, chainsNativeAsset[chainId])
   );
 };
 

--- a/src/core/utils/swaps.ts
+++ b/src/core/utils/swaps.ts
@@ -6,7 +6,6 @@ import {
 } from '@rainbow-me/swaps';
 
 import { i18n } from '../languages';
-import { chainsNativeAsset } from '../references/chains';
 import { useConnectedToHardhatStore } from '../state/currentSettings/connectedToHardhat';
 import { ChainId } from '../types/chains';
 
@@ -69,7 +68,7 @@ export const isUnwrapEth = ({
     isLowerCaseMatch(
       sellTokenAddress,
       WRAPPED_ASSET[connectedToHardhat ? ChainId.mainnet : chainId],
-    ) && isLowerCaseMatch(buyTokenAddress, chainsNativeAsset[chainId])
+    ) && isLowerCaseMatch(buyTokenAddress, ETH_ADDRESS)
   );
 };
 


### PR DESCRIPTION
Fixes BX-1554
Figma link (if any):

## What changed (plus any additional context for devs)

we had checks only making `isNativeAssetUnwrapping` true in mainnet

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
