### PR TITLE
fix: tabs messenger not responding on fast refresh

### DIFF
--- a/src/core/messengers/internal/tab.ts
+++ b/src/core/messengers/internal/tab.ts
@@ -1,5 +1,7 @@
 import { RequestArguments } from '@rainbow-me/provider';
 
+import { rpcMethods } from '~/core/types/rpcMethods';
+
 import {
   CallbackFunction,
   ReplyMessage,
@@ -13,18 +15,9 @@ let activeTab: chrome.tabs.Tab;
 
 const shouldNotifyAllTabs = (method: string) =>
   [
-    'eth_chainId',
-    'eth_accounts',
-    'eth_sendTransaction',
-    'eth_signTransaction',
-    'personal_sign',
-    'eth_signTypedData',
-    'eth_signTypedData_v3',
-    'eth_signTypedData_v4',
-    'wallet_watchAsset',
-    'wallet_addEthereumChain',
-    'wallet_switchEthereumChain',
-    'eth_requestAccounts',
+    rpcMethods.eth_requestAccounts,
+    rpcMethods.eth_accounts,
+    rpcMethods.eth_chainId,
   ].includes(method);
 
 function getCurrentActiveTab() {

--- a/src/core/messengers/internal/tab.ts
+++ b/src/core/messengers/internal/tab.ts
@@ -12,7 +12,20 @@ import { isValidSend } from './isValidSend';
 let activeTab: chrome.tabs.Tab;
 
 const shouldNotifyAllTabs = (method: string) =>
-  ['eth_requestAccounts'].includes(method);
+  [
+    'eth_chainId',
+    'eth_accounts',
+    'eth_sendTransaction',
+    'eth_signTransaction',
+    'personal_sign',
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+    'wallet_watchAsset',
+    'wallet_addEthereumChain',
+    'wallet_switchEthereumChain',
+    'eth_requestAccounts',
+  ].includes(method);
 
 function getCurrentActiveTab() {
   if (!chrome.tabs) return Promise.resolve([]);
@@ -25,7 +38,7 @@ function getCurrentActiveTab() {
     });
 }
 
-function getAllActiveTabs() {
+function getAllTabs() {
   if (!chrome.tabs) return Promise.resolve([]);
   return chrome.tabs.query({});
 }
@@ -111,7 +124,7 @@ export const tabMessenger = createMessenger({
       let tabs: chrome.tabs.Tab[] = [];
 
       if (shouldNotifyAllTabs((message.payload as RequestArguments)?.method)) {
-        tabs = await getAllActiveTabs();
+        tabs = await getAllTabs();
       } else {
         tabs = await getCurrentActiveTab();
       }


### PR DESCRIPTION
Fixes BX-1478
Figma link (if any):

## What changed (plus any additional context for devs)

`tabMessenger` now sends message events to all tabs if RPC methods are supported. Before it could send to the active tab only.

## Screen recordings / screenshots

**Before**

https://github.com/user-attachments/assets/3015e04b-235d-45dd-aec9-c7eda3a4d2e0

**After**

https://github.com/user-attachments/assets/ac034181-8291-4970-a5f4-112f55031a87

## What to test

- Make sure you open 5 tabs with this url https://blur.io/collections and connect your wallet. Then do fast refresh on every tab and meanwhile switch back and fourth. The wallet should be connected on all tabs.