### PR TITLE
extend user native asset

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1184,8 +1184,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/src/core/graphql/queries/metadata.graphql
+++ b/src/core/graphql/queries/metadata.graphql
@@ -490,3 +490,17 @@ mutation claimUserRewards($address: String!) {
     txHash
   }
 }
+
+query externalToken($address: String!, $chainId: Int!, $currency: String) {
+  token(address: $address, chainID: $chainId, currency: $currency) {
+    decimals
+    iconUrl
+    name
+    networks
+    price {
+      relativeChange24h
+      value
+    }
+    symbol
+  }
+}

--- a/src/core/resources/assets/externalToken.ts
+++ b/src/core/resources/assets/externalToken.ts
@@ -11,11 +11,7 @@ import {
   queryClient,
 } from '~/core/react-query';
 import { SupportedCurrencyKey } from '~/core/references';
-import {
-  AddressOrEth,
-  ParsedAsset,
-  ParsedUserAsset,
-} from '~/core/types/assets';
+import { AddressOrEth, ParsedAsset } from '~/core/types/assets';
 import { ChainId, chainIdToNameMapping } from '~/core/types/chains';
 import { isNativeAsset } from '~/core/utils/chains';
 import {
@@ -165,7 +161,7 @@ export function useExternalToken(
   config: QueryConfig<
     ExternalTokenQueryFunctionResult,
     Error,
-    ParsedUserAsset,
+    ParsedAsset,
     externalTokenQueryKey
   > = {},
 ) {

--- a/src/core/resources/assets/externalToken.ts
+++ b/src/core/resources/assets/externalToken.ts
@@ -1,0 +1,180 @@
+import { useQuery } from '@tanstack/react-query';
+import { Address } from 'viem';
+
+import { metadataClient } from '~/core/graphql';
+import { Token } from '~/core/graphql/__generated__/metadata';
+import {
+  QueryConfig,
+  QueryFunctionArgs,
+  QueryFunctionResult,
+  createQueryKey,
+  queryClient,
+} from '~/core/react-query';
+import { SupportedCurrencyKey } from '~/core/references';
+import {
+  AddressOrEth,
+  ParsedAsset,
+  ParsedUserAsset,
+} from '~/core/types/assets';
+import { ChainId, chainIdToNameMapping } from '~/core/types/chains';
+import { isNativeAsset } from '~/core/utils/chains';
+import {
+  convertAmountAndPriceToNativeDisplay,
+  convertAmountToPercentageDisplay,
+} from '~/core/utils/numbers';
+
+export const EXTERNAL_TOKEN_CACHE_TIME = 1000 * 60 * 60 * 24; // 24 hours
+export const EXTERNAL_TOKEN_STALE_TIME = 1000 * 60; // 1 minute
+
+// need to keep these queried tokens up to date
+//   ETH_ADDRESS,
+// MATIC_MAINNET_ADDRESS,
+// BNB_MAINNET_ADDRESS,
+// OP_ADDRESS
+
+// Types
+type ExternalToken = Pick<
+  Token,
+  'decimals' | 'iconUrl' | 'name' | 'networks' | 'symbol' | 'price'
+>;
+// export type FormattedExternalAsset = ExternalToken & {
+//   address: string;
+//   icon_url?: string;
+//   isNativeAsset: boolean;
+//   native: {
+//     change: string;
+//     price: {
+//       amount: string;
+//       display: string;
+//     };
+//   };
+//   networks?: {
+//     [chainId in ChainId]?: {
+//       address: chainId extends ChainId.mainnet ? AddressOrEth : Address;
+//       decimals: number;
+//     };
+//   };
+// };
+
+// Query Types for External Token
+type ExternalTokenArgs = {
+  address: string;
+  chainId: ChainId;
+  currency: SupportedCurrencyKey;
+};
+
+// Query Key for Token Price
+export const externalTokenQueryKey = ({
+  address,
+  chainId,
+  currency,
+}: ExternalTokenArgs) =>
+  createQueryKey(
+    'externalToken',
+    { address, chainId, currency },
+    { persisterVersion: 1 },
+  );
+
+type externalTokenQueryKey = ReturnType<typeof externalTokenQueryKey>;
+
+// Helpers
+const formatExternalAsset = (
+  address: string,
+  chainId: ChainId,
+  asset: ExternalToken,
+  nativeCurrency: SupportedCurrencyKey,
+): ParsedAsset => {
+  return {
+    ...asset,
+    chainId,
+    chainName: chainIdToNameMapping[chainId],
+    uniqueId: `${address}_${chainId}`,
+    address: address as Address,
+    isNativeAsset: isNativeAsset(address as AddressOrEth, chainId),
+    native: {
+      price: {
+        change: asset?.price?.relativeChange24h
+          ? convertAmountToPercentageDisplay(
+              `${asset?.price?.relativeChange24h}`,
+            )
+          : '',
+        amount: asset?.price?.value ?? 0,
+        display: convertAmountAndPriceToNativeDisplay(
+          1,
+          asset?.price?.value ?? 0,
+          nativeCurrency,
+        ).display,
+      },
+    },
+    price: {
+      value: asset?.price?.value ?? 0,
+      relative_change_24h: asset?.price?.relativeChange24h ?? 0,
+    },
+    icon_url: asset?.iconUrl || undefined,
+  };
+};
+
+// Query Function for Token Price
+export async function fetchExternalToken({
+  address,
+  chainId,
+  currency,
+}: ExternalTokenArgs) {
+  const response = await metadataClient.externalToken({
+    address,
+    chainId,
+    currency,
+  });
+  if (response?.token) {
+    return formatExternalAsset(address, chainId, response.token, currency);
+  } else {
+    return null;
+  }
+}
+
+export async function externalTokenQueryFunction({
+  queryKey: [{ address, chainId, currency }],
+}: QueryFunctionArgs<
+  typeof externalTokenQueryKey
+>): Promise<ParsedAsset | null> {
+  if (!address || !chainId) return null;
+  return fetchExternalToken({ address, chainId, currency });
+}
+
+export type ExternalTokenQueryFunctionResult = QueryFunctionResult<
+  typeof externalTokenQueryFunction
+>;
+
+// Prefetch function for Token Price
+export async function prefetchExternalToken({
+  address,
+  chainId,
+  currency,
+}: ExternalTokenArgs) {
+  await queryClient.prefetchQuery({
+    queryKey: externalTokenQueryKey({ address, chainId, currency }),
+    queryFn: externalTokenQueryFunction,
+    staleTime: EXTERNAL_TOKEN_STALE_TIME,
+    gcTime: EXTERNAL_TOKEN_CACHE_TIME,
+  });
+}
+
+// Query Hook for Token Price
+export function useExternalToken(
+  { address, chainId, currency }: ExternalTokenArgs,
+  config: QueryConfig<
+    ExternalTokenQueryFunctionResult,
+    Error,
+    ParsedUserAsset,
+    externalTokenQueryKey
+  > = {},
+) {
+  return useQuery({
+    queryKey: externalTokenQueryKey({ address, chainId, currency }),
+    queryFn: externalTokenQueryFunction,
+    staleTime: EXTERNAL_TOKEN_STALE_TIME,
+    gcTime: EXTERNAL_TOKEN_CACHE_TIME,
+    enabled: !!address && !!chainId,
+    ...config,
+  });
+}

--- a/src/core/resources/assets/externalToken.ts
+++ b/src/core/resources/assets/externalToken.ts
@@ -8,7 +8,6 @@ import {
   QueryFunctionArgs,
   QueryFunctionResult,
   createQueryKey,
-  queryClient,
 } from '~/core/react-query';
 import { SupportedCurrencyKey } from '~/core/references';
 import { AddressOrEth, ParsedAsset } from '~/core/types/assets';
@@ -116,20 +115,6 @@ export async function externalTokenQueryFunction({
 export type ExternalTokenQueryFunctionResult = QueryFunctionResult<
   typeof externalTokenQueryFunction
 >;
-
-// Prefetch function for Token Price
-export async function prefetchExternalToken({
-  address,
-  chainId,
-  currency,
-}: ExternalTokenArgs) {
-  await queryClient.prefetchQuery({
-    queryKey: externalTokenQueryKey({ address, chainId, currency }),
-    queryFn: externalTokenQueryFunction,
-    staleTime: EXTERNAL_TOKEN_STALE_TIME,
-    gcTime: EXTERNAL_TOKEN_CACHE_TIME,
-  });
-}
 
 // Query Hook for Token Price
 export function useExternalToken(

--- a/src/core/resources/assets/externalToken.ts
+++ b/src/core/resources/assets/externalToken.ts
@@ -22,35 +22,11 @@ import {
 export const EXTERNAL_TOKEN_CACHE_TIME = 1000 * 60 * 60 * 24; // 24 hours
 export const EXTERNAL_TOKEN_STALE_TIME = 1000 * 60; // 1 minute
 
-// need to keep these queried tokens up to date
-//   ETH_ADDRESS,
-// MATIC_MAINNET_ADDRESS,
-// BNB_MAINNET_ADDRESS,
-// OP_ADDRESS
-
 // Types
 type ExternalToken = Pick<
   Token,
   'decimals' | 'iconUrl' | 'name' | 'networks' | 'symbol' | 'price'
 >;
-// export type FormattedExternalAsset = ExternalToken & {
-//   address: string;
-//   icon_url?: string;
-//   isNativeAsset: boolean;
-//   native: {
-//     change: string;
-//     price: {
-//       amount: string;
-//       display: string;
-//     };
-//   };
-//   networks?: {
-//     [chainId in ChainId]?: {
-//       address: chainId extends ChainId.mainnet ? AddressOrEth : Address;
-//       decimals: number;
-//     };
-//   };
-// };
 
 // Query Types for External Token
 type ExternalTokenArgs = {

--- a/src/core/resources/assets/userTestnetNativeAsset.ts
+++ b/src/core/resources/assets/userTestnetNativeAsset.ts
@@ -113,7 +113,7 @@ export function useUserTestnetNativeAsset(
   config: QueryConfig<
     UserAssetsResult,
     Error,
-    UserAssetsResult,
+    ParsedUserAsset,
     UserTestnetNativeAssetQueryKey
   > = {},
 ) {

--- a/src/entries/popup/hooks/send/useSendValidations.ts
+++ b/src/entries/popup/hooks/send/useSendValidations.ts
@@ -17,7 +17,7 @@ import {
 } from '~/core/utils/numbers';
 import { getProvider } from '~/core/wagmi/clientToProvider';
 
-import { useNativeAsset } from '../useNativeAsset';
+import { useUserNativeAsset } from '../useUserNativeAsset';
 
 export const useSendValidations = ({
   asset,
@@ -45,7 +45,7 @@ export const useSendValidations = ({
     }
     return ChainId.mainnet;
   };
-  const { nativeAsset } = useNativeAsset({
+  const { nativeAsset } = useUserNativeAsset({
     chainId: getNativeAssetChainId(),
   });
 

--- a/src/entries/popup/hooks/swap/useSwapReviewDetails.ts
+++ b/src/entries/popup/hooks/swap/useSwapReviewDetails.ts
@@ -13,7 +13,7 @@ import {
   multiply,
 } from '~/core/utils/numbers';
 
-import { useNativeAssetForNetwork } from '../useNativeAssetForNetwork';
+import { useNativeAsset } from '../useNativeAsset';
 
 const getExchangeIconUrl = (protocol: string): string | null => {
   if (!protocol) return null;
@@ -46,7 +46,7 @@ export const useSwapReviewDetails = ({
   quote: Quote | CrosschainQuote;
 }) => {
   const { currentCurrency } = useCurrentCurrencyStore();
-  const nativeAsset = useNativeAssetForNetwork({
+  const nativeAsset = useNativeAsset({
     chainId: assetToSell.chainId,
   });
 

--- a/src/entries/popup/hooks/swap/useSwapValidations.ts
+++ b/src/entries/popup/hooks/swap/useSwapValidations.ts
@@ -26,7 +26,7 @@ export const useSwapValidations = ({
   selectedGas?: GasFeeParams | GasFeeLegacyParams;
 }) => {
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
-    chainId: assetToSell?.chainId || ChainId.mainnet,
+    chainId: assetToSell?.chainId,
   });
   const { data: userNativeAsset } = useUserAsset(nativeAssetUniqueId || '');
 

--- a/src/entries/popup/hooks/useGas.ts
+++ b/src/entries/popup/hooks/useGas.ts
@@ -36,8 +36,8 @@ import {
 } from '~/core/utils/gas';
 
 import { useDebounce } from './useDebounce';
-import { useNativeAsset } from './useNativeAsset';
 import usePrevious from './usePrevious';
+import { useUserNativeAsset } from './useUserNativeAsset';
 
 const useGas = ({
   chainId,
@@ -60,7 +60,7 @@ const useGas = ({
 }) => {
   const { currentCurrency } = useCurrentCurrencyStore();
   const { data: gasData, isLoading } = useGasData({ chainId });
-  const { nativeAsset } = useNativeAsset({ chainId, address });
+  const { nativeAsset } = useUserNativeAsset({ chainId, address });
   const prevDefaultSpeed = usePrevious(defaultSpeed);
 
   const [internalMaxPriorityFee, setInternalMaxPriorityFee] = useState('');

--- a/src/entries/popup/hooks/useNativeAsset.ts
+++ b/src/entries/popup/hooks/useNativeAsset.ts
@@ -1,0 +1,32 @@
+import { ETH_ADDRESS } from '~/core/references';
+import { chainsNativeAsset } from '~/core/references/chains';
+import {
+  fetchExternalToken,
+  useExternalToken,
+} from '~/core/resources/assets/externalToken';
+import { currentCurrencyStore, useCurrentCurrencyStore } from '~/core/state';
+import { AddressOrEth } from '~/core/types/assets';
+import { ChainId } from '~/core/types/chains';
+
+export const useNativeAsset = ({ chainId }: { chainId: ChainId }) => {
+  const address = (chainsNativeAsset[chainId] || ETH_ADDRESS) as AddressOrEth;
+  const { currentCurrency } = useCurrentCurrencyStore();
+
+  const { data: nativeAsset } = useExternalToken({
+    address,
+    chainId,
+    currency: currentCurrency,
+  });
+
+  return nativeAsset;
+};
+
+export const fetchNativeAsset = async ({ chainId }: { chainId: ChainId }) => {
+  const currentCurrency = currentCurrencyStore.getState().currentCurrency;
+  const address = (chainsNativeAsset[chainId] || ETH_ADDRESS) as AddressOrEth;
+  return await fetchExternalToken({
+    address,
+    chainId,
+    currency: currentCurrency,
+  });
+};

--- a/src/entries/popup/hooks/useNativeAssetForNetwork.ts
+++ b/src/entries/popup/hooks/useNativeAssetForNetwork.ts
@@ -1,91 +1,9 @@
-import { Address } from 'viem';
-
 import { chainsNativeAsset } from '~/core/references/chains';
-import { ParsedAsset, UniqueId } from '~/core/types/assets';
-import { ChainId, ChainName, chainIdToNameMapping } from '~/core/types/chains';
-
-import { getNativeAssets, useNativeAssets } from './useNativeAssets';
-
-export const getNetworkNativeAssetChainId = ({
-  chainId,
-}: {
-  chainId: ChainId;
-}):
-  | ChainId.mainnet
-  | ChainId.polygon
-  | ChainId.avalanche
-  | ChainId.degen
-  | ChainId.bsc => {
-  switch (chainId) {
-    case ChainId.avalanche:
-      return ChainId.avalanche;
-    case ChainId.bsc:
-      return ChainId.bsc;
-    case ChainId.polygon:
-      return ChainId.polygon;
-    case ChainId.degen:
-      return ChainId.degen;
-    case ChainId.arbitrum:
-    case ChainId.mainnet:
-    case ChainId.optimism:
-    case ChainId.base:
-    case ChainId.zora:
-    case ChainId.blast:
-    default:
-      return ChainId.mainnet;
-  }
-};
+import { UniqueId } from '~/core/types/assets';
+import { ChainId } from '~/core/types/chains';
 
 export const getNetworkNativeAssetUniqueId = ({
-  chainId,
+  chainId = ChainId.mainnet,
 }: {
-  chainId: ChainId;
+  chainId?: ChainId;
 }): UniqueId => `${chainsNativeAsset[chainId]}_${chainId}` as UniqueId;
-
-export async function getNativeAssetForNetwork({
-  chainId,
-}: {
-  chainId: ChainId;
-}) {
-  const nativeAssets = await getNativeAssets();
-  const nativeAssetMetadataChainId = getNetworkNativeAssetChainId({ chainId });
-  const nativeAsset = nativeAssets?.[nativeAssetMetadataChainId];
-  if (nativeAsset) {
-    return {
-      ...nativeAsset,
-      chainId: chainId || nativeAsset?.chainId || ChainId.mainnet,
-      chainName:
-        chainIdToNameMapping[chainId] ||
-        nativeAsset?.chainName ||
-        ChainName.mainnet,
-      uniqueId: getNetworkNativeAssetUniqueId({ chainId }),
-      address: chainsNativeAsset[chainId] as Address,
-      isNativeAsset: true,
-    };
-  }
-  return undefined;
-}
-
-export function useNativeAssetForNetwork({
-  chainId,
-}: {
-  chainId: ChainId;
-}): ParsedAsset | undefined {
-  const nativeAssets = useNativeAssets();
-  const nativeAssetMetadataChainId = getNetworkNativeAssetChainId({ chainId });
-  const nativeAsset = nativeAssets?.[nativeAssetMetadataChainId];
-  if (nativeAsset) {
-    return {
-      ...nativeAsset,
-      chainId: chainId || nativeAsset?.chainId || ChainId.mainnet,
-      chainName:
-        chainIdToNameMapping[chainId] ||
-        nativeAsset?.chainName ||
-        ChainName.mainnet,
-      uniqueId: getNetworkNativeAssetUniqueId({ chainId }),
-      address: chainsNativeAsset[chainId] as Address,
-      isNativeAsset: true,
-    };
-  }
-  return undefined;
-}

--- a/src/entries/popup/hooks/useUserNativeAsset.ts
+++ b/src/entries/popup/hooks/useUserNativeAsset.ts
@@ -5,38 +5,12 @@ import { useConfig } from 'wagmi';
 import { useUserTestnetNativeAsset } from '~/core/resources/assets/userTestnetNativeAsset';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { ParsedUserAsset } from '~/core/types/assets';
-import { ChainId, chainIdToNameMapping } from '~/core/types/chains';
+import { ChainId } from '~/core/types/chains';
 import { isCustomChain } from '~/core/utils/chains';
 
 import { useCustomNetworkAsset } from './useCustomNetworkAsset';
-import {
-  getNetworkNativeAssetChainId,
-  getNetworkNativeAssetUniqueId,
-} from './useNativeAssetForNetwork';
-import { useNativeAssets } from './useNativeAssets';
+import { getNetworkNativeAssetUniqueId } from './useNativeAssetForNetwork';
 import { useUserAsset } from './useUserAsset';
-
-const useMockNativeAsset = ({
-  chainId,
-}: {
-  chainId: ChainId;
-}): ParsedUserAsset | undefined | null => {
-  const nativeAssets = useNativeAssets();
-  const { chains } = useConfig();
-  const chain = chains.find((c) => c.id === chainId);
-  if (!nativeAssets || !chain) return null;
-  const nativeAssetMetadataChainId = getNetworkNativeAssetChainId({ chainId });
-  const nativeAsset = nativeAssets?.[nativeAssetMetadataChainId];
-  return {
-    ...nativeAsset,
-    chainId: chain.id,
-    chainName: chainIdToNameMapping[chain.id],
-    native: {
-      balance: { amount: '0', display: `0 ${nativeAsset?.symbol}` },
-    },
-    balance: { amount: '0', display: `0 ${nativeAsset?.symbol}` },
-  };
-};
 
 export const useUserNativeAsset = ({
   address,
@@ -49,13 +23,12 @@ export const useUserNativeAsset = ({
   const { currentCurrency } = useCurrentCurrencyStore();
   const { chains } = useConfig();
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
-    chainId: chainId || ChainId.mainnet,
+    chainId,
   });
   const { data: userNativeAsset } = useUserAsset(
     nativeAssetUniqueId || '',
     address || currentAddress,
   );
-  const mockNativeAsset = useMockNativeAsset({ chainId });
 
   const { data: testnetNativeAsset } = useUserTestnetNativeAsset({
     address: address || currentAddress,
@@ -78,7 +51,7 @@ export const useUserNativeAsset = ({
   } else if (chain?.testnet) {
     nativeAsset = testnetNativeAsset;
   } else {
-    nativeAsset = userNativeAsset || mockNativeAsset;
+    nativeAsset = userNativeAsset;
   }
   return { nativeAsset };
 };

--- a/src/entries/popup/hooks/useUserNativeAsset.ts
+++ b/src/entries/popup/hooks/useUserNativeAsset.ts
@@ -38,7 +38,7 @@ const useMockNativeAsset = ({
   };
 };
 
-export const useNativeAsset = ({
+export const useUserNativeAsset = ({
   address,
   chainId,
 }: {

--- a/src/entries/popup/pages/home/Points/ClaimSheet.tsx
+++ b/src/entries/popup/pages/home/Points/ClaimSheet.tsx
@@ -30,7 +30,7 @@ import { BottomSheet } from '~/design-system/components/BottomSheet/BottomSheet'
 import { rowTransparentAccentHighlight } from '~/design-system/styles/rowTransparentAccentHighlight.css';
 import { ChainBadge } from '~/entries/popup/components/ChainBadge/ChainBadge';
 import { useSwapGas } from '~/entries/popup/hooks/useGas';
-import { useNativeAssetForNetwork } from '~/entries/popup/hooks/useNativeAssetForNetwork';
+import { useNativeAsset } from '~/entries/popup/hooks/useNativeAsset';
 import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
 import { ROUTES } from '~/entries/popup/urls';
 import { zIndexes } from '~/entries/popup/utils/zIndexes';
@@ -70,9 +70,9 @@ export function ClaimSheet() {
   const rewards = data?.user?.rewards;
   const { claimable } = rewards || {};
 
-  const opEth = useNativeAssetForNetwork({ chainId: ChainId.optimism });
+  const opEth = useNativeAsset({ chainId: ChainId.optimism });
   const ethPrice = opEth?.native?.price?.amount;
-  const destinationEth = useNativeAssetForNetwork({ chainId: selectedChainId });
+  const destinationEth = useNativeAsset({ chainId: selectedChainId });
 
   const claimableBalance = convertRawAmountToBalance(claimable || '0', {
     decimals: 18,

--- a/src/entries/popup/pages/home/Points/PointsDashboard.tsx
+++ b/src/entries/popup/pages/home/Points/PointsDashboard.tsx
@@ -57,8 +57,8 @@ import {
 import { AddressOrEns } from '~/entries/popup/components/AddressOrEns/AddressorEns';
 import ExternalImage from '~/entries/popup/components/ExternalImage/ExternalImage';
 import { WalletAvatar } from '~/entries/popup/components/WalletAvatar/WalletAvatar';
-import { useNativeAsset } from '~/entries/popup/hooks/useNativeAsset';
 import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
+import { useUserNativeAsset } from '~/entries/popup/hooks/useUserNativeAsset';
 import { ROUTES } from '~/entries/popup/urls';
 
 import { AirdropIcon } from './AirdropIcon';
@@ -705,7 +705,7 @@ function ClaimYourPoints({
   claimableReward?: string;
   showClaimSheet: () => void;
 }) {
-  const eth = useNativeAsset({ chainId: ChainId.mainnet });
+  const eth = useUserNativeAsset({ chainId: ChainId.mainnet });
   const ethPrice = eth?.nativeAsset?.price?.value;
   const { currentCurrency: currency } = useCurrentCurrencyStore();
   if (!claimableReward || claimableReward === '0' || !ethPrice) return null;
@@ -963,7 +963,7 @@ function RainbowUserEarnings({ totalEarnings }: { totalEarnings: string }) {
 }
 
 function MyEarnings({ earnings = '0' }: { earnings?: string }) {
-  const eth = useNativeAsset({ chainId: ChainId.mainnet });
+  const eth = useUserNativeAsset({ chainId: ChainId.mainnet });
   const ethPrice = eth?.nativeAsset?.price?.value;
   const { currentCurrency: currency } = useCurrentCurrencyStore();
 

--- a/src/entries/popup/pages/messages/AccountSigningWith.tsx
+++ b/src/entries/popup/pages/messages/AccountSigningWith.tsx
@@ -6,7 +6,7 @@ import { Inline, Stack, Text } from '~/design-system';
 import { ChainBadge } from '~/entries/popup/components/ChainBadge/ChainBadge';
 import { WalletAvatar } from '~/entries/popup/components/WalletAvatar/WalletAvatar';
 
-import { useNativeAsset } from '../../hooks/useNativeAsset';
+import { useUserNativeAsset } from '../../hooks/useUserNativeAsset';
 
 import { WalletName } from './BottomActions';
 import { useHasEnoughGas } from './useHasEnoughGas';
@@ -20,7 +20,7 @@ export interface SelectedNetwork {
 function WalletNativeBalance({ session }: { session: ActiveSession }) {
   const chainId = session?.chainId || ChainId.mainnet;
   const chainName = getChain({ chainId }).name;
-  const { nativeAsset } = useNativeAsset({
+  const { nativeAsset } = useUserNativeAsset({
     chainId,
     address: session?.address,
   });

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -35,8 +35,8 @@ import { DappIcon } from '~/entries/popup/components/DappIcon/DappIcon';
 import { Tag } from '~/entries/popup/components/Tag';
 import { triggerToast } from '~/entries/popup/components/Toast/Toast';
 import { useAppSession } from '~/entries/popup/hooks/useAppSession';
-import { useNativeAsset } from '~/entries/popup/hooks/useNativeAsset';
 import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
+import { useUserNativeAsset } from '~/entries/popup/hooks/useUserNativeAsset';
 import { ROUTES } from '~/entries/popup/urls';
 
 import {
@@ -382,7 +382,7 @@ function InsuficientGasFunds({
   const { testnetMode } = useTestnetModeStore();
   const isTestnet = testnetMode || getChain({ chainId }).testnet;
 
-  const { nativeAsset } = useNativeAsset({ chainId, address });
+  const { nativeAsset } = useUserNativeAsset({ chainId, address });
   const chainName = getChain({ chainId }).name;
 
   const { currentCurrency } = useCurrentCurrencyStore();

--- a/src/entries/popup/pages/messages/useHasEnoughGas.ts
+++ b/src/entries/popup/pages/messages/useHasEnoughGas.ts
@@ -4,12 +4,12 @@ import { ChainId } from '~/core/types/chains';
 import { toWei } from '~/core/utils/ethereum';
 import { lessThan } from '~/core/utils/numbers';
 
-import { useNativeAsset } from '../../hooks/useNativeAsset';
+import { useUserNativeAsset } from '../../hooks/useUserNativeAsset';
 
 export const useHasEnoughGas = (session: ActiveSession) => {
   const chainId = session?.chainId || ChainId.mainnet;
 
-  const { nativeAsset } = useNativeAsset({
+  const { nativeAsset } = useUserNativeAsset({
     address: session?.address,
     chainId,
   });

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
@@ -220,7 +220,7 @@ const SwapReviewSheetWithQuote = ({
   const isHardwareWallet = type === KeychainType.HardwareWalletKeychain;
 
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
-    chainId: assetToSell?.chainId || ChainId.mainnet,
+    chainId: assetToSell?.chainId,
   });
   const { data: nativeAsset } = useUserAsset(nativeAssetUniqueId || '');
 


### PR DESCRIPTION
Fixes BX-1635
Figma link (if any):

using metadata external token query to get native assets for all chains as described in ticket


now we have two different hooks for this:


- useNativeAsset:  that will give you a ParsedAsset object, that contains the price of the asset for stuff like tx fees
- useUserNativeAsset: that will give you a ParsedUserAsset object, that contains the wallet's balance

## What changed (plus any additional context for devs)

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
