### PR TITLE
Missing App field for ETH Rewards claim transactions, From address should be rich metadata for Rainbow

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1156,8 +1156,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/src/core/types/transactions.ts
+++ b/src/core/types/transactions.ts
@@ -207,6 +207,7 @@ export type TransactionApiResponse = {
     asset?: AssetApiResponse;
     quantity?: 'UNLIMITED' | string;
     status: string;
+    external_subtype?: 'rewards_claim';
   };
   block_number?: number;
   mined_at?: number;

--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -9,6 +9,8 @@ import { formatUnits } from '@ethersproject/units';
 import { isString } from 'lodash';
 import { Address } from 'viem';
 
+import RainbowIcon from 'static/images/icon-16@2x.png';
+
 import { i18n } from '../languages';
 import { createHttpClient } from '../network/internal/createHttpClient';
 import {
@@ -296,10 +298,20 @@ export function parseTransaction({
     value: valueInNative,
   };
 
-  const contract = meta.contract_name && {
-    name: meta.contract_name,
-    iconUrl: meta.contract_icon_url,
-  };
+  let contract;
+  if (meta.contract_name) {
+    if (meta.external_subtype === 'rewards_claim') {
+      contract = {
+        name: 'Rainbow',
+        iconUrl: RainbowIcon,
+      };
+    } else {
+      contract = {
+        name: meta.contract_name,
+        iconUrl: meta.contract_icon_url,
+      };
+    }
+  }
 
   return {
     from: tx.address_from,
@@ -642,7 +654,8 @@ export const getAdditionalDetails = (transaction: RainbowTransaction) => {
     !exchangeRate &&
     !collection &&
     !standard &&
-    !approval
+    !approval &&
+    contract?.name !== 'Rainbow'
   )
     return;
 


### PR DESCRIPTION
Fixes BX-1536

## What changed (plus any additional context for devs)
- replaced the 'from' row in claim transaction details with Rainbow + rainbow icon
- added app row to claim tx details

## Screen recordings / screenshots
<img width="474" alt="Screenshot 2024-07-22 at 3 52 53 AM" src="https://github.com/user-attachments/assets/d455447c-3a28-400f-b008-19aca3b3612f">

## What to test
Eth reward claims should show rainbow in the from row and list rainbow in the app row.