### PR TITLE
promotion banner font issue (firefox)

### DIFF
--- a/src/entries/popup/components/QuickPromo/QuickPromo.tsx
+++ b/src/entries/popup/components/QuickPromo/QuickPromo.tsx
@@ -58,7 +58,12 @@ export const QuickPromo = ({
               />
             </Column>
 
-            <Box>
+            <Box
+              className={textStyles({
+                fontSize: '12pt',
+                fontFamily: 'rounded',
+              })}
+            >
               <Box
                 as="span"
                 className={textStyles({


### PR DESCRIPTION
Fixes BX-1537
Figma link (if any):

## What changed (plus any additional context for devs)

Firefox had a font issue with `<span>` element. Now we manually set the font family and font size to the `<QuickPromo>` component.

## Screen recordings / screenshots

**Before:**

<img width="360" alt="BX-1537 (before)" src="https://github.com/user-attachments/assets/a3aab3bf-5a67-463b-8f7c-4198d0b4a4c7">


**After:**

<img width="360" alt="BX-1537 (after)" src="https://github.com/user-attachments/assets/7024eba2-d70a-46e2-93a9-ae274099b4d5">


## What to test

Go to firefox and make sure none of the promotion banner has a font issue.
