### PR TITLE
fix: show referral and referral activity points when empty

### DIFF
--- a/src/entries/popup/pages/home/Points/utils.ts
+++ b/src/entries/popup/pages/home/Points/utils.ts
@@ -85,6 +85,14 @@ export const getWeeklyEarnings = (points: PointsQuery['points']) => {
       !(['retroactive', 'redemption'].includes(d.type) && d.earnings === 0),
   );
 
+  if (!diffs.find((d) => d.type === 'new_referrals')) {
+    diffs.push({ type: 'new_referrals', earnings: 0 });
+  }
+
+  if (!diffs.find((d) => d.type === 'referral_activity')) {
+    diffs.push({ type: 'referral_activity', earnings: 0 });
+  }
+
   return { total, differences: diffs };
 };
 


### PR DESCRIPTION
Fixes BX-1287

## What changed (plus any additional context for devs)
Users with empty referral activity will now always see referral line items in the weekly summary even if empty ("none").

## Screen recordings / screenshots
<img width="360" alt="Screenshot 2024-07-24 at 12 41 53 PM" src="https://github.com/user-attachments/assets/80f26ad4-4eb2-4ca0-ab97-97586874bb9b">

## What to test
Ensure these line items appear for addresses with no activity for a given week.
