### PR TITLE
fix: prevent asset to buy dropdown from opening if asset to buy is already set

### DIFF
--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -799,7 +799,9 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                   }
                   setAssetToSellInputValue={setAssetToSellInputValue}
                   inputRef={assetToSellInputRef}
-                  openDropdownOnMount={inputToOpenOnMount === 'sell'}
+                  openDropdownOnMount={
+                    inputToOpenOnMount === 'sell' && !assetToSell
+                  }
                   assetToSellNativeValue={assetToSellNativeValue}
                   assetToSellNativeDisplay={assetToSellNativeDisplay}
                   setAssetToSellInputNativeValue={
@@ -881,7 +883,9 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                   assetToSellValue={assetToSellValue}
                   setAssetToBuyInputValue={setAssetToBuyInputValue}
                   inputRef={assetToBuyInputRef}
-                  openDropdownOnMount={inputToOpenOnMount === 'buy'}
+                  openDropdownOnMount={
+                    inputToOpenOnMount === 'buy' && !assetToBuy
+                  }
                   inputDisabled={isCrosschainSwap}
                   assetToBuyNativeDisplay={assetToBuyNativeDisplay}
                   assetToSellNativeDisplay={assetToSellNativeDisplay}


### PR DESCRIPTION
Fixes BX-1612

## What changed (plus any additional context for devs)
We are not focusing the asset to buy dropdown on the swap screen if asset to buy is already set.

## Screen recordings / screenshots
PoW: https://www.loom.com/share/4c0b1883a5b84c76a2cc1e798b8d761b

## What to test
Ensure the dropdown remains closed when navigating to the swap screen with an asset to buy already set.
