### PR TITLE
happy dom allowlist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,7 @@ jobs:
         run: exit 1
   chrome-e2e-send:
     runs-on: send-runner-bx
-    timeout-minutes: 16
+    timeout-minutes: 25
     needs: [build]
     env:
       DISPLAY: :0

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -14,6 +14,7 @@
     "GHSA-j8xg-fqg3-53r7",
     "GHSA-67hx-6x53-jw92",
     "GHSA-c24v-8rfc-w8vw",
-    "GHSA-mgfv-m47x-4wqp"
+    "GHSA-mgfv-m47x-4wqp",
+    "GHSA-96g7-g7g9-jxw8"
   ]
 }

--- a/e2e/serial/send/4_nft-sendFlow.test.ts
+++ b/e2e/serial/send/4_nft-sendFlow.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'vitest';
 
 import {
+  delay,
   delayTime,
   doNotFindElementByTestId,
   findElementByTestId,
@@ -110,6 +111,7 @@ describe('should be able to perform the nft send flow', () => {
       driver,
     });
     await assetInput.click();
+    await delay(20_000);
     await assetInput.sendKeys('poap');
     const poapSection = await findElementByTestId({
       id: 'nfts-collection-section-POAP',


### PR DESCRIPTION
Fixes BX-1700

Vulnerability: GHSA-96g7-g7g9-jxw8
Advisory title: happy-dom allows for server side code to be executed by a <script> tag
Advisory URL: https://github.com/advisories/GHSA-96g7-g7g9-jxw8

- This vulnerability only impacts vitest, which isn't user facing so it shouldn't impact us to allowlist it instead of bumping + fixing. 
- We attempted to bump but it broke unit tests, and this is needed to merge a critical swaps issue so we're opting to allowlist instead

```
browser-extension@1.5.60 /Users/brodyhughes/browser-extension-master
├── happy-dom@8.9.0
└─┬ vitest@0.34.6
  └── happy-dom@8.9.0
```