### PR TITLE
Replace broken Edge browser logo with working version from jsDelivr CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rainbow is a fun, simple, and secure Ethereum wallet that makes managing your as
 
 [Chromium](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama) including Chrome, Brave and Arc
 
-<img align="left" width="20" height="20" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Edge_Logo_2019.svg/200px-Edge_Logo_2019.svg.png" alt="Edge">
+<img align="left" width="20" height="20" src="https://cdn.jsdelivr.net/npm/@browser-logos/edge/edge.png" alt="Edge">
 
 [Edge](https://chrome.google.com/webstore/detail/opfgelmcmbiajamepnmloijbpoleiama)
 


### PR DESCRIPTION
Update Edge browser logo URL
Changed the Edge browser logo source from Wikimedia to jsDelivr CDN for better reliability and performance.The previous icon was not displayed correctly
Before:
![image](https://github.com/user-attachments/assets/f4b1ebfc-19b0-402e-b1dd-90deca39ca2c)
After:
![image](https://github.com/user-attachments/assets/d2e29db4-3298-45b3-afa3-fb4cf6900b36)
