### PR TITLE
Handle error states for when txn simulation is not yet supported for a network

### DIFF
--- a/src/entries/popup/pages/messages/useSimulateTransaction.tsx
+++ b/src/entries/popup/pages/messages/useSimulateTransaction.tsx
@@ -125,6 +125,9 @@ export const useSimulateTransaction = ({
           domain,
         },
       )) as TransactionSimulationResponse;
+
+      if (!response?.simulateTransactions?.[0]) throw 'UNSUPPORTED';
+
       return parseSimulation(response.simulateTransactions[0], chainId);
     },
     staleTime: 60 * 1000, // 1 min

--- a/src/entries/popup/pages/messages/useSimulateTransaction.tsx
+++ b/src/entries/popup/pages/messages/useSimulateTransaction.tsx
@@ -166,6 +166,8 @@ export const useSimulateMessage = ({
         currency,
       })) as MessageSimulationResponse;
 
+      if (!response?.simulateMessage) throw 'UNSUPPORTED';
+
       return parseSimulation(response.simulateMessage, chainId);
     },
     staleTime: 60 * 1000, // 1 min


### PR DESCRIPTION
Fixes BX-1733

## What changed (plus any additional context for devs)
* This is a non-urgent PR but good to have for future networks we want to support that might not have transaction simulation support. In this scenario, the simulation response does not return the data that we expect, and we were trying to index into nonexistent simulation data. Updated for both transaction and message simulation paths. 
* You won't be able to test this out as of now, as we've turned on transaction simulation support for Ink, so you'll only see the success state. Locally, I tested with a "fake" bad response that was the same as what we were previously getting before Ink support was turned on.

## Screen recordings / screenshots
Screen recordings for the resolved state can be seen on the associated Linear ticket.

