### PR TITLE
fix: weth unwrap swap review undefined

### DIFF
--- a/src/entries/popup/hooks/swap/useSwapReviewDetails.ts
+++ b/src/entries/popup/hooks/swap/useSwapReviewDetails.ts
@@ -102,12 +102,12 @@ export const useSwapReviewDetails = ({
 
   const exchangeRate = useMemo(() => {
     const convertedSellAmount = convertRawAmountToDecimalFormat(
-      quote.sellAmountDisplay.toString(),
+      quote.sellAmountDisplay?.toString(),
       assetToSell.decimals,
     );
 
     const convertedBuyAmount = convertRawAmountToDecimalFormat(
-      quote.buyAmountDisplay.toString(),
+      quote.buyAmountDisplay?.toString(),
       assetToBuy.decimals,
     );
 


### PR DESCRIPTION
Fixes BX-1647
Figma link (if any):

## What changed (plus any additional context for devs)
- `sellAmountDisplay` and `buyAmountDisplay` could be undefined for `WETH` unwrap quotes

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

- Tested both Optimism WETH -> ETH and Degen Chain WDEGEN to DEGEN

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
