### PR TITLE
internal networks filtering

### DIFF
--- a/scripts/networks.js
+++ b/scripts/networks.js
@@ -17,6 +17,7 @@ async function fetchData() {
         badgeURL
       }
       testnet
+      internal
       opStack
       defaultExplorer {
         url

--- a/src/core/types/chains.ts
+++ b/src/core/types/chains.ts
@@ -263,6 +263,7 @@ export interface BackendNetwork {
     badgeURL: string;
   };
   testnet: boolean;
+  internal: boolean;
   opStack: boolean;
   defaultExplorer: {
     url: string;

--- a/src/core/utils/backendNetworks.ts
+++ b/src/core/utils/backendNetworks.ts
@@ -4,6 +4,7 @@ import { mainnet } from 'viem/chains';
 import { BackendNetwork } from '../types/chains';
 
 const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
+const IS_DEV = process.env.IS_DEV === 'true';
 
 const proxyBackendNetworkRpcEndpoint = (endpoint: string) => {
   return `${endpoint}${process.env.RPC_PROXY_API_KEY}`;
@@ -51,6 +52,6 @@ export function transformBackendNetworksToChains(
   }
   // include all networks for internal builds, otherwise filter out flagged as internal
   return networks
-    .filter((network) => !network.internal || INTERNAL_BUILD)
+    .filter((network) => !network.internal || INTERNAL_BUILD || IS_DEV)
     .map((network) => transformBackendNetworkToChain(network));
 }

--- a/src/core/utils/backendNetworks.ts
+++ b/src/core/utils/backendNetworks.ts
@@ -3,6 +3,8 @@ import { mainnet } from 'viem/chains';
 
 import { BackendNetwork } from '../types/chains';
 
+const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
+
 const proxyBackendNetworkRpcEndpoint = (endpoint: string) => {
   return `${endpoint}${process.env.RPC_PROXY_API_KEY}`;
 };
@@ -47,5 +49,8 @@ export function transformBackendNetworksToChains(
   if (!networks) {
     return [];
   }
-  return networks.map((network) => transformBackendNetworkToChain(network));
+  // include all networks for internal builds, otherwise filter out flagged as internal
+  return networks
+    .filter((network) => !network.internal || INTERNAL_BUILD)
+    .map((network) => transformBackendNetworkToChain(network));
 }


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- added `internal` type to `BackendNetwork` type and ingestion query
- filtering out `internal` networks in prod, showing for `INTERNAL_BUILD` or `IS_DEV`

## Screen recordings / screenshots
<img width="243" alt="Screenshot 2024-09-25 at 12 25 10 AM" src="https://github.com/user-attachments/assets/7db18fe2-639f-4fa6-914e-323b0f724d30">
<img width="360" alt="Screenshot 2024-09-25 at 12 24 46 AM" src="https://github.com/user-attachments/assets/d3df48b5-f6b0-4f10-88b4-da1d3b90feb6">

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
