### PR TITLE
Remove permit support and modify node ack logic

### DIFF
--- a/src/core/raps/actions/swap.test.ts
+++ b/src/core/raps/actions/swap.test.ts
@@ -56,7 +56,6 @@ test('[rap/swap] :: should execute swap', async () => {
     },
     quote: quote as Quote,
     wallet,
-    permit: false,
   });
 
   expect(swapTx?.hash).toBeDefined();

--- a/src/core/raps/actions/swap.ts
+++ b/src/core/raps/actions/swap.ts
@@ -220,7 +220,6 @@ export const executeSwap = async ({
   quote,
   gasParams,
   wallet,
-  permit = false,
 }: {
   chainId: ChainId;
   gasLimit: string;
@@ -228,7 +227,6 @@ export const executeSwap = async ({
   nonce?: number;
   quote: Quote;
   wallet: Signer;
-  permit: boolean;
 }): Promise<Transaction | null> => {
   if (!wallet || !quote) return null;
 
@@ -260,7 +258,7 @@ export const executeSwap = async ({
       quote,
       transactionParams,
       wallet,
-      permit,
+      false,
       chainId as unknown as SwapChainId,
       REFERRER,
     );
@@ -276,7 +274,7 @@ export const swap = async ({
 }: ActionProps<'swap'>): Promise<RapActionResult> => {
   const { selectedGas, gasFeeParamsBySpeed } = gasStore.getState();
 
-  const { quote, permit, chainId, requiresApprove } = parameters;
+  const { quote, chainId, requiresApprove } = parameters;
   let gasParams = selectedGas.transactionGasParams;
   // if swap isn't the last action, use fast gas or custom (whatever is faster)
 
@@ -312,7 +310,6 @@ export const swap = async ({
       chainId,
       gasLimit,
       nonce,
-      permit: !!permit,
       quote,
       wallet,
     };

--- a/src/core/raps/execute.ts
+++ b/src/core/raps/execute.ts
@@ -112,9 +112,12 @@ function getRapFullName<T extends RapActionTypes>(actions: RapAction<T>[]) {
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
+const NODE_ACK_MAX_TRIES = 10;
+
 const waitForNodeAck = async (
   hash: string,
   provider: Signer['provider'],
+  tries = 0,
 ): Promise<void> => {
   return new Promise(async (resolve) => {
     const tx = await provider?.getTransaction(hash);
@@ -126,8 +129,10 @@ const waitForNodeAck = async (
       resolve();
     } else {
       // Wait for 1 second and try again
-      await delay(1000);
-      return waitForNodeAck(hash, provider);
+      if (tries < NODE_ACK_MAX_TRIES) {
+        await delay(1000);
+        return waitForNodeAck(hash, provider, tries + 1);
+      }
     }
   });
 };

--- a/src/core/raps/unlockAndCrosschainSwap.ts
+++ b/src/core/raps/unlockAndCrosschainSwap.ts
@@ -112,7 +112,6 @@ export const createUnlockAndCrosschainSwapRap = async (
   // create a swap rap
   const swap = createNewAction('crosschainSwap', {
     chainId,
-    permit: swapAssetNeedsUnlocking,
     requiresApprove: swapAssetNeedsUnlocking,
     quote,
     meta: swapParameters.meta,

--- a/src/core/raps/unlockAndSwap.ts
+++ b/src/core/raps/unlockAndSwap.ts
@@ -125,7 +125,6 @@ export const createUnlockAndSwapRap = async (
   const swap = createNewAction('swap', {
     chainId,
     sellAmount,
-    permit: swapAssetNeedsUnlocking,
     requiresApprove: swapAssetNeedsUnlocking,
     quote,
     meta: swapParameters.meta,

--- a/src/core/raps/utils.ts
+++ b/src/core/raps/utils.ts
@@ -3,7 +3,6 @@ import { MaxUint256 } from '@ethersproject/constants';
 import { Contract, PopulatedTransaction } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import {
-  ALLOWS_PERMIT,
   CrosschainQuote,
   Quote,
   getQuoteExecutionDetails,
@@ -207,22 +206,8 @@ export const getDefaultGasLimitForTrade = (
   quote: Quote,
   chainId: ChainId,
 ): string => {
-  const allowsPermit =
-    chainId === mainnet.id &&
-    ALLOWS_PERMIT[quote?.sellTokenAddress?.toLowerCase()];
-
-  let defaultGasLimit = quote?.defaultGasLimit;
-
-  if (allowsPermit) {
-    defaultGasLimit = Math.max(
-      Number(defaultGasLimit),
-      Number(
-        multiply(getChainGasUnits(chainId).basic.swapPermit, EXTRA_GAS_PADDING),
-      ),
-    ).toString();
-  }
   return (
-    defaultGasLimit ||
+    quote?.defaultGasLimit ||
     multiply(getChainGasUnits(chainId).basic.swap, EXTRA_GAS_PADDING)
   );
 };


### PR DESCRIPTION
Please see details on corresponding PR: https://github.com/rainbow-me/rainbow/pull/6259

Separate error on BX:
A change caused the `permit` flag to be sent for all ERC20s on all networks even if the ERC20 did not support permit.
Introduced in: https://github.com/rainbow-me/browser-extension/pull/1746/files#diff-2f8283f2d99b48500b1dba49e5fdf8a9e34914021392d58d25878323dd82d149R115