### PR TITLE
fix: delete `isMetaMask` property and share same EIP-1193 instance with EIP-6963

### DIFF
--- a/src/entries/inpage/index.ts
+++ b/src/entries/inpage/index.ts
@@ -69,12 +69,6 @@ const rainbowProvider = new RainbowProvider({
 delete rainbowProvider.isMetaMask;
 
 if (shouldInjectProvider()) {
-  // eslint-disable-next-line prefer-object-spread
-  const providerCopy = Object.create(
-    Object.getPrototypeOf(rainbowProvider),
-    Object.getOwnPropertyDescriptors(rainbowProvider),
-  );
-  providerCopy.isMetaMask = false;
   announceProvider({
     info: {
       icon: RAINBOW_ICON_RAW_SVG,
@@ -82,7 +76,7 @@ if (shouldInjectProvider()) {
       rdns: 'me.rainbow',
       uuid: uuid4(),
     },
-    provider: providerCopy as RainbowProvider as EIP1193Provider,
+    provider: rainbowProvider as EIP1193Provider,
   });
 
   backgroundMessenger.reply(


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- `window.ethereum.providers` causing infinite loop with Rainbow wallet when having Coinbase and MetaMask installed. This is causing a memory leak due to `window.ethereum.providers` overrides.

EDIT:
This is a small improvement from previous fix we did

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test
