### PR TITLE
fix: wipe saved custom asset draft after addition

### DIFF
--- a/src/entries/popup/pages/settings/customChain/addAsset.tsx
+++ b/src/entries/popup/pages/settings/customChain/addAsset.tsx
@@ -181,6 +181,7 @@ export function AddAsset() {
         chainId,
         rainbowChainAsset: assetToAdd,
       });
+      saveCustomTokenDraft(chainId, undefined);
       navigate(-1);
     }
   }, [
@@ -195,6 +196,7 @@ export function AddAsset() {
     chainId,
     customRPCAssetsForChain,
     navigate,
+    saveCustomTokenDraft,
     validateAddCustomAsset,
   ]);
 


### PR DESCRIPTION
Fixes BX-1417

## What changed (plus any additional context for devs)
The custom asset draft for a particular network will wipe saved data after successful token addition. 

## What to test
Add a custom asset to a network, then revisit the add asset form for the same network to ensure that the saved form data was wiped.
