### PR TITLE
fix: add border radius to lens cmp wrapping cards

### DIFF
--- a/src/entries/popup/pages/home/Points/PointsDashboard.tsx
+++ b/src/entries/popup/pages/home/Points/PointsDashboard.tsx
@@ -74,11 +74,20 @@ function Card({
 }: PropsWithChildren<BoxProps & MotionProps> & {
   onClick?: () => void;
 }) {
+  const getTabIndex = () => {
+    if (typeof props.tabIndex === 'number') {
+      return props.tabIndex;
+    } else if (props.onClick) {
+      return 0;
+    }
+    return -1;
+  };
   return (
     <Lens
       onClick={props.onClick}
       width={props.width || 'full'}
-      tabIndex={typeof props.tabIndex === 'number' ? props.tabIndex : 0}
+      tabIndex={getTabIndex()}
+      borderRadius={props.borderRadius || '20px'}
     >
       <Box
         as={motion.div}
@@ -317,6 +326,7 @@ function ReferralCode() {
               onTap={copyReferralCode}
               onClick={copyReferralCode}
               style={{ height: 40, willChange: 'transform' }}
+              tabIndex={-1}
             >
               <Text size="16pt" weight="heavy" align="center">
                 {formatReferralCode(data.user.referralCode)}
@@ -334,6 +344,7 @@ function ReferralCode() {
               onTap={() => copyReferralLink(data.user.referralCode)}
               onClick={() => copyReferralLink(data.user.referralCode)}
               style={{ height: 40, willChange: 'transform' }}
+              tabIndex={-1}
             >
               <Inline alignVertical="center" space="8px">
                 <Symbol


### PR DESCRIPTION
Fixes BX-1609

## What changed (plus any additional context for devs)
Passed border radius from <Card /> props to <Lens /> to fix navigation highlighting display issues and also removed a few things from the tab index that probably don't need to be there.

This screen could probably use some extra kb functionality + nav, but this PR just fixes the existing display issues.

## Screen recordings / screenshots
<img width="357" alt="Screenshot 2024-08-19 at 12 59 59 PM" src="https://github.com/user-attachments/assets/56b87791-ea84-4001-ac45-b8293e8e45a6">

## What to test
Make sure that selecting the Last Week's Earnings card with the keyboard looks and behaves normally.
