### PR TITLE
reduce animation dropdown on bridge entry point (swaps)

### DIFF
--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -449,9 +449,11 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
   const tokenToBuyInputRef = useRef<TokenInputRef>();
 
   const selectAssetToSell = useCallback(
-    (asset: ParsedSearchAsset | null) => {
+    (asset: ParsedSearchAsset | null, openAssetToBuyDropdown = true) => {
       setAssetToSell(asset);
-      if (!assetToBuy) tokenToBuyInputRef.current?.openDropdown();
+      if (!assetToBuy && openAssetToBuyDropdown) {
+        tokenToBuyInputRef.current?.openDropdown();
+      }
       setAssetToSellInputValue('');
       setAssetToBuyInputValue('');
     },
@@ -482,11 +484,13 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
         (asset) => asset?.uniqueId === selectedTokenId,
       );
       if (selectedSearchAsset) {
-        selectAssetToSell(selectedSearchAsset);
+        selectAssetToSell(selectedSearchAsset, !bridge);
         // clear selected token
         setSelectedToken();
       }
-      setInputToOpenOnMount('buy');
+      if (!bridge) {
+        setInputToOpenOnMount('buy');
+      }
     } else {
       if (!didPopulateSavedTokens) {
         if (savedTokenToBuy) {


### PR DESCRIPTION
Fixes BX-1083
Figma link (if any):

## What changed (plus any additional context for devs)

Reduce showing receive dropdown on bridge entry point from token details page or home page

## Screen recordings / screenshots

https://github.com/user-attachments/assets/04ec46cf-f7ec-49cf-891c-7ee8ae9b7de7

## What to test

Home page:

1. Right click on token
2. Click bridge menu
3. Make sure you don't see the receive dropdown open on bridge page


Token details page:

1. Click bridge button
3. You shouldn't see the receive dropdown open on bridge page (same behaviour from home page)