### PR TITLE
feat: use BE explorer values for txs

### DIFF
--- a/src/core/types/transactions.ts
+++ b/src/core/types/transactions.ts
@@ -62,6 +62,10 @@ type BaseTransaction = {
   gasPrice?: string;
   gasLimit?: string;
   baseFee?: string;
+  explorer?: {
+    name: string;
+    url: string;
+  };
 } & Partial<TransactionGasParams & TransactionLegacyGasParams>;
 
 export type PendingTransaction = BaseTransaction & {
@@ -202,6 +206,8 @@ export type TransactionApiResponse = {
     approval_to?: Address;
     contract_name?: string;
     contract_icon_url?: string;
+    explorer_label?: string;
+    explorer_url?: string;
     type?: TransactionType;
     action?: string;
     asset?: AssetApiResponse;

--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -301,6 +301,12 @@ export function parseTransaction({
     iconUrl: meta.contract_icon_url,
   };
 
+  const explorer = meta.explorer_label &&
+    meta.explorer_url && {
+      name: meta.explorer_label,
+      url: meta.explorer_url,
+    };
+
   return {
     from: tx.address_from,
     to: addressTo,
@@ -322,6 +328,7 @@ export function parseTransaction({
     confirmations: tx.block_confirmations,
     contract,
     native,
+    explorer,
     ...fee,
   } as RainbowTransaction;
 }

--- a/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityDetails.tsx
@@ -486,7 +486,9 @@ function MoreOptions({
   revoke?: boolean;
   onRevoke: () => void;
 }) {
-  const explorer = getTransactionBlockExplorer(transaction);
+  const explorer = transaction?.explorer?.name
+    ? transaction.explorer
+    : getTransactionBlockExplorer(transaction);
   const hash = transaction.hash;
   return (
     <DropdownMenu>


### PR DESCRIPTION
Fixes BX-1438

## What changed (plus any additional context for devs)
We are now using BE values for explorer names and explorer urls in activity context menus. 

## Screen recordings / screenshots
<img width="456" alt="Screenshot 2024-07-22 at 6 51 32 AM" src="https://github.com/user-attachments/assets/a4b9fc3d-2488-4368-9fc1-4cd7d556ff1e">


## What to test
Explorer names + links in activity context menu and activity details more menu
