### PR TITLE
24 word secret phrase e2e validation

### DIFF
--- a/e2e/parallel/importWalletFlow.test.ts
+++ b/e2e/parallel/importWalletFlow.test.ts
@@ -36,4 +36,20 @@ describe('Import wallet with a secret phrase flow', () => {
   it('should display account name', async () => {
     await checkWalletName(driver, rootURL, TEST_VARIABLES.EMPTY_WALLET.ADDRESS);
   });
+  it('should be able import a wallet with a 24 word seed phrase', async () => {
+    await importWalletFlow(
+      driver,
+      rootURL,
+      TEST_VARIABLES.SEED_PHRASE_24.SECRET,
+      true,
+      true,
+    );
+  });
+  it('should display account name of the 24 word seed phrase wallet', async () => {
+    await checkWalletName(
+      driver,
+      rootURL,
+      TEST_VARIABLES.SEED_PHRASE_24.ADDRESS,
+    );
+  });
 });

--- a/e2e/walletVariables.ts
+++ b/e2e/walletVariables.ts
@@ -38,6 +38,11 @@ export const TEST_VARIABLES = {
   DAPP_RECIPIENT: {
     ADDRESS: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
   },
+  SEED_PHRASE_24: {
+    SECRET:
+      'pattern timber trouble emotion promote dignity south screen black resource churn noise famous junk gym slam author sense perfect shoulder disorder company rain spawn',
+    ADDRESS: '0x9979527b7ff3f05BC08800A0Dc8d216f080bA016',
+  },
 };
 
 export const SWAP_VARIABLES = {

--- a/src/entries/popup/components/ImportWallet/ImportWalletViaSeed.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletViaSeed.tsx
@@ -447,6 +447,7 @@ const ImportWalletViaSeed = () => {
                   height="24px"
                   variant="transparent"
                   onClick={toggleWordLength}
+                  testId="toggle-24-word-seed-phrase"
                 >
                   {i18n.t(
                     `import_wallet_via_seed.${


### PR DESCRIPTION
Fixes BX-1623

## What changed (plus any additional context for devs)
 - adds a test to check 24 word seed phrases
 - refactors seed import helper to work with 24 word phrases
 - adds 24 word secret and address to the variables file