### PR TITLE
[BX-1545] fix: prevent touchpad dbltap zoom

### DIFF
--- a/src/entries/popup/App.tsx
+++ b/src/entries/popup/App.tsx
@@ -77,6 +77,14 @@ export function App() {
     if (process.env.IS_DEV !== 'true') {
       document.addEventListener('contextmenu', (e) => e.preventDefault());
     }
+
+    // prevent trackpad double tap zoom
+    const app = document.getElementById('app');
+    app?.addEventListener('wheel', (e) => {
+      if (e.ctrlKey) {
+        e.preventDefault();
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Disabled default behavior when we receive a `'wheel'` event with the `ctrlKey` field set to true.

## Screen recordings / screenshots
Pretend I posted a video of nothing happening.

## What to test
Attempt to zoom in on the application using the 2 finger double tap gesture on the touchpad.
