### PR TITLE
Femove unncessary token from publish jobs

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -13,10 +13,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.REPO_TOKEN }}
       - name: Check for new commits
         run: |
           last_commit=$(git log -1 --pretty=%B)

--- a/.github/workflows/publish-prod-chrome.yml
+++ b/.github/workflows/publish-prod-chrome.yml
@@ -10,10 +10,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20.16.0"

--- a/.github/workflows/publish-prod-firefox.yml
+++ b/.github/workflows/publish-prod-firefox.yml
@@ -10,10 +10,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.REPO_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20.16.0"


### PR DESCRIPTION
Just removing that, which I don't think we need and it expired so it's blocking release