### PR TITLE
fix: window. rainbow providers

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1156,8 +1156,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
   },
   "devDependencies": {
     "@foundry-rs/hardhat-anvil": "0.1.7",
+    "@graphql-eslint/eslint-plugin": "3.10.7",
     "@lavamoat/allow-scripts": "3.0.1",
     "@lavamoat/preinstall-always-fail": "2.0.0",
     "@peculiar/webcrypto": "1.4.1",
@@ -230,8 +231,7 @@
     "webpack-bundle-analyzer": "4.8.0",
     "webpack-cli": "5.1.4",
     "webpack-extension-reloader": "rainbow-me/webpack-extension-reloader#23fc3ed1f59f295702d459ad58aec90d6f0a3551",
-    "worker-loader": "3.0.8",
-    "@graphql-eslint/eslint-plugin": "3.10.7"
+    "worker-loader": "3.0.8"
   },
   "resolutions": {
     "tar": "6.2.1",

--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -63,6 +63,12 @@ const rainbowProvider = new RainbowProvider({
 });
 
 if (shouldInjectProvider()) {
+  // eslint-disable-next-line prefer-object-spread
+  const providerCopy = Object.create(
+    Object.getPrototypeOf(rainbowProvider),
+    Object.getOwnPropertyDescriptors(rainbowProvider),
+  );
+  providerCopy.isMetaMask = false;
   announceProvider({
     info: {
       icon: RAINBOW_ICON_RAW_SVG,
@@ -70,10 +76,7 @@ if (shouldInjectProvider()) {
       rdns: 'me.rainbow',
       uuid: uuid4(),
     },
-    provider: {
-      ...rainbowProvider,
-      isMetaMask: false,
-    } as RainbowProvider as EIP1193Provider,
+    provider: providerCopy as RainbowProvider as EIP1193Provider,
   });
 
   backgroundMessenger.reply(

--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -63,7 +63,7 @@ const rainbowProvider = new RainbowProvider({
 });
 
 if (shouldInjectProvider()) {
-  const provider = rainbowProvider;
+  const provider = { ...rainbowProvider } as RainbowProvider;
   provider.isMetaMask = false;
   announceProvider({
     info: {

--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -63,6 +63,8 @@ const rainbowProvider = new RainbowProvider({
 });
 
 if (shouldInjectProvider()) {
+  const provider = rainbowProvider;
+  provider.isMetaMask = false;
   announceProvider({
     info: {
       icon: RAINBOW_ICON_RAW_SVG,
@@ -70,7 +72,7 @@ if (shouldInjectProvider()) {
       rdns: 'me.rainbow',
       uuid: uuid4(),
     },
-    provider: rainbowProvider as EIP1193Provider,
+    provider: provider as EIP1193Provider,
   });
 
   backgroundMessenger.reply(
@@ -100,10 +102,7 @@ if (shouldInjectProvider()) {
 
   Object.defineProperties(window, {
     rainbow: {
-      value: {
-        ...rainbowProvider,
-        providers: window.rnbwWalletRouter.providers,
-      },
+      value: rainbowProvider,
       configurable: false,
       writable: false,
     },

--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -63,8 +63,6 @@ const rainbowProvider = new RainbowProvider({
 });
 
 if (shouldInjectProvider()) {
-  const provider = { ...rainbowProvider } as RainbowProvider;
-  provider.isMetaMask = false;
   announceProvider({
     info: {
       icon: RAINBOW_ICON_RAW_SVG,
@@ -72,7 +70,10 @@ if (shouldInjectProvider()) {
       rdns: 'me.rainbow',
       uuid: uuid4(),
     },
-    provider: provider as EIP1193Provider,
+    provider: {
+      ...rainbowProvider,
+      isMetaMask: false,
+    } as RainbowProvider as EIP1193Provider,
   });
 
   backgroundMessenger.reply(

--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -102,10 +102,7 @@ if (shouldInjectProvider()) {
     rainbow: {
       value: {
         ...rainbowProvider,
-        providers: [
-          rainbowProvider,
-          ...(window.ethereum ? [window.ethereum] : []),
-        ],
+        providers: window.rnbwWalletRouter.providers,
       },
       configurable: false,
       writable: false,


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

`window.rainbow.providers` was only defined once at the beginning, so any updates to `rnbwWalletRouter.providers` won't be reflected in `window.rainbow.providers`, in which case were rainbow provider is `window.ethereum` the `window.ethereum.providers` would only have the first definition of `window.rainbow.providers` at the beginning 


EDIT

ended up removing `isMetaMask` flag when `announceProvider`

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
