### PR TITLE
fix chain migrations

### DIFF
--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -1184,8 +1184,13 @@
         "define": true
       },
       "packages": {
-        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/generator>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {

--- a/src/core/state/rainbowChains/index.ts
+++ b/src/core/state/rainbowChains/index.ts
@@ -122,7 +122,7 @@ export const rainbowChainsStore = createStore<RainbowChainsState>(
   {
     persist: persistOptions({
       name: 'rainbowChains',
-      version: 9,
+      version: 10,
       migrations: [
         // v1 didn't need a migration
         function v1(s: RainbowChainsState) {
@@ -131,55 +131,73 @@ export const rainbowChainsStore = createStore<RainbowChainsState>(
 
         // version 2 added support for Avalanche and Avalanche Fuji
         function v2(state) {
-          return mergeNewOfficiallySupportedChainsState(state, [
+          const rnbwChainState = state as RainbowChainsState;
+          return mergeNewOfficiallySupportedChainsState(rnbwChainState, [
             ChainId.avalanche,
             ChainId.avalancheFuji,
           ]);
         },
 
         // version 3 added support for Blast
-        function v3(state) {
-          return mergeNewOfficiallySupportedChainsState(state, [ChainId.blast]);
+        function v3(state: unknown) {
+          const rnbwChainState = state as RainbowChainsState;
+          return mergeNewOfficiallySupportedChainsState(rnbwChainState, [
+            ChainId.blast,
+          ]);
         },
 
-        function v4(state) {
+        function v4(state: unknown) {
+          const rnbwChainState = state as RainbowChainsState;
           return removeCustomRPC({
-            state,
+            state: rnbwChainState,
             rpcUrl: 'https://rpc.zora.co',
-            rainbowChains: state.rainbowChains,
+            rainbowChains: rnbwChainState.rainbowChains,
           });
         },
 
         // version 5 added support for Degen
-        function v5(state) {
-          return mergeNewOfficiallySupportedChainsState(state, [ChainId.degen]);
+        function v5(state: unknown) {
+          const rnbwChainState = state as RainbowChainsState;
+          return mergeNewOfficiallySupportedChainsState(rnbwChainState, [
+            ChainId.degen,
+          ]);
         },
 
-        function v6(state) {
+        function v6(state: unknown) {
+          const rnbwChainState = state as RainbowChainsState;
           if (
-            !state.rainbowChains[zora.id] ||
-            state.rainbowChains[zora.id]?.chains.length === 0
+            !rnbwChainState.rainbowChains[zora.id] ||
+            rnbwChainState.rainbowChains[zora.id]?.chains.length === 0
           ) {
-            return addCustomRPC({ chain: zora, state });
+            return addCustomRPC({ chain: zora, state: rnbwChainState });
           }
           return state;
         },
 
-        function v7(state) {
+        function v7(state: unknown) {
           return state;
         },
 
-        function v8(state) {
+        function v8(state: unknown) {
+          const rnbwChainState = state as RainbowChainsState;
           if (
-            !state.rainbowChains[degen.id] ||
-            state.rainbowChains[degen.id]?.chains.length === 0
+            !rnbwChainState.rainbowChains[degen.id] ||
+            rnbwChainState.rainbowChains[degen.id]?.chains.length === 0
           ) {
-            return addCustomRPC({ chain: degen, state });
+            return addCustomRPC({
+              chain: degen,
+              state: state as RainbowChainsState,
+            });
           }
           return state;
         },
-        function v9(state) {
-          return replaceChainsWithInitial(state);
+        function v9(state: unknown) {
+          return replaceChainsWithInitial(state as RainbowChainsState);
+        },
+        function v10(state: unknown) {
+          const rnbwState = state as RainbowChainsState;
+          rnbwState.rainbowChains = getInitialRainbowChains();
+          return rnbwState;
         },
       ],
     }),

--- a/src/core/state/userChains/index.ts
+++ b/src/core/state/userChains/index.ts
@@ -110,7 +110,7 @@ export const userChainsStore = createStore<UserChainsState>(
   {
     persist: {
       name: 'userChains',
-      version: 4,
+      version: 5,
     },
   },
 );

--- a/src/core/utils/persistOptions.ts
+++ b/src/core/utils/persistOptions.ts
@@ -88,6 +88,23 @@ interface PersistOptionsWithMigrations {
       ]
     >,
   ): R<Final>;
+  <Final, A, B, C, D, E, F, G, H, I>(
+    opts: Opts<
+      Final,
+      [
+        (s: any) => A,
+        (s: A) => B,
+        (s: B) => C,
+        (s: C) => D,
+        (s: D) => E,
+        (s: E) => F,
+        (s: F) => G,
+        (s: G) => H,
+        (s: H) => I,
+        (s: I) => Final,
+      ]
+    >,
+  ): R<Final>;
 
   // if you need more migrations, add more overloads here
 }

--- a/src/entries/popup/hooks/useRainbowChains.ts
+++ b/src/entries/popup/hooks/useRainbowChains.ts
@@ -4,20 +4,17 @@ import { useRainbowChainsStore } from '~/core/state';
 
 export const useRainbowChains = () => {
   const rainbowChains = useRainbowChainsStore.use.rainbowChains();
-  const chains = useMemo(
-    () =>
-      Object.values(rainbowChains)
-        .map((rainbowChain) =>
-          rainbowChain.chains.find(
-            (chain) =>
-              chain.rpcUrls.default.http[0] === rainbowChain.activeRpcUrl,
-          ),
-        )
-        .filter(Boolean),
-    [rainbowChains],
-  );
 
-  return {
-    rainbowChains: chains,
-  };
+  const chains = useMemo(() => {
+    return Object.values(rainbowChains)
+      .map((rainbowChain) =>
+        rainbowChain.chains.find(
+          (chain) =>
+            chain.rpcUrls.default.http[0] === rainbowChain.activeRpcUrl,
+        ),
+      )
+      .filter(Boolean);
+  }, [rainbowChains]);
+
+  return { rainbowChains: chains };
 };


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

Couple of issues are happening right now

For state userChains we could update `version` to `SUPPORTED_CHAINS.length` so if there's a new change we don't have to update the version number manually and zustand migrates automatically.

This works in `state/userChains` but it doesn't in `state/rainbowChains` because we're using `persistOptions` that doesn't allow this.

`persistOptions` needs to manually pass a new migration function on every version bump which is not ideal and is causing additional issues for this case in particular: if `rainbowChains` updates with a new chain, the migration doesn't pick it automatically, I had to add 

```
function v10(state: unknown) {
          const rnbwState = state as RainbowChainsState;
          rnbwState.rainbowChains = getInitialRainbowChains();
          return rnbwState;
        },
```

which is manually adding the new chains, we need another way to handle this state bumps automatically


## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
