### PR TITLE
fix: token details info text selection

### DIFF
--- a/src/design-system/components/TextOverflow/TextOverflow.tsx
+++ b/src/design-system/components/TextOverflow/TextOverflow.tsx
@@ -1,8 +1,10 @@
+import clsx from 'clsx';
 import React, { CSSProperties } from 'react';
 
 import { TextStyles, textStyles } from '../../styles/core.css';
 import { Box } from '../Box/Box';
 import { Inset } from '../Inset/Inset';
+import { selectionStyle } from '../Text/Text.css';
 
 interface TextOverflowProps {
   align?: TextStyles['textAlign'];
@@ -37,12 +39,10 @@ export function TextOverflow({
         marginVertical="-8px"
         className={textStyles({
           color,
-          cursor,
           fontFamily: 'rounded',
           fontSize: size,
           fontWeight: weight,
           textAlign: align,
-          userSelect,
           textOverflow: 'ellipsis',
           overflow: 'hidden',
           whiteSpace: 'nowrap',
@@ -53,11 +53,16 @@ export function TextOverflow({
         <Inset vertical="8px">
           <Box
             as={as}
-            style={{
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
+            className={clsx([
+              textStyles({
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                userSelect,
+                cursor,
+              }),
+              selectionStyle,
+            ])}
           >
             {children}
           </Box>

--- a/src/entries/popup/pages/home/TokenDetails/About.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/About.tsx
@@ -208,7 +208,13 @@ function Description({ text = '' }: { text?: string | null }) {
   if (!text) return null;
   const chunks = chunkLinks(text);
   return (
-    <Text color="labelTertiary" size="14pt" weight="regular">
+    <Text
+      color="labelTertiary"
+      size="14pt"
+      weight="regular"
+      cursor="text"
+      userSelect="text"
+    >
       {chunks.map((chunk, i) => {
         if (chunk.type === 'text') {
           return chunk.value;

--- a/src/entries/popup/pages/home/TokenDetails/About.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/About.tsx
@@ -88,7 +88,7 @@ export const InfoRow = ({
       size="12pt"
       weight="semibold"
       cursor="text"
-      userSelect="all"
+      userSelect="text"
     >
       {value}
     </TextOverflow>

--- a/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
@@ -90,7 +90,7 @@ const TokenPrice = memo(function TokenPrice({
         justifyContent="center"
         gap="10px"
       >
-        <Text size="16pt" weight="heavy" cursor="text" userSelect="all">
+        <Text size="16pt" weight="heavy" cursor="text" userSelect="text">
           {!isLoading && !hasPriceData && !fallbackPrice
             ? i18n.t('token_details.not_available')
             : formatCurrency(

--- a/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
@@ -47,14 +47,20 @@ const PriceChange = memo(function PriceChange({
   const { color, symbol } = parsePriceChange(+changePercentage.toFixed(2));
   return (
     <Box display="flex" flexDirection="column" gap="10px" alignItems="flex-end">
-      <Text size="16pt" weight="heavy" color={color}>
-        <Inline alignVertical="center" space="4px">
-          {symbol && (
-            <Symbol color={color} size={12} symbol={symbol} weight="heavy" />
-          )}{' '}
+      <Inline alignVertical="center" space="4px">
+        {symbol && (
+          <Symbol color={color} size={12} symbol={symbol} weight="heavy" />
+        )}
+        <Text
+          size="16pt"
+          weight="heavy"
+          color={color}
+          cursor="text"
+          userSelect="text"
+        >
           {Math.abs(changePercentage).toFixed(2)} %
-        </Inline>
-      </Text>
+        </Text>
+      </Inline>
       <Text size="14pt" weight="heavy" color={color}>
         {formatDate(date)}
       </Text>

--- a/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/TokenDetails.tsx
@@ -142,7 +142,7 @@ function BalanceValue({
             weight="semibold"
             color={color}
             cursor="text"
-            userSelect="all"
+            userSelect="text"
           >
             {hideAssetBalances ? <HiddenValue /> : balance.value}{' '}
             {balance.symbol}
@@ -160,7 +160,7 @@ function BalanceValue({
             color={color}
             align="right"
             cursor="text"
-            userSelect="all"
+            userSelect="text"
           >
             {getPrice(nativeBalance, chainId)}
           </TextOverflow>


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- follow up to #1640
- mirrored `Text` component `selectionStyle` behavior and `cursor` and `user-select` to `TextOverflow`
- ensured all components in Text Details are selectable with appropriate accent color

## Screen recordings / screenshots

<img width="340" alt="Screenshot 2024-07-24 at 6 24 47 PM" src="https://github.com/user-attachments/assets/69cbd13a-1194-471c-8cf0-06c9b1b08b9e">
<br>
<img width="360" alt="Screenshot 2024-07-24 at 6 24 39 PM" src="https://github.com/user-attachments/assets/48c11cb8-27d2-4ead-b214-f4569ed198e3">
<br>
<img width="358" alt="Screenshot 2024-07-24 at 6 24 32 PM" src="https://github.com/user-attachments/assets/610ff9c3-1ba8-4b16-8a7c-62bfc36b1eb0">
<br>
<img width="356" alt="Screenshot 2024-07-24 at 6 24 28 PM" src="https://github.com/user-attachments/assets/65e8364b-3dbb-444f-a570-e30dc3d853b6">
