### PR TITLE
create wallet analytics

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -3,6 +3,7 @@
 import { Address } from 'viem';
 
 import { ChainId } from '~/core/types/chains';
+import { KeychainType } from '~/core/types/keychainTypes';
 import { KeyboardEventDescription } from '~/entries/popup/hooks/useKeyboardAnalytics';
 
 import { screen } from './screen';
@@ -234,6 +235,10 @@ export const event = {
    * Called when the user views the token details screen
    */
   tokenDetailsViewed: 'token_details.viewed',
+  /**
+   * Called when a wallet is created/imported/watched or a hardware wallet is connected
+   */
+  walletAdded: 'wallet.added',
   /**
    * Called when user completes or skips the wallet backup flow.
    * potential outcomes are 'succeeded,' 'failed,' or 'skipped.'
@@ -961,5 +966,17 @@ export type EventProperties = {
      */
     index: number;
   };
+  [event.walletAdded]:
+    | {
+        type: KeychainType;
+      }
+    | {
+        type: KeychainType.HardwareWalletKeychain;
+        vendor: 'Ledger' | 'Trezor';
+      }
+    | {
+        type: KeychainType.HdKeychain;
+        isNewGroup: boolean;
+      };
   [event.walletViewed]: undefined;
 };

--- a/src/entries/popup/components/ImportWallet/ImportWalletViaPrivateKey.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletViaPrivateKey.tsx
@@ -5,8 +5,10 @@ import { KeyboardEvent, useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Address } from 'viem';
 
+import { analytics } from '~/analytics';
 import { i18n } from '~/core/languages';
 import { useCurrentAddressStore } from '~/core/state';
+import { KeychainType } from '~/core/types/keychainTypes';
 import { isValidPrivateKey } from '~/core/utils/ethereum';
 import { addHexPrefix } from '~/core/utils/hex';
 import {
@@ -127,6 +129,10 @@ const ImportWalletViaPrivateKey = () => {
               });
             else navigate(ROUTES.HOME);
           }, 1);
+
+          analytics.track('wallet.added', {
+            type: KeychainType.ReadOnlyKeychain,
+          });
 
           setIsAddingWallets(false);
           removeImportWalletSecrets();

--- a/src/entries/popup/pages/hw/ledger.tsx
+++ b/src/entries/popup/pages/hw/ledger.tsx
@@ -5,7 +5,9 @@ import { useLocation } from 'react-router-dom';
 import ledgerDeviceEth from 'static/assets/hw/ledger-device-eth.png';
 import ledgerDeviceUnlock from 'static/assets/hw/ledger-device-unlock.png';
 import ledgerDevice from 'static/assets/hw/ledger-device.png';
+import { analytics } from '~/analytics';
 import { i18n } from '~/core/languages';
+import { KeychainType } from '~/core/types/keychainTypes';
 import { goToNewTab } from '~/core/utils/tabs';
 import { Box, Separator, Stack, Text } from '~/design-system';
 import { TextLink } from '~/design-system/components/TextLink/TextLink';
@@ -214,6 +216,10 @@ export function ConnectLedger() {
           direction: state?.direction,
           navbarIcon: state?.navbarIcon,
         },
+      });
+      analytics.track('wallet.added', {
+        type: KeychainType.HardwareWalletKeychain,
+        vendor: 'Ledger',
       });
     } else if (res.error) {
       setConnectingState(

--- a/src/entries/popup/pages/hw/trezor.tsx
+++ b/src/entries/popup/pages/hw/trezor.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 
 import trezorDevice from 'static/assets/hw/trezor-device.png';
+import { analytics } from '~/analytics';
 import { i18n } from '~/core/languages';
+import { KeychainType } from '~/core/types/keychainTypes';
 import { goToNewTab } from '~/core/utils/tabs';
 import { Box, Separator, Text } from '~/design-system';
 import { TextLink } from '~/design-system/components/TextLink/TextLink';
@@ -23,6 +25,10 @@ export function ConnectTrezor() {
             ...res,
             vendor: 'Trezor',
           },
+        });
+        analytics.track('wallet.added', {
+          type: KeychainType.HardwareWalletKeychain,
+          vendor: 'Trezor',
         });
       }
     }, 1500);

