### PR TITLE
Fix BX-1641 & BX-1642

### DIFF
--- a/src/entries/popup/hooks/swap/useSwapQuote.ts
+++ b/src/entries/popup/hooks/swap/useSwapQuote.ts
@@ -57,12 +57,12 @@ export const useSwapQuote = ({
   );
 
   const quotesParams: QuoteParams | undefined = useMemo(() => {
-    const paramsReady =
-      assetToSell &&
-      assetToBuy &&
-      (independentField === 'buyField'
+    const independentValue =
+      independentField === 'buyField'
         ? Number(assetToBuyValue)
-        : Number(assetToSellValue));
+        : Number(assetToSellValue);
+    const paramsReady =
+      assetToSell && assetToBuy && typeof independentValue === 'number';
     if (!paramsReady) return undefined;
 
     return {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We were not properly clearing swap data when a user cleared the input or manually typed '0' into the swap inputs.

## Screen recordings / screenshots
PoW: https://www.loom.com/share/5415e6ba392f474489728d7a1a50cbf1

## What to test
Reference the bugs detailed in the two attached tickets, but generally play the swap inputs and ensure that unnecessary market warnings are not displayed when clearing swap input data and that we don't see any wacky values displayed in the native currency display fields when swap input data is cleared from either input.
