### PR TITLE
fix: catch error when sound fails to play on firefox due to permissions

### DIFF
--- a/src/entries/popup/utils/playSound.ts
+++ b/src/entries/popup/utils/playSound.ts
@@ -4,6 +4,7 @@ import LockSound from 'static/assets/audio/ui_lock.mp3';
 import UnlockSound from 'static/assets/audio/ui_unlock.mp3';
 import SendSound from 'static/assets/audio/woosh.mp3';
 import { soundStore } from '~/core/state/sound';
+import { logger } from '~/logger';
 
 const SOUNDS = {
   CorrectSeedQuiz,
@@ -16,6 +17,8 @@ const SOUNDS = {
 export default function playSound(sound: keyof typeof SOUNDS) {
   const { soundsEnabled } = soundStore.getState();
   if (soundsEnabled) {
-    new Audio(SOUNDS[sound]).play();
+    new Audio(SOUNDS[sound]).play().catch((e) => {
+      logger.warn(`Failed to play sound ${sound}`, e);
+    });
   }
 }


### PR DESCRIPTION
Fixes BX-1563
Figma link (if any):

## What changed (plus any additional context for devs)
- added `catch()` to `.play()` promise

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
