### PR TITLE
ci: ignore GHSA-m95q-7qp3-xv42

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -13,6 +13,7 @@
     "GHSA-353f-5xf4-qw67",
     "GHSA-j8xg-fqg3-53r7",
     "GHSA-67hx-6x53-jw92",
-    "GHSA-c24v-8rfc-w8vw"
+    "GHSA-c24v-8rfc-w8vw",
+    "GHSA-m95q-7qp3-xv42"
   ]
 }


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- ignoring `GHSA-m95q-7qp3-xv42` DDOS vulnerability of `zod` used in `make-color-more-chill` dependency

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