--- a/src/entries/popup/pages/walletSwitcher/addWallet.tsx
+++ b/src/entries/popup/pages/walletSwitcher/addWallet.tsx
@@ -18,9 +18,37 @@ const AddWallet = () => {
   const { featureFlags } = useFeatureFlagsStore();
 
   const handleCreateWallet = useCallback(async () => {
-    navigate(ROUTES.CHOOSE_WALLET_GROUP),
-      { state: { goHomeOnWalletCreation: true } };
+    navigate(ROUTES.CHOOSE_WALLET_GROUP, {
+      state: { goHomeOnWalletCreation: true },
+    });
   }, [navigate]);
+
+  const onImportWallet = () => {
+    navigate(ROUTES.NEW_IMPORT_WALLET, {
+      state: {
+        // Force isBack to false because the onBack function otherwise
+        // causes this to be interpreted as a backward navigation
+        isBack: false,
+        onBack: () => removeImportWalletSecrets(),
+      },
+    });
+  };
+
+  const onAddHardwareWallet = () => {
+    if (featureFlags.hw_wallets_enabled) {
+      triggerAlert({ text: i18n.t('alert.coming_soon') });
+      return;
+    }
+    if (isFirefox) {
+      triggerAlert({ text: i18n.t('alert.no_hw_ff') });
+      return;
+    }
+    navigate(ROUTES.HW_CHOOSE);
+  };
+
+  const onWatchWallet = () => {
+    navigate(ROUTES.NEW_WATCH_WALLET);
+  };
 
   return (
     <Box height="full">
@@ -44,16 +72,7 @@ const AddWallet = () => {
           />
           <OnboardMenu.Separator />
           <OnboardMenu.Item
-            onClick={() =>
-              navigate(ROUTES.NEW_IMPORT_WALLET, {
-                state: {
-                  // Force isBack to false because the onBack function otherwise
-                  // causes this to be interpreted as a backward navigation
-                  isBack: false,
-                  onBack: () => removeImportWalletSecrets(),
-                },
-              })
-            }
+            onClick={onImportWallet}
             title={i18n.t('add_wallet.import_wallet')}
             subtitle={i18n.t('add_wallet.import_wallet_description')}
             symbolColor="purple"
@@ -62,13 +81,7 @@ const AddWallet = () => {
           />
           <OnboardMenu.Separator />
           <OnboardMenu.Item
-            onClick={() =>
-              featureFlags.hw_wallets_enabled
-                ? isFirefox
-                  ? triggerAlert({ text: i18n.t('alert.no_hw_ff') })
-                  : navigate(ROUTES.HW_CHOOSE)
-                : triggerAlert({ text: i18n.t('alert.coming_soon') })
-            }
+            onClick={onAddHardwareWallet}
             title={i18n.t('add_wallet.hardware_wallet')}
             subtitle={i18n.t('add_wallet.hardware_wallet_description')}
             symbolColor="blue"
@@ -77,7 +90,7 @@ const AddWallet = () => {
           />
           <OnboardMenu.Separator />
           <OnboardMenu.Item
-            onClick={() => navigate(ROUTES.NEW_WATCH_WALLET)}
+            onClick={onWatchWallet}
             title={i18n.t('add_wallet.watch_address')}
             subtitle={i18n.t('add_wallet.watch_address_description')}
             symbolColor="green"

--- a/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
+++ b/src/entries/popup/pages/walletSwitcher/chooseWalletGroup.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Address } from 'viem';
 
+import { analytics } from '~/analytics';
 import { i18n } from '~/core/languages';
 import { shortcuts } from '~/core/references/shortcuts';
 import { SessionStorage } from '~/core/storage';
@@ -281,6 +282,10 @@ const ChooseWalletGroup = () => {
       imported: false,
       type: KeychainType.HdKeychain,
     };
+    analytics.track('wallet.added', {
+      type: KeychainType.HdKeychain,
+      isNewGroup: true,
+    });
     navigate(
       ROUTES.SETTINGS__PRIVACY__WALLETS_AND_KEYS__WALLET_DETAILS__RECOVERY_PHRASE_WARNING,
       {
@@ -302,6 +307,10 @@ const ChooseWalletGroup = () => {
       if (goHomeOnWalletCreation) {
         setFromChooseGroup(true);
       }
+      analytics.track('wallet.added', {
+        type: KeychainType.HdKeychain,
+        isNewGroup: false,
+      });
     },
     [wallets, goHomeOnWalletCreation],
   );

--- a/src/entries/popup/pages/walletSwitcher/newWatchWallet.tsx
+++ b/src/entries/popup/pages/walletSwitcher/newWatchWallet.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from 'react';
 
+import { analytics } from '~/analytics';
+import { KeychainType } from '~/core/types/keychainTypes';
 import { POPUP_DIMENSIONS } from '~/core/utils/dimensions';
 import { Box } from '~/design-system';
 
@@ -12,6 +14,7 @@ const NewWatchWallet = () => {
 
   const onFinishImporting = useCallback(async () => {
     navigate(-3);
+    analytics.track('wallet.added', { type: KeychainType.ReadOnlyKeychain });
   }, [navigate]);
 
   return (


### PR DESCRIPTION
Fixes BX-701
Figma link (if any):

## What changed (plus any additional context for devs)

added a `wallet.added` analytics event, triggered every time the user successfully create/imports/connect or watch a new wallet 
the event metadata is 
```ts
type: 'HdKeychain' | 'KeyPairKeychain' | 'ReadOnlyKeychain' | 'HardwareWalletKeychain'
vendor: 'Ledger' | 'Trezor' // only included when the type is 'HardwareWalletKeychain'
isNewGroup: boolean // only included when the type is 'HdKeychain'
```

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
