### PR TITLE
Surface UUID in a more user friendly way for support

### DIFF
--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -174,13 +174,6 @@ export const getStaticCommandInfo = (): CommandInfo => {
       symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
-    copyAppUUID: {
-      name: getCommandName('diagnostics'),
-      page: PAGES.HOME,
-      symbol: 'square.on.square',
-      symbolSize: 15,
-      type: SearchItemType.Shortcut,
-    },
     viewProfile: {
       actionLabel: actionLabels.openInNewTab,
       name: getCommandName('view_profile'),
@@ -652,6 +645,16 @@ export const getStaticCommandInfo = (): CommandInfo => {
       page: PAGES.UNOWNED_TOKEN_DETAIL,
       symbol: 'magnifyingglass',
       symbolSize: 14.5,
+      type: SearchItemType.Shortcut,
+    },
+
+    // PAGE: DIAGNOSTICS
+    copyUUID: {
+      name: getCommandName('copy_uuid'),
+      searchTags: getSearchTags('diagnostics'),
+      page: PAGES.HOME,
+      symbol: 'square.on.square',
+      symbolSize: 15,
       type: SearchItemType.Shortcut,
     },
   };
@@ -1419,11 +1422,11 @@ export const useCommands = (
           !previousPageState.selectedCommand?.asset?.address ||
           isETHAddress(previousPageState.selectedCommand?.asset?.address),
       },
-      copyAppUUID: {
+
+      // PAGE: DIAGNOSTICS
+      copyUUID: {
         action: async () => handleUUIDCopy(await getAppUUID()),
-        hidden:
-          searchQuery.toLowerCase() !==
-          getCommandName('diagnostics').toLowerCase(),
+        hidden: searchQuery.toLowerCase() !== getSearchTags('diagnostics')[0],
       },
     }),
     [

--- a/src/entries/popup/components/CommandK/useCommands.tsx
+++ b/src/entries/popup/components/CommandK/useCommands.tsx
@@ -44,6 +44,7 @@ import { ROUTES } from '~/entries/popup/urls';
 
 import { useBrowser } from '../../hooks/useBrowser';
 import { useCurrentWalletTypeAndVendor } from '../../hooks/useCurrentWalletType';
+import { useDeviceUUID } from '../../hooks/useDeviceUUID';
 import { useIsFullScreen } from '../../hooks/useIsFullScreen';
 import { triggerToast } from '../Toast/Toast';
 
@@ -169,6 +170,13 @@ export const getStaticCommandInfo = (): CommandInfo => {
       page: PAGES.HOME,
       shortcut: shortcuts.home.COPY_ADDRESS,
       shouldRemainOnActiveRoute: true,
+      symbol: 'square.on.square',
+      symbolSize: 15,
+      type: SearchItemType.Shortcut,
+    },
+    copyAppUUID: {
+      name: getCommandName('diagnostics'),
+      page: PAGES.HOME,
       symbol: 'square.on.square',
       symbolSize: 15,
       type: SearchItemType.Shortcut,
@@ -727,6 +735,7 @@ export const useCommands = (
   const isFullScreen = useIsFullScreen();
   const navigate = useRainbowNavigate();
   const navigateToSwaps = useNavigateToSwaps();
+  const { getAppUUID, handleUUIDCopy } = useDeviceUUID();
 
   // Wrapped to add analytics
   const wrappedNavigateToSwaps = React.useCallback(() => {
@@ -1410,6 +1419,12 @@ export const useCommands = (
           !previousPageState.selectedCommand?.asset?.address ||
           isETHAddress(previousPageState.selectedCommand?.asset?.address),
       },
+      copyAppUUID: {
+        action: async () => handleUUIDCopy(await getAppUUID()),
+        hidden:
+          searchQuery.toLowerCase() !==
+          getCommandName('diagnostics').toLowerCase(),
+      },
     }),
     [
       wrappedNavigateToSwaps,
@@ -1432,6 +1447,7 @@ export const useCommands = (
       currentAddress,
       isTokenHidden,
       isNftHidden,
+      searchQuery,
       navigate,
       handleCopy,
       sortedAccounts,
@@ -1448,6 +1464,8 @@ export const useCommands = (
       toggleHideToken,
       toggleHideNFT,
       selectSearchTokenAndNavigate,
+      handleUUIDCopy,
+      getAppUUID,
     ],
   );
 

--- a/src/entries/popup/hooks/useDeviceUUID.ts
+++ b/src/entries/popup/hooks/useDeviceUUID.ts
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { i18n } from '~/core/languages';
+
+import { triggerToast } from '../components/Toast/Toast';
+
+export const useDeviceUUID = () => {
+  const getAppUUID = React.useCallback(async () => {
+    const storage = await chrome.storage.local.get('rainbow.zustand.deviceId');
+    const entries = Object.entries(storage) as [string, string][];
+    const jsonString = entries[0][1];
+    const parsed = JSON.parse(jsonString) as {
+      state: { deviceId: string };
+      version: number;
+    };
+    return parsed.state.deviceId as string;
+  }, []);
+
+  const handleUUIDCopy = React.useCallback(async (uuid: string) => {
+    navigator.clipboard.writeText(uuid);
+    triggerToast({
+      title: i18n.t('command_k.action_labels.uuid_copied'),
+      description: `${uuid.slice(0, 5)}…${uuid.slice(-5)}`,
+    });
+  }, []);
+
+  return {
+    getAppUUID,
+    handleUUIDCopy,
+  };
+};

--- a/src/entries/popup/pages/settings/settings.tsx
+++ b/src/entries/popup/pages/settings/settings.tsx
@@ -37,6 +37,7 @@ import { logger } from '~/logger';
 
 import packageJson from '../../../../../package.json';
 import { testSandbox } from '../../handlers/wallet';
+import { useDeviceUUID } from '../../hooks/useDeviceUUID';
 import { useRainbowNavigate } from '../../hooks/useRainbowNavigate';
 import { useWallets } from '../../hooks/useWallets';
 import { ROUTES } from '../../urls';
@@ -51,6 +52,7 @@ export function Settings() {
   const { soundsEnabled, toggleSoundsEnabled } = useSoundStore();
   const { featureFlags, setFeatureFlag } = useFeatureFlagsStore();
   const { isWatchingWallet } = useWallets();
+  const { getAppUUID, handleUUIDCopy } = useDeviceUUID();
 
   const { currentUserSelectedTheme, currentTheme, setCurrentTheme } =
     useCurrentThemeStore();
@@ -529,7 +531,12 @@ export function Settings() {
             />
           </Menu>
         )}
-        <Box padding="10px" alignItems="center" justifyContent="center">
+        <Box
+          padding="10px"
+          alignItems="center"
+          justifyContent="center"
+          onDoubleClick={async () => handleUUIDCopy(await getAppUUID())}
+        >
           <Text
             size="12pt"
             weight="semibold"

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -499,7 +499,7 @@
         "export_addresses_as_csv": "Export Addresses as CSV",
         "enable_flashbots": "Enable Flashbots",
         "disable_flashbots": "Disable Flashbots",
-        "diagnostics": "Diagnostics"
+        "copy_uuid": "Copy UUID"
       },
       "search_tags": {
         "swap": "buy, sell, trade, order, exchange, dex, routes",
@@ -524,7 +524,8 @@
         "add_hardware_wallet": "ledger, trezor, connect",
         "hide_balances": "toggle",
         "hide_small_balances": "toggle",
-        "wallets_and_keys": "wallets and keys, settings, preferences"
+        "wallets_and_keys": "wallets and keys, settings, preferences",
+        "diagnostics": "diagnostics"
       }
     },
     "command_rows": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -434,7 +434,8 @@
       "open_in_new_tab": "Open in New Tab",
       "switch_to_wallet": "Switch to Wallet",
       "send_to_contact": "Send to Contact",
-      "view": "View"
+      "view": "View",
+      "uuid_copied": "UUID copied"
     },
     "commands": {
       "names": {
@@ -497,7 +498,8 @@
         "send_contact": "Send to Contact",
         "export_addresses_as_csv": "Export Addresses as CSV",
         "enable_flashbots": "Enable Flashbots",
-        "disable_flashbots": "Disable Flashbots"
+        "disable_flashbots": "Disable Flashbots",
+        "diagnostics": "Diagnostics"
       },
       "search_tags": {
         "swap": "buy, sell, trade, order, exchange, dex, routes",


### PR DESCRIPTION
Fixes BX-1717

Goal as explained in the ticket:

- Add diagnostic Cmd K actions when when searching Diagnostics (should be hidden otherwise)
- Create a Copy UUID action that copies the deviceId to the clipboard with a toast
- When clicking the version number at the bottom of the Settings, trigger the same Copy UUID action

## What changed (plus any additional context for devs)
- Added a hook for handling user UUID and the copying action / toast
- Added the commandK action searchable by 'Diagnostics' as described in ticket. if 'Diagnostics' in it's entirety isn't searched for, the command will not surface
- Also added the ability to copy the UUID to clipboard by double-clicking the version number on the settings sheet

## Screen recordings / screenshots

<video src="https://github.com/user-attachments/assets/9edfa6ea-7837-4e01-8257-7e59f50b8af6" />


## What to test

- is the command hidden until 'diagnostics' is searched for in its entirety?
- does it copy the UUID to the clipboard?
