### PR TITLE
Re-adding optional chaining for sellAsset and buyAsset on quote response

### DIFF
--- a/src/entries/popup/hooks/swap/useSwapNativeAmounts.tsx
+++ b/src/entries/popup/hooks/swap/useSwapNativeAmounts.tsx
@@ -31,12 +31,12 @@ export const useSwapNativeAmounts = ({
     let nativeDisplay = null;
     if (isWrapOrUnwrapEth) {
       nativeDisplay =
-        !quote?.sellAmount || !quote.sellTokenAsset.price.value
+        !quote?.sellAmount || !quote?.sellTokenAsset?.price?.value
           ? null
           : convertRawAmountToNativeDisplay(
               quote?.sellAmount?.toString(),
-              quote.sellTokenAsset.decimals || 18,
-              quote.sellTokenAsset.price.value,
+              quote?.sellTokenAsset?.decimals || 18,
+              quote?.sellTokenAsset?.price?.value,
               currentCurrency,
             );
     } else if (assetToSell?.native?.price?.amount && assetToSellValue) {
@@ -47,12 +47,12 @@ export const useSwapNativeAmounts = ({
       );
     } else {
       nativeDisplay =
-        !quote?.sellAmountInEth || !quote.sellTokenAsset.price.value
+        !quote?.sellAmountInEth || !quote?.sellTokenAsset?.price?.value
           ? null
           : convertRawAmountToNativeDisplay(
-              quote?.sellAmountInEth.toString(),
-              quote.sellTokenAsset.decimals || 18,
-              quote.sellTokenAsset.price?.value,
+              quote?.sellAmountInEth?.toString(),
+              quote?.sellTokenAsset?.decimals || 18,
+              quote?.sellTokenAsset?.price?.value,
               currentCurrency,
             );
     }
@@ -72,8 +72,8 @@ export const useSwapNativeAmounts = ({
     assetToSellValue,
     currentCurrency,
     quote?.sellAmount,
-    quote?.sellTokenAsset.price.value,
-    quote?.sellTokenAsset.decimals,
+    quote?.sellTokenAsset?.price?.value,
+    quote?.sellTokenAsset?.decimals,
     quote?.sellAmountInEth,
   ]);
 
@@ -97,12 +97,12 @@ export const useSwapNativeAmounts = ({
       );
     } else {
       nativeDisplay =
-        !quote?.buyAmountInEth || !quote.buyTokenAsset.price?.value
+        !quote?.buyAmountInEth || !quote?.buyTokenAsset?.price?.value
           ? null
           : convertRawAmountToNativeDisplay(
-              quote?.buyAmountInEth.toString(),
-              quote.buyTokenAsset.decimals || 18,
-              quote.buyTokenAsset.price?.value,
+              quote?.buyAmountInEth?.toString(),
+              quote?.buyTokenAsset?.decimals || 18,
+              quote?.buyTokenAsset?.price?.value,
               currentCurrency,
             );
     }
@@ -124,8 +124,8 @@ export const useSwapNativeAmounts = ({
     quote?.buyAmount,
     quote?.buyAmountInEth,
     currentCurrency,
-    quote?.buyTokenAsset.price?.value,
-    quote?.buyTokenAsset.decimals,
+    quote?.buyTokenAsset?.price?.value,
+    quote?.buyTokenAsset?.decimals,
   ]);
 
   return {


### PR DESCRIPTION
Fixes BX-1610

Related to: https://github.com/rainbow-me/rainbow/pull/6022

## What changed (plus any additional context for devs)
Re-added optional chaining on Quote object as the WETH/ETH unwrap/wrap path has different response type than normal swaps.

## Screen recordings / screenshots
Did not take screen recordings - someone please verify.

## What to test
Test ETH -> WETH and flip (WETH -> ETH)
