### PR TITLE
Version Bump (Internal) - v1.5.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-extension",
   "license": "GPL-3.0-only",
-  "version": "1.5.64",
+  "version": "1.5.65",
   "scripts": {
     "//enable dev mode": "",
     "devmode:on": "sed -i'' -e 's/IS_DEV.*/IS_DEV=true/g' .env",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -68,7 +68,7 @@
     "notifications"
   ],
   "short_name": "Rainbow",
-  "version": "1.5.64",
+  "version": "1.5.65",
   "web_accessible_resources": [
     {
       "matches": [


### PR DESCRIPTION
Doing a manual bump because https://github.com/rainbow-me/browser-extension/actions/runs/12305640395 went through but failed to commit bc of an expired token.

We need this otherwise versions will collide and we'll be rejected