### PR TITLE
Copy checksummed address

### DIFF
--- a/src/core/utils/copy.ts
+++ b/src/core/utils/copy.ts
@@ -1,4 +1,5 @@
 import { AddressZero } from '@ethersproject/constants';
+import { getAddress } from 'viem';
 
 import { triggerToast } from '~/entries/popup/components/Toast/Toast';
 
@@ -26,6 +27,6 @@ export const copyAddress = (address: AddressOrEth) => {
   copy({
     title: i18n.t('wallet_header.copy_toast'),
     description: truncateAddress(address),
-    value: address,
+    value: getAddress(address),
   });
 };

--- a/src/entries/popup/pages/home/TokenDetails/About.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/About.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { ReactNode, useState } from 'react';
+import { getAddress } from 'viem';
 
 import { i18n } from '~/core/languages';
 import { ParsedUserAsset } from '~/core/types/assets';
@@ -348,7 +349,7 @@ export function About({
                   value={
                     <CopyableValue
                       title={i18n.t('wallet_header.copy_toast')}
-                      value={token.address}
+                      value={getAddress(token.address)}
                     >
                       {truncateAddress(token.address)}
                     </CopyableValue>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
When a user copies a token address to their clipboard, the copied address should be the proper checksummed version.
This is done by wrapping the address that is copied inside a `getAddress()` call from viem.

## Screen recordings / screenshots
<img width="358" alt="Screenshot 2024-11-01 at 12 58 40 AM" src="https://github.com/user-attachments/assets/ba2d04cb-75e8-4918-b6a1-70b1db13ac56">
<img width="362" alt="Screenshot 2024-11-01 at 12 58 51 AM" src="https://github.com/user-attachments/assets/ecd9efe5-34e7-45fa-94fc-c28686ffe27d">

## What to test
Test if the copied addresses of tokens are properly checksummed. 

## Notes
This is my first time formally contributing to the codebase. I am not familiar with it and am not sure how to set up a local environment. Thus I just made the proposed changes to the best of my ability/knowledge. Glad to work through the problem to get the feature where it needs to be.

It is possible that this feature should be expanded to ANY address, rather than just token addresses.

Cheers!