### PR TITLE
fix: duplicate wallet result in Cmd+K search

### DIFF
--- a/src/entries/popup/components/CommandK/useSearchableENSOrAddress.ts
+++ b/src/entries/popup/components/CommandK/useSearchableENSOrAddress.ts
@@ -4,6 +4,7 @@ import { truncateAddress } from '~/core/utils/address';
 import { isENSAddressFormat } from '~/core/utils/ethereum';
 import { isLowerCaseMatch } from '~/core/utils/strings';
 
+import { useContacts } from '../../hooks/useContacts';
 import { useDebounce } from '../../hooks/useDebounce';
 import { useWallets } from '../../hooks/useWallets';
 import { useValidateInput } from '../WatchWallet/WatchWallet';
@@ -35,6 +36,13 @@ export const useSearchableENSorAddress = ({
   const { isFetching, setIsFetching } = useCommandKStatus();
   const { allWallets } = useWallets();
 
+  const contacts = useContacts();
+
+  const allWalletsWithContacts = React.useMemo(
+    () => [...allWallets, ...contacts],
+    [contacts, allWallets],
+  );
+
   const query = searchQuery.trim();
   const debouncedSearchQuery = useDebounce(query, 250);
 
@@ -47,7 +55,9 @@ export const useSearchableENSorAddress = ({
       validation.address &&
       !validation.error &&
       !isFetchingSearchAssets &&
-      !allWallets.some((wallet) => wallet.address === validation.address) &&
+      !allWalletsWithContacts.some((wallet) =>
+        isLowerCaseMatch(wallet.address, validation.address),
+      ) &&
       !assets.some((asset) =>
         isLowerCaseMatch(asset.address, validation.address),
       )
@@ -74,7 +84,7 @@ export const useSearchableENSorAddress = ({
     isFetchingSearchAssets,
     currentPage,
     assets,
-    allWallets,
+    allWalletsWithContacts,
     validation.address,
     validation.ensName,
     validation.error,


### PR DESCRIPTION
Fixes BX-1482
Figma link (if any):

## What changed (plus any additional context for devs)

Searching for wallet address will show duplicates for Watching, Contact, and Owned wallets

## Screen recordings / screenshots

**Before:**
<img width="358" alt="duplicate_wallets" src="https://github.com/user-attachments/assets/c8168366-2846-4cb0-bc35-cd3ae174135a">

**Now:**

<img width="322" alt="image" src="https://github.com/user-attachments/assets/d4d3bfbb-ae54-4179-99a5-c000681eda62">

## What to test

Try adding a watched wallet and/or a contact wallet, and make sure that no additional result appear.