### PR TITLE
More precisely default to -1 for currentNonce when it does not exist

### DIFF
--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -450,7 +450,7 @@ export async function getNextNonce({
 }) {
   const { getNonce } = nonceStore.getState();
   const localNonceData = getNonce({ address, chainId });
-  const localNonce = localNonceData?.currentNonce || 0;
+  const localNonce = localNonceData?.currentNonce || -1;
   const provider = getBatchedProvider({ chainId });
   const privateMempoolTimeout = chainsPrivateMempoolTimeout[chainId];
 
@@ -543,7 +543,7 @@ export function updateTransaction({
     pendingTransaction: updatedPendingTransaction,
   });
   const localNonceData = getNonce({ address, chainId });
-  const localNonce = localNonceData?.currentNonce || 0;
+  const localNonce = localNonceData?.currentNonce || -1;
   if (transaction.nonce > localNonce) {
     setNonce({
       address,


### PR DESCRIPTION
This change sets the default "currentNonce" to -1 to distinguish between an actual current nonce of 0 vs an unknown current nonce (e.g, for a fresh wallet we just created that has no outgoing txns, or a freshly imported wallet that we hadn't previously tracked.)

This helps us treat nonces vs txn counts accurately.