### PR TITLE
fix: disable activity details shortcuts without dropdown

### DIFF
--- a/src/entries/popup/hooks/useTokenDetailsShortcuts.ts
+++ b/src/entries/popup/hooks/useTokenDetailsShortcuts.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { shortcuts } from '~/core/references/shortcuts';
 import { useContainerRef } from '~/design-system/components/AnimatedRoute/AnimatedRoute';
 
+import { radixIsActive } from '../utils/activeElement';
 import { simulateClick } from '../utils/simulateClick';
 
 import useKeyboardAnalytics from './useKeyboardAnalytics';
@@ -30,33 +31,35 @@ export function useTokenDetailsShortcuts({
 
   const handleTokenShortcuts = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === shortcuts.tokens.PIN_ASSET.key && !unownedToken) {
-        simulateClick(containerRef.current);
-        trackShortcut({
-          key: shortcuts.tokens.PIN_ASSET.display,
-          type: 'tokenDetailsMenu.pin',
-        });
-        togglePinToken();
-      }
-      if (
-        e.key === shortcuts.tokens.HIDE_ASSET.key &&
-        !isWatchingWallet &&
-        !unownedToken
-      ) {
-        simulateClick(containerRef.current);
-        trackShortcut({
-          key: shortcuts.tokens.HIDE_ASSET.display,
-          type: 'tokenDetailsMenu.hide',
-        });
-        toggleHideToken();
-      }
-      if (e.key === shortcuts.home.COPY_ADDRESS.key) {
-        simulateClick(containerRef.current);
-        trackShortcut({
-          key: shortcuts.home.COPY_ADDRESS.display,
-          type: 'tokenDetailsMenu.copyTokenAddress',
-        });
-        copyTokenAddress();
+      if (radixIsActive()) {
+        if (e.key === shortcuts.tokens.PIN_ASSET.key && !unownedToken) {
+          simulateClick(containerRef.current);
+          trackShortcut({
+            key: shortcuts.tokens.PIN_ASSET.display,
+            type: 'tokenDetailsMenu.pin',
+          });
+          togglePinToken();
+        }
+        if (
+          e.key === shortcuts.tokens.HIDE_ASSET.key &&
+          !isWatchingWallet &&
+          !unownedToken
+        ) {
+          simulateClick(containerRef.current);
+          trackShortcut({
+            key: shortcuts.tokens.HIDE_ASSET.display,
+            type: 'tokenDetailsMenu.hide',
+          });
+          toggleHideToken();
+        }
+        if (e.key === shortcuts.home.COPY_ADDRESS.key) {
+          simulateClick(containerRef.current);
+          trackShortcut({
+            key: shortcuts.home.COPY_ADDRESS.display,
+            type: 'tokenDetailsMenu.copyTokenAddress',
+          });
+          copyTokenAddress();
+        }
       }
     },
     [


### PR DESCRIPTION
Fixes BX-1565

## What changed (plus any additional context for devs)
From ticket:
"Goal:

Only register Token Details shortcuts when the context menu is visibile

Allow a user to select text and copy"

The shortcuts associated with the more options menu in token details now are only active when the dropdown is visible.

## What to test
Make sure that token details does not intercept the 'C' key when the more options dropdown is hidden.