### PR TITLE
fix: round total eth rewards to 3 decimals

### DIFF
--- a/src/entries/popup/pages/home/Points/PointsDashboard.tsx
+++ b/src/entries/popup/pages/home/Points/PointsDashboard.tsx
@@ -942,7 +942,9 @@ function RainbowUserEarnings({ totalEarnings }: { totalEarnings: string }) {
       <Inline alignVertical="center" space="4px">
         <EthIcon size={12} />
         <Text size="12pt" color="labelSecondary" weight="heavy">
-          {`${convertRawAmountToDecimalFormat(totalEarnings, 18)} ETH`}
+          {`${parseFloat(
+            convertRawAmountToDecimalFormat(totalEarnings, 18),
+          ).toFixed(3)} ETH`}
         </Text>
       </Inline>
     </Inline>


### PR DESCRIPTION
Fixes BX-1570

## What changed (plus any additional context for devs)
The total eth earned by rainbow users displayed on the points page is now restricted to 3 decimal places.

## Screen recordings / screenshots
<img width="347" alt="Screenshot 2024-07-24 at 12 39 06 PM" src="https://github.com/user-attachments/assets/b9a2a6ef-435d-465d-972b-b12608d7ea63">

## What to test
Check that this value does not exceed 3 decimal places.
