### PR TITLE
Rounding large numbers

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1099,13 +1099,13 @@
         "eslint>debug": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-environment-visitor": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/parser": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/types": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>globals": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>globals": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame": {
@@ -1114,8 +1114,36 @@
         "process.emitWarning": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true,
-        "lavamoat>@babel/highlight": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": true,
+        "react>loose-envify>js-tokens": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
+        "supports-color": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": {
@@ -1167,6 +1195,93 @@
         "define": true
       }
     },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/parser": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": {
+      "globals": {
+        "console.warn": true,
+        "process.emitWarning": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>escape-string-regexp": true,
+        "supports-color": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert>color-name": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-string-parser": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-string-parser": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration": {
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-string-parser": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
+      }
+    },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/types": {
       "globals": {
         "console.warn": true,
@@ -1187,121 +1302,6 @@
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-string-parser": true,
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
         "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
-      }
-    },
-    "lavamoat>@babel/highlight": {
-      "packages": {
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
-        "lavamoat>@babel/highlight>chalk": true,
-        "react>loose-envify>js-tokens": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles": true,
-        "lavamoat>@babel/highlight>chalk>escape-string-regexp": true,
-        "supports-color": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>ansi-styles": {
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/parser": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": {
-      "globals": {
-        "console.warn": true,
-        "process.emitWarning": true
-      },
-      "packages": {
-        "lavamoat>@babel/highlight": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>escape-string-regexp": true,
-        "supports-color": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert>color-name": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-validator-identifier": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-validator-identifier": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-validator-identifier": true
       }
     },
     "lint-staged>execa>merge-stream": {

--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1099,13 +1099,13 @@
         "eslint>debug": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-environment-visitor": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/parser": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/types": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>globals": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>globals": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame": {
@@ -1114,36 +1114,8 @@
         "process.emitWarning": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": true,
-        "react>loose-envify>js-tokens": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
-        "supports-color": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true,
+        "lavamoat>@babel/highlight": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": {
@@ -1195,93 +1167,6 @@
         "define": true
       }
     },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/parser": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": {
-      "globals": {
-        "console.warn": true,
-        "process.emitWarning": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>escape-string-regexp": true,
-        "supports-color": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert>color-name": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-string-parser": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-validator-identifier": true,
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-string-parser": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-validator-identifier": true,
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration": {
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": true
-      }
-    },
-    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-string-parser": true,
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-validator-identifier": true,
-        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
-      }
-    },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/types": {
       "globals": {
         "console.warn": true,
@@ -1302,6 +1187,121 @@
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-string-parser": true,
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
         "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
+      }
+    },
+    "lavamoat>@babel/highlight": {
+      "packages": {
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "lavamoat>@babel/highlight>chalk": true,
+        "react>loose-envify>js-tokens": true
+      }
+    },
+    "lavamoat>@babel/highlight>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "lavamoat>@babel/highlight>chalk>ansi-styles": true,
+        "lavamoat>@babel/highlight>chalk>escape-string-regexp": true,
+        "supports-color": true
+      }
+    },
+    "lavamoat>@babel/highlight>chalk>ansi-styles": {
+      "packages": {
+        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": {
+      "packages": {
+        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/parser": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame": {
+      "globals": {
+        "console.warn": true,
+        "process.emitWarning": true
+      },
+      "packages": {
+        "lavamoat>@babel/highlight": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>escape-string-regexp": true,
+        "supports-color": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk>ansi-styles>color-convert>color-name": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-validator-identifier": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables>@babel/types>@babel/helper-validator-identifier": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration>@babel/types>@babel/helper-validator-identifier": true
       }
     },
     "lint-staged>execa>merge-stream": {

--- a/src/core/utils/numbers.ts
+++ b/src/core/utils/numbers.ts
@@ -228,13 +228,68 @@ export const lessOrEqualThan = (
   new BigNumber(numberOne).lt(numberTwo) ||
   new BigNumber(numberOne).eq(numberTwo);
 
+// returns decimal within threshold and trims excess 0's
 export const handleSignificantDecimalsWithThreshold = (
   value: BigNumberish,
   decimals: number,
   threshold = '0.0001',
-) => {
-  const result = toFixedDecimals(value, decimals);
-  return lessThan(result, threshold) ? `< ${threshold}` : result;
+): string => {
+  const cleanValue = value.toString().replace(/,/g, '');
+  const bnValue = new BigNumber(cleanValue);
+  const result = bnValue.toFixed(decimals).replace(/\.?0+$/, '');
+  return new BigNumber(result).lt(threshold) ? `< ${threshold}` : result;
+};
+
+// abbreviate numbers and return abbreivated values
+export const abbreviateNumber = (value: BigNumberish): string => {
+  console.log('abbreviateNumber value: ', value);
+
+  // Remove commas from the input value
+  const cleanValue = value.toString().replace(/,/g, '');
+  const bnValue = new BigNumber(cleanValue);
+  console.log('abbreviateNumber bnValue: ', bnValue);
+
+  if (bnValue.isNaN()) return 'NaN';
+  if (bnValue.isZero()) return '0';
+  const absValue = bnValue.abs();
+  console.log('abbreviateNumber absValue: ', absValue);
+
+  const suffixes = [
+    { value: 1e27, symbol: 'No' },
+    { value: 1e24, symbol: 'Oc' },
+    { value: 1e21, symbol: 'Sp' },
+    { value: 1e18, symbol: 'Sx' },
+    { value: 1e15, symbol: 'Qi' },
+    { value: 1e12, symbol: 'Qa' },
+    { value: 1e9, symbol: 'B' },
+    { value: 1e6, symbol: 'M' },
+    { value: 1e3, symbol: 'K' },
+  ];
+
+  for (let i = 0; i < suffixes.length; i++) {
+    if (absValue.gte(suffixes[i].value)) {
+      const newValue = `${bnValue.dividedBy(suffixes[i].value).toFixed(2)}${
+        suffixes[i].symbol
+      }`;
+      console.log('abbreviateNumber newValue: ', newValue);
+      return newValue;
+    }
+  }
+
+  // Handle small numbers and decimals
+  if (absValue.lt(0.000001)) {
+    return `< 0.000001`;
+  } else if (absValue.lt(1)) {
+    // Ensure up to 8 significant digits
+    let significantValue = bnValue.toPrecision(8);
+    // Trim to ensure maximum 6 characters, considering decimal point
+    if (significantValue.length > 8) {
+      significantValue = significantValue.slice(0, 8);
+    }
+    return significantValue.replace(/\.?0+$/, '');
+  }
+
+  return bnValue.toFixed(2);
 };
 
 export const handleSignificantDecimals = (

--- a/src/core/utils/numbers.ts
+++ b/src/core/utils/numbers.ts
@@ -5,6 +5,7 @@ import { isNil } from 'lodash';
 
 import { supportedCurrencies } from '~/core/references';
 
+import { formatCurrency } from './formatNumber';
 import { BigNumberish } from './hex';
 
 type nativeCurrencyType = typeof supportedCurrencies;
@@ -473,3 +474,32 @@ export const convertDecimalFormatToRawAmount = (
 
 export const fromWei = (number: BigNumberish): string =>
   convertRawAmountToDecimalFormat(number, 18);
+
+const cleanNumber = (n: number | string | null | undefined): number => {
+  if (typeof n === 'string') {
+    return parseFloat(n.replace(/,/g, ''));
+  }
+  return n || 0;
+};
+
+export const formatNumber = (n?: number | string | null) => {
+  let value = formatCurrency(cleanNumber(n), {
+    notation: 'compact',
+    maximumSignificantDigits: 4,
+  });
+  while (value.charAt(0) === '$') {
+    value = value.substring(1);
+  }
+  return value;
+};
+
+export const processExchangeRateArray = (arr: string[]): string[] => {
+  return arr.map((item) => {
+    const parts = item.split(' ');
+    if (parts.length === 5) {
+      const formattedAmount = formatNumber(parts[3]);
+      return `${parts[0]} ${parts[1]} ${parts[2]} ${formattedAmount} ${parts[4]}`;
+    }
+    return item;
+  });
+};

--- a/src/core/utils/numbers.ts
+++ b/src/core/utils/numbers.ts
@@ -228,31 +228,24 @@ export const lessOrEqualThan = (
   new BigNumber(numberOne).lt(numberTwo) ||
   new BigNumber(numberOne).eq(numberTwo);
 
-// returns decimal within threshold and trims excess 0's
 export const handleSignificantDecimalsWithThreshold = (
   value: BigNumberish,
   decimals: number,
   threshold = '0.0001',
 ): string => {
-  const cleanValue = value.toString().replace(/,/g, '');
-  const bnValue = new BigNumber(cleanValue);
-  const result = bnValue.toFixed(decimals).replace(/\.?0+$/, '');
-  return new BigNumber(result).lt(threshold) ? `< ${threshold}` : result;
+  const result = toFixedDecimals(value, decimals);
+  return lessThan(result, threshold) ? `< ${threshold}` : result;
 };
 
 // abbreviate numbers and return abbreivated values
 export const abbreviateNumber = (value: BigNumberish): string => {
-  console.log('abbreviateNumber value: ', value);
-
   // Remove commas from the input value
   const cleanValue = value.toString().replace(/,/g, '');
   const bnValue = new BigNumber(cleanValue);
-  console.log('abbreviateNumber bnValue: ', bnValue);
 
   if (bnValue.isNaN()) return 'NaN';
   if (bnValue.isZero()) return '0';
   const absValue = bnValue.abs();
-  console.log('abbreviateNumber absValue: ', absValue);
 
   const suffixes = [
     { value: 1e27, symbol: 'No' },
@@ -280,9 +273,7 @@ export const abbreviateNumber = (value: BigNumberish): string => {
   if (absValue.lt(0.000001)) {
     return `< 0.000001`;
   } else if (absValue.lt(1)) {
-    // Ensure up to 8 significant digits
     let significantValue = bnValue.toPrecision(8);
-    // Trim to ensure maximum 6 characters, considering decimal point
     if (significantValue.length > 8) {
       significantValue = significantValue.slice(0, 8);
     }

--- a/src/core/utils/numbers.ts
+++ b/src/core/utils/numbers.ts
@@ -232,55 +232,9 @@ export const handleSignificantDecimalsWithThreshold = (
   value: BigNumberish,
   decimals: number,
   threshold = '0.0001',
-): string => {
+) => {
   const result = toFixedDecimals(value, decimals);
   return lessThan(result, threshold) ? `< ${threshold}` : result;
-};
-
-// abbreviate numbers and return abbreivated values
-export const abbreviateNumber = (value: BigNumberish): string => {
-  // Remove commas from the input value
-  const cleanValue = value.toString().replace(/,/g, '');
-  const bnValue = new BigNumber(cleanValue);
-
-  if (bnValue.isNaN()) return 'NaN';
-  if (bnValue.isZero()) return '0';
-  const absValue = bnValue.abs();
-
-  const suffixes = [
-    { value: 1e27, symbol: 'No' },
-    { value: 1e24, symbol: 'Oc' },
-    { value: 1e21, symbol: 'Sp' },
-    { value: 1e18, symbol: 'Sx' },
-    { value: 1e15, symbol: 'Qi' },
-    { value: 1e12, symbol: 'Qa' },
-    { value: 1e9, symbol: 'B' },
-    { value: 1e6, symbol: 'M' },
-    { value: 1e3, symbol: 'K' },
-  ];
-
-  for (let i = 0; i < suffixes.length; i++) {
-    if (absValue.gte(suffixes[i].value)) {
-      const newValue = `${bnValue.dividedBy(suffixes[i].value).toFixed(2)}${
-        suffixes[i].symbol
-      }`;
-      console.log('abbreviateNumber newValue: ', newValue);
-      return newValue;
-    }
-  }
-
-  // Handle small numbers and decimals
-  if (absValue.lt(0.000001)) {
-    return `< 0.000001`;
-  } else if (absValue.lt(1)) {
-    let significantValue = bnValue.toPrecision(8);
-    if (significantValue.length > 8) {
-      significantValue = significantValue.slice(0, 8);
-    }
-    return significantValue.replace(/\.?0+$/, '');
-  }
-
-  return bnValue.toFixed(2);
 };
 
 export const handleSignificantDecimals = (

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -53,8 +53,6 @@ export const SwapAssetCard = ({
 
   const amountWithAbbreviation = abbreviateNumber(amount);
 
-  console.log('amountWIthAbbreviation: ', amountWithAbbreviation);
-
   return (
     <AccentColorProvider
       color={asset?.colors?.primary || asset?.colors?.fallback}

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 
 import { useCurrentCurrencyStore } from '~/core/state';
 import { ParsedSearchAsset } from '~/core/types/assets';
-import { formatCurrency } from '~/core/utils/formatNumber';
 import {
   convertRawAmountToBalance,
   convertRawAmountToNativeDisplay,
+  formatNumber,
 } from '~/core/utils/numbers';
 import {
   Box,
@@ -50,18 +50,6 @@ export const SwapAssetCard = ({
       ).display,
     [asset.decimals, asset.price?.value, assetAmount, currentCurrency],
   );
-  const cleanNumber = (n: number | string | null | undefined): number => {
-    if (typeof n === 'string') {
-      return parseFloat(n.replace(/,/g, ''));
-    }
-    return n || 0;
-  };
-
-  const formatNumber = (n?: number | string | null) =>
-    formatCurrency(cleanNumber(n), {
-      notation: 'compact',
-      maximumSignificantDigits: 4,
-    });
 
   return (
     <AccentColorProvider

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 
 import { useCurrentCurrencyStore } from '~/core/state';
 import { ParsedSearchAsset } from '~/core/types/assets';
+import { formatCurrency } from '~/core/utils/formatNumber';
 import {
-  abbreviateNumber,
   convertRawAmountToBalance,
   convertRawAmountToNativeDisplay,
 } from '~/core/utils/numbers';
@@ -50,8 +50,18 @@ export const SwapAssetCard = ({
       ).display,
     [asset.decimals, asset.price?.value, assetAmount, currentCurrency],
   );
+  const cleanNumber = (n: number | string | null | undefined): number => {
+    if (typeof n === 'string') {
+      return parseFloat(n.replace(/,/g, ''));
+    }
+    return n || 0;
+  };
 
-  const amountWithAbbreviation = abbreviateNumber(amount);
+  const formatNumber = (n?: number | string | null) =>
+    formatCurrency(cleanNumber(n), {
+      notation: 'compact',
+      maximumSignificantDigits: 4,
+    });
 
   return (
     <AccentColorProvider
@@ -78,7 +88,7 @@ export const SwapAssetCard = ({
                 <Columns space="4px" alignVertical="center">
                   <Column>
                     <TextOverflow color="label" size="14pt" weight="bold">
-                      {`${amountWithAbbreviation}`}
+                      {`${formatNumber(amount)}`}
                     </TextOverflow>
                   </Column>
                   <Column width="content">

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useCurrentCurrencyStore } from '~/core/state';
 import { ParsedSearchAsset } from '~/core/types/assets';
 import {
+  abbreviateNumber,
   convertRawAmountToBalance,
   convertRawAmountToNativeDisplay,
 } from '~/core/utils/numbers';
@@ -50,6 +51,10 @@ export const SwapAssetCard = ({
     [asset.decimals, asset.price?.value, assetAmount, currentCurrency],
   );
 
+  const amountWithAbbreviation = abbreviateNumber(amount);
+
+  console.log('amountWIthAbbreviation: ', amountWithAbbreviation);
+
   return (
     <AccentColorProvider
       color={asset?.colors?.primary || asset?.colors?.fallback}
@@ -75,7 +80,7 @@ export const SwapAssetCard = ({
                 <Columns space="4px" alignVertical="center">
                   <Column>
                     <TextOverflow color="label" size="14pt" weight="bold">
-                      {`${amount}`}
+                      {`${amountWithAbbreviation}`}
                     </TextOverflow>
                   </Column>
                   <Column width="content">

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
@@ -20,6 +20,7 @@ import { useSwapAssetsToRefreshStore } from '~/core/state/swapAssetsToRefresh';
 import { ParsedSearchAsset } from '~/core/types/assets';
 import { ChainId } from '~/core/types/chains';
 import { truncateAddress } from '~/core/utils/address';
+import { formatCurrency } from '~/core/utils/formatNumber';
 import { isLowerCaseMatch } from '~/core/utils/strings';
 import { isUnwrapEth, isWrapEth } from '~/core/utils/swaps';
 import {
@@ -242,6 +243,33 @@ const SwapReviewSheetWithQuote = ({
 
   const { minimumReceived, swappingRoute, includedFee, exchangeRate } =
     useSwapReviewDetails({ quote, assetToBuy, assetToSell });
+
+  const cleanNumber = (n: string): number => {
+    return parseFloat(n.replace(/,/g, ''));
+  };
+
+  const formatNumber = (n: string) =>
+    formatCurrency(cleanNumber(n), {
+      notation: 'compact',
+      maximumSignificantDigits: 4,
+    });
+
+  const processArray = (arr: string[]): string[] => {
+    return arr.map((item) => {
+      const parts = item.split(' ');
+      if (parts.length === 5) {
+        const formattedAmount = formatNumber(parts[3]);
+        return `${parts[0]} ${parts[1]} ${parts[2]} ${formattedAmount} ${parts[4]}`;
+      }
+      return item;
+    });
+  };
+
+  const formattedExchangeRate = useMemo(
+    () => processArray(exchangeRate),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [exchangeRate],
+  );
 
   const { explainerSheetParams, showExplainerSheet, hideExplainerSheet } =
     useExplainerSheetParams();
@@ -615,7 +643,7 @@ const SwapReviewSheetWithQuote = ({
                         <CarrouselButton
                           testId="exchange-rate"
                           symbol="arrow.2.squarepath"
-                          textArray={exchangeRate}
+                          textArray={formattedExchangeRate}
                         />
                       </ReviewDetailsRow>
                       {!assetToSell.isNativeAsset && (

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
@@ -20,7 +20,7 @@ import { useSwapAssetsToRefreshStore } from '~/core/state/swapAssetsToRefresh';
 import { ParsedSearchAsset } from '~/core/types/assets';
 import { ChainId } from '~/core/types/chains';
 import { truncateAddress } from '~/core/utils/address';
-import { formatCurrency } from '~/core/utils/formatNumber';
+import { processExchangeRateArray } from '~/core/utils/numbers';
 import { isLowerCaseMatch } from '~/core/utils/strings';
 import { isUnwrapEth, isWrapEth } from '~/core/utils/swaps';
 import {
@@ -244,29 +244,8 @@ const SwapReviewSheetWithQuote = ({
   const { minimumReceived, swappingRoute, includedFee, exchangeRate } =
     useSwapReviewDetails({ quote, assetToBuy, assetToSell });
 
-  const cleanNumber = (n: string): number => {
-    return parseFloat(n.replace(/,/g, ''));
-  };
-
-  const formatNumber = (n: string) =>
-    formatCurrency(cleanNumber(n), {
-      notation: 'compact',
-      maximumSignificantDigits: 4,
-    });
-
-  const processArray = (arr: string[]): string[] => {
-    return arr.map((item) => {
-      const parts = item.split(' ');
-      if (parts.length === 5) {
-        const formattedAmount = formatNumber(parts[3]);
-        return `${parts[0]} ${parts[1]} ${parts[2]} ${formattedAmount} ${parts[4]}`;
-      }
-      return item;
-    });
-  };
-
   const formattedExchangeRate = useMemo(
-    () => processArray(exchangeRate),
+    () => processExchangeRateArray(exchangeRate),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [exchangeRate],
   );


### PR DESCRIPTION
Fixes BX-1550, BX-121, BX-1551

## What changed:
- this PR effects the swap review cards and the swap review
- follow up PRs to follow changing this behavior elsewhere in the app
- numbers >= 1,000 are now abbreviated using K, M, B, T, etc.

## Screen recordings / screenshots
New behavior:
<img width="300" alt="Screenshot 2024-07-02 at 11 07 26 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/e8bd2243-53ee-44ec-85de-dbf56bab6d2b">
<img width="300" alt="Screenshot 2024-07-02 at 11 05 58 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/2dee275f-e23b-41d0-8726-941b91481126">
<img width="300" alt="Screenshot 2024-07-02 at 11 08 23 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/9857a73f-4796-4b8d-bb7a-d8d7ee314c60">
<img width="300" alt="Screenshot 2024-07-09 at 3 46 58 PM" src="https://github.com/rainbow-me/browser-extension/assets/41711440/2eae8ed7-9a83-48ff-a92c-6e3d7955385b">


## What to test
- do large and small values round correctly on the review cards