### PR TITLE
e2e swap fixes, bump chromedriver

### DIFF
--- a/.github/actions/chromeTestsSetup/action.yml
+++ b/.github/actions/chromeTestsSetup/action.yml
@@ -12,4 +12,4 @@ runs:
       gh-access-token: ${{ inputs.gh-access-token }}
   - name: Install chrome
     shell: 'bash'
-    run: npx @puppeteer/browsers install chrome@128
+    run: npx @puppeteer/browsers install chrome@130

--- a/e2e/serial/swap/1_swapFlow1.test.ts
+++ b/e2e/serial/swap/1_swapFlow1.test.ts
@@ -108,6 +108,11 @@ it('should be able to connect to hardhat', async () => {
   const button = await findElementByText(driver, 'Disconnect from Hardhat');
   expect(button).toBeTruthy();
   await findElementByTestIdAndClick({ id: 'navbar-button-with-back', driver });
+
+  // sometimes hardhat balances take time to display.
+  // If we go straight to swap and they aren't updated,
+  // the swap gets auto-populated with the wrong token.
+  await delay(10_000);
 });
 
 it('should be able to go to swap flow', async () => {
@@ -591,6 +596,7 @@ it('should be able to filter assets to buy by network', async () => {
     driver,
     text: 'op',
   });
+  await delayTime('medium');
   await findElementByTestIdAndClick({
     id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-favorites-token-to-buy-row`,
     driver,
@@ -613,6 +619,7 @@ it('should be able to filter assets to buy by network', async () => {
     driver,
     text: 'pol',
   });
+  await delayTime('medium');
   await findElementByTestIdAndClick({
     id: `${SWAP_VARIABLES.POL_POLYGON_ID}-favorites-token-to-buy-row`,
     driver,
@@ -635,10 +642,23 @@ it('should be able to filter assets to buy by network', async () => {
     driver,
     text: 'gmx',
   });
-  await findElementByTestIdAndClick({
-    id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-verified-token-to-buy-row`,
-    driver,
-  });
+  await delayTime('medium');
+
+  // this token is occassionally included in 'popular in rainbow.'
+  // tokens are only set to appear in one section at a time, so if
+  // it is in that section, the test will fail without this try / catch.
+  try {
+    await findElementByTestIdAndClick({
+      id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-verified-token-to-buy-row`,
+      driver,
+    });
+  } catch {
+    await findElementByTestIdAndClick({
+      id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-popular-token-to-buy-row-active-element-item`,
+      driver,
+    });
+  }
+
   // BNB
   await findElementByTestIdAndClick({
     id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-token-to-buy-token-input-remove`,
@@ -657,6 +677,7 @@ it('should be able to filter assets to buy by network', async () => {
     driver,
     text: 'uni',
   });
+  await delayTime('medium');
   await findElementByTestIdAndClick({
     id: `${SWAP_VARIABLES.UNI_BNB_ID}-verified-token-to-buy-row`,
     driver,
@@ -709,10 +730,21 @@ it('should be able to see no route explainer', async () => {
     text: 'gmx',
   });
   await delayTime('long');
-  await findElementByTestIdAndClick({
-    id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-verified-token-to-buy-row`,
-    driver,
-  });
+
+  // this token is occassionally included in 'popular in rainbow.'
+  // tokens are only set to appear in one section at a time, so if
+  // it is in that section, the test will fail without this try / catch.
+  try {
+    await findElementByTestIdAndClick({
+      id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-verified-token-to-buy-row`,
+      driver,
+    });
+  } catch {
+    await findElementByTestIdAndClick({
+      id: `${SWAP_VARIABLES.GMX_ARBITRUM_ID}-popular-token-to-buy-row-active-element-item`,
+      driver,
+    });
+  }
   await typeOnTextInput({
     id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-token-to-sell-swap-token-input-swap-input-mask`,
     driver,
@@ -764,27 +796,25 @@ it('should be able to find exact match on other networks', async () => {
     id: `switch-network-item-${ChainId.polygon}`,
     driver,
   });
-  // UNCOMMENT ONCE #1732 GETS MERGED
+  await typeOnTextInput({
+    id: 'token-to-buy-search-token-input',
+    driver,
+    text: 'optimism',
+  });
+  const onOtherNetworksSections = await findElementByTestId({
+    id: 'other_networks-token-to-buy-section',
+    driver,
+  });
+  expect(onOtherNetworksSections).toBeTruthy();
 
-  // await typeOnTextInput({
-  //   id: 'token-to-buy-search-token-input',
-  //   driver,
-  //   text: 'optimism',
-  // });
-  // const onOtherNetworksSections = await findElementByTestId({
-  //   id: 'other_networks-token-to-buy-section',
-  //   driver,
-  // });
-  // expect(onOtherNetworksSections).toBeTruthy();
-
-  // await findElementByTestIdAndClick({
-  //   id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-other_networks-token-to-buy-row`,
-  //   driver,
-  // });
-  // await findElementByTestIdAndClick({
-  //   id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-token-to-buy-token-input-remove`,
-  //   driver,
-  // });
+  await findElementByTestIdAndClick({
+    id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-other_networks-token-to-buy-row`,
+    driver,
+  });
+  await findElementByTestIdAndClick({
+    id: `${SWAP_VARIABLES.OP_OPTIMISM_ID}-token-to-buy-token-input-remove`,
+    driver,
+  });
   await findElementByTestIdAndClick({
     id: 'token-to-buy-search-token-input',
     driver,

--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -12,7 +12,7 @@
     "@testing-library/react>@testing-library/dom>@babel/code-frame>@babel/highlight": {
       "packages": {
         "@testing-library/react>@testing-library/dom>@babel/code-frame>@babel/highlight>chalk": true,
-        "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
         "react>loose-envify>js-tokens": true
       }
     },
@@ -617,7 +617,7 @@
         "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/template": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse": true,
         "jest>@jest/core>jest-snapshot>@babel/types": true,
-        "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
       }
     },
     "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": {
@@ -1143,7 +1143,7 @@
       },
       "packages": {
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true,
-        "lavamoat>@babel/highlight": true
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": {
@@ -1213,36 +1213,36 @@
       },
       "packages": {
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-string-parser": true,
-        "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
         "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
       }
     },
-    "lavamoat>@babel/highlight": {
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": {
       "packages": {
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
-        "lavamoat>@babel/highlight>chalk": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": true,
         "react>loose-envify>js-tokens": true
       }
     },
-    "lavamoat>@babel/highlight>chalk": {
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": {
       "globals": {
         "process.env.TERM": true,
         "process.platform": true
       },
       "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles": true,
-        "lavamoat>@babel/highlight>chalk>escape-string-regexp": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
         "supports-color": true
       }
     },
-    "lavamoat>@babel/highlight>chalk>ansi-styles": {
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
       "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": true
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": true
       }
     },
-    "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": {
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": {
       "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
       }
     },
     "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
@@ -1264,7 +1264,7 @@
         "process.emitWarning": true
       },
       "packages": {
-        "lavamoat>@babel/highlight": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": true,
         "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
       }
     },

--- a/lavamoat/build-webpack/policy.json
+++ b/lavamoat/build-webpack/policy.json
@@ -12,7 +12,7 @@
     "@testing-library/react>@testing-library/dom>@babel/code-frame>@babel/highlight": {
       "packages": {
         "@testing-library/react>@testing-library/dom>@babel/code-frame>@babel/highlight>chalk": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
         "react>loose-envify>js-tokens": true
       }
     },
@@ -614,10 +614,10 @@
         "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": true,
         "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": true,
         "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-split-export-declaration": true,
+        "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-validator-identifier": true,
         "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/template": true,
         "jest>@jest/core>jest-snapshot>@babel/traverse": true,
-        "jest>@jest/core>jest-snapshot>@babel/types": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
+        "jest>@jest/core>jest-snapshot>@babel/types": true
       }
     },
     "eslint-config-rainbow>eslint-import-resolver-babel-module>@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": {
@@ -1142,8 +1142,15 @@
         "process.emitWarning": true
       },
       "packages": {
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": true,
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true
+      }
+    },
+    "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>@babel/highlight": {
+      "packages": {
         "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": true
+        "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/types>@babel/helper-validator-identifier": true,
+        "react>loose-envify>js-tokens": true
       }
     },
     "jest>@jest/core>jest-snapshot>@babel/traverse>@babel/code-frame>chalk": {
@@ -1213,36 +1220,8 @@
       },
       "packages": {
         "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "jest>@jest/core>jest-snapshot>@babel/types>@babel/helper-validator-identifier": true,
         "lavamoat>lavamoat-core>@babel/types>to-fast-properties": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": true,
-        "react>loose-envify>js-tokens": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
-        "supports-color": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
       }
     },
     "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
@@ -1264,8 +1243,15 @@
         "process.emitWarning": true
       },
       "packages": {
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/code-frame>@babel/highlight": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>@babel/highlight": true,
         "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>@babel/highlight": {
+      "packages": {
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/types>@babel/helper-validator-identifier": true,
+        "react>loose-envify>js-tokens": true
       }
     },
     "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template>@babel/code-frame>chalk": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "audit-ci": "6.3.0",
     "browserify": "17.0.0",
     "chalk": "5.3.0",
-    "chromedriver": "128.0.3",
+    "chromedriver": "130",
     "circular-dependency-plugin": "5.2.2",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7234,10 +7234,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@128.0.3:
-  version "128.0.3"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-128.0.3.tgz#7c2cd2d160f269e78f40840ee7a043dac3687148"
-  integrity sha512-Xn/bknOpGlY9tKinwS/hVWeNblSeZvbbJbF8XZ73X1jeWfAFPRXx3fMLdNNz8DqruDbx3cKEJ5wR3mnst6G3iw==
+chromedriver@130:
+  version "130.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-130.0.1.tgz#24fd5b2c9c9df4ebfc5d28c94eca8658915fbe15"
+  integrity sha512-JH+OxDZ7gVv02r9oXwj4mQ8JCtj62g0fCD1LMUUYdB/4mPxn/E2ys+1IzXItoE7vXM9fGVc9R1akvXLqwwuSww==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.7.4"


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- E2e is currently unable to run on local
- Greg's PR that added popular in rainbow indirectly caused a couple of these issues
- If a token is in the 'popular in Rainbow' section, it doesn't appear in other sections of the search. `gmx` sometimes appears here and sometimes doesn't. When greg merged his PR it wasn't so e2e was passing but now it is, so it failed. 
- to fix this, added a couple try / catch blocks when we search for this specific token
- added a couple of delays in areas i was seeing random sporadic failures as well.
- also bumping chromedriver / chrome version to match my local so I can run tests
