### PR TITLE
Clear deprecated WAGMI storage via `localStorageRecycler` to improve extension boot performance

### DIFF
--- a/src/core/storage/localStorageRecycler.ts
+++ b/src/core/storage/localStorageRecycler.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/browser';
 
 import { RainbowError, logger } from '~/logger';
 
-// Define as regular array instead of readonly
 const OBSOLETE_KEYS = ['rainbow.wagmi'];
 
 /**
@@ -10,20 +9,17 @@ const OBSOLETE_KEYS = ['rainbow.wagmi'];
  */
 export async function localStorageRecycler(): Promise<void> {
   try {
-    // Check if any obsolete keys exist
     const storage = await chrome.storage.local.get(OBSOLETE_KEYS);
     if (Object.keys(storage).length === 0) {
       logger.debug('No obsolete storage keys found');
       return;
     }
 
-    // Get storage size before cleanup for logging
     const beforeSize = Object.values(storage).reduce(
       (acc, value) => acc + JSON.stringify(value).length / 1024,
       0,
     );
 
-    // Remove obsolete keys
     await chrome.storage.local.remove(OBSOLETE_KEYS);
 
     logger.info('Storage cleanup completed', {

--- a/src/core/storage/localStorageRecycler.ts
+++ b/src/core/storage/localStorageRecycler.ts
@@ -1,60 +1,39 @@
-export class LocalStorageRecycler {
-  private static instance: LocalStorageRecycler;
-  private obsoleteKeys: string[] = [];
+import * as Sentry from '@sentry/browser';
 
-  private constructor() {
-    // Initialize with known obsolete keys
-    this.obsoleteKeys = ['rainbow.wagmi'];
-  }
+import { RainbowError, logger } from '~/logger';
 
-  public static getInstance(): LocalStorageRecycler {
-    if (!LocalStorageRecycler.instance) {
-      LocalStorageRecycler.instance = new LocalStorageRecycler();
+// Define as regular array instead of readonly
+const OBSOLETE_KEYS = ['rainbow.wagmi'];
+
+/**
+ * Cleanup obsolete storage keys
+ */
+export async function localStorageRecycler(): Promise<void> {
+  try {
+    // Check if any obsolete keys exist
+    const storage = await chrome.storage.local.get(OBSOLETE_KEYS);
+    if (Object.keys(storage).length === 0) {
+      logger.debug('No obsolete storage keys found');
+      return;
     }
-    return LocalStorageRecycler.instance;
-  }
 
-  /**
-   * Add new keys to be recycled
-   */
-  public addObsoleteKeys(keys: string[]): void {
-    this.obsoleteKeys.push(...keys);
-  }
+    // Get storage size before cleanup for logging
+    const beforeSize = Object.values(storage).reduce(
+      (acc, value) => acc + JSON.stringify(value).length / 1024,
+      0,
+    );
 
-  /**
-   * Check if any obsolete keys exist in storage
-   */
-  private async hasObsoleteData(): Promise<boolean> {
-    const storage = await chrome.storage.local.get(this.obsoleteKeys);
-    return Object.keys(storage).length > 0;
-  }
+    // Remove obsolete keys
+    await chrome.storage.local.remove(OBSOLETE_KEYS);
 
-  /**
-   * Clean up obsolete storage keys
-   */
-  public async cleanup(): Promise<void> {
-    try {
-      // Check if there's anything to clean
-      const hasObsoleteData = await this.hasObsoleteData();
-      if (!hasObsoleteData) {
-        return;
-      }
-
-      // Get storage size before cleanup for logging
-      const beforeStorage = await chrome.storage.local.get(this.obsoleteKeys);
-      const beforeSize = Object.values(beforeStorage).reduce(
-        (acc, value) => acc + JSON.stringify(value).length / 1024,
-        0,
-      );
-
-      // Remove obsolete keys
-      await chrome.storage.local.remove(this.obsoleteKeys);
-
-      console.log(`Storage cleanup completed:`);
-      console.log(`- Removed keys: ${this.obsoleteKeys.join(', ')}`);
-      console.log(`- Freed approximately ${beforeSize.toFixed(2)} KB`);
-    } catch (error) {
-      console.error('Storage cleanup failed:', error);
-    }
+    logger.info('Storage cleanup completed', {
+      removedKeys: OBSOLETE_KEYS,
+      freedSpaceKB: beforeSize.toFixed(2),
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+    logger.error(new RainbowError('Failed to clean up obsolete storage'), {
+      message: (error as Error)?.message,
+    });
   }
 }

--- a/src/core/storage/localStorageRecycler.ts
+++ b/src/core/storage/localStorageRecycler.ts
@@ -1,0 +1,60 @@
+export class LocalStorageRecycler {
+  private static instance: LocalStorageRecycler;
+  private obsoleteKeys: string[] = [];
+
+  private constructor() {
+    // Initialize with known obsolete keys
+    this.obsoleteKeys = ['rainbow.wagmi'];
+  }
+
+  public static getInstance(): LocalStorageRecycler {
+    if (!LocalStorageRecycler.instance) {
+      LocalStorageRecycler.instance = new LocalStorageRecycler();
+    }
+    return LocalStorageRecycler.instance;
+  }
+
+  /**
+   * Add new keys to be recycled
+   */
+  public addObsoleteKeys(keys: string[]): void {
+    this.obsoleteKeys.push(...keys);
+  }
+
+  /**
+   * Check if any obsolete keys exist in storage
+   */
+  private async hasObsoleteData(): Promise<boolean> {
+    const storage = await chrome.storage.local.get(this.obsoleteKeys);
+    return Object.keys(storage).length > 0;
+  }
+
+  /**
+   * Clean up obsolete storage keys
+   */
+  public async cleanup(): Promise<void> {
+    try {
+      // Check if there's anything to clean
+      const hasObsoleteData = await this.hasObsoleteData();
+      if (!hasObsoleteData) {
+        return;
+      }
+
+      // Get storage size before cleanup for logging
+      const beforeStorage = await chrome.storage.local.get(this.obsoleteKeys);
+      const beforeSize = Object.values(beforeStorage).reduce(
+        (acc, value) => acc + JSON.stringify(value).length / 1024,
+        0,
+      );
+
+      // Remove obsolete keys
+      await chrome.storage.local.remove(this.obsoleteKeys);
+
+      console.log(`Storage cleanup completed:`);
+      console.log(`- Removed keys: ${this.obsoleteKeys.join(', ')}`);
+      console.log(`- Freed approximately ${beforeSize.toFixed(2)} KB`);
+    } catch (error) {
+      console.error('Storage cleanup failed:', error);
+    }
+  }
+}

--- a/src/core/storage/localStorageRecycler.ts
+++ b/src/core/storage/localStorageRecycler.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/browser';
-
 import { RainbowError, logger } from '~/logger';
 
 const OBSOLETE_KEYS = ['rainbow.wagmi'];
@@ -27,7 +25,6 @@ export async function localStorageRecycler(): Promise<void> {
       freedSpaceKB: beforeSize.toFixed(2),
     });
   } catch (error) {
-    Sentry.captureException(error);
     logger.error(new RainbowError('Failed to clean up obsolete storage'), {
       message: (error as Error)?.message,
     });

--- a/src/entries/background/index.ts
+++ b/src/entries/background/index.ts
@@ -4,6 +4,7 @@ import { initFCM } from '~/core/firebase/fcm';
 import { initializeMessenger } from '~/core/messengers';
 import { initializeSentry } from '~/core/sentry';
 import { syncStores } from '~/core/state/internal/syncStores';
+import { LocalStorageRecycler } from '~/core/storage/localStorageRecycler';
 import { getRainbowChains } from '~/core/utils/rainbowChains';
 import { updateWagmiConfig } from '~/core/wagmi';
 
@@ -18,6 +19,12 @@ import { handleWallets } from './handlers/handleWallets';
 require('../../core/utils/lockdown');
 
 initializeSentry('background');
+
+try {
+  await LocalStorageRecycler.getInstance().cleanup();
+} catch (error) {
+  console.error('Failed to clean up storage:', error);
+}
 
 const popupMessenger = initializeMessenger({ connect: 'popup' });
 const inpageMessenger = initializeMessenger({ connect: 'inpage' });

--- a/src/entries/background/index.ts
+++ b/src/entries/background/index.ts
@@ -19,7 +19,7 @@ import { handleWallets } from './handlers/handleWallets';
 require('../../core/utils/lockdown');
 
 initializeSentry('background');
-await localStorageRecycler();
+localStorageRecycler();
 
 const popupMessenger = initializeMessenger({ connect: 'popup' });
 const inpageMessenger = initializeMessenger({ connect: 'inpage' });

--- a/src/entries/background/index.ts
+++ b/src/entries/background/index.ts
@@ -4,7 +4,7 @@ import { initFCM } from '~/core/firebase/fcm';
 import { initializeMessenger } from '~/core/messengers';
 import { initializeSentry } from '~/core/sentry';
 import { syncStores } from '~/core/state/internal/syncStores';
-import { LocalStorageRecycler } from '~/core/storage/localStorageRecycler';
+import { localStorageRecycler } from '~/core/storage/localStorageRecycler';
 import { getRainbowChains } from '~/core/utils/rainbowChains';
 import { updateWagmiConfig } from '~/core/wagmi';
 
@@ -19,12 +19,7 @@ import { handleWallets } from './handlers/handleWallets';
 require('../../core/utils/lockdown');
 
 initializeSentry('background');
-
-try {
-  await LocalStorageRecycler.getInstance().cleanup();
-} catch (error) {
-  console.error('Failed to clean up storage:', error);
-}
+await localStorageRecycler();
 
 const popupMessenger = initializeMessenger({ connect: 'popup' });
 const inpageMessenger = initializeMessenger({ connect: 'inpage' });


### PR DESCRIPTION
## Problem / Background

During performance investigations, we discovered that old installations of the browser extension are carrying unnecessary storage weight from deprecated WAGMI data (8-11MB) that was left behind after our migration to Wagmi v2 in May. This legacy data primarily consists of RPC logs and token metadata that is no longer accessed or needed.

While recent installations don't have this overhead, older installations are experiencing slower boot times, potentially exacerbated by Chrome 131's handling of chrome.storage.local bootstrapping. The combination of:

- Deprecated `rainbow.wagmi` storage (8-11MB)
- Active `rainbow.react-query` storage (2-4MB)

Is likely contributing to startup performance issues.

## Solution

I've implemented a `localStorageRecycler` utility that:

- Runs during extension initialization to clean up obsolete storage keys
- Currently targets the deprecated `rainbow.wagmi` key
- Includes proper error handling and logging via our existing logger/Sentry setup
- Is extensible for future storage cleanup needs

## Screen recordings / screenshots

To test I just changed the sentry logs to `console.log` statements and tested that way. Prod logs will ingest to Sentry. I did not have `rainbow.wagmi` storage on my bx at the time of recording so i pushed some dummy data. In the video below you can see me:

1. Check for the data on the current bx
2. Refresh the bx so it wipes the data
3. Refresh the bx so it shows no data is found

<video src="https://github.com/user-attachments/assets/535135e3-26a4-4501-93b0-2c3835462c55"></video>

## What to test
This runs on install / startup and can be seen in the service worker logs. To test this whole flow:
- replace the `logger.x` statements in `src/core/storage/localStorageRecycler.ts` with `console.log` statements
- run `await chrome.storage.local.get('rainbow.wagmi')` in your rainbow console to see if you have wagmi storage
- if not, push some dummy data via `await chrome.storage.local.set({ 'rainbow.wagmi': { someTestData: 'test', moreData: { foo: 'bar' } } });`
- visit <a href="chrome://extensions/" target="_blank">href="chrome://extensions/</a>
- go to the rainbow bx details
- click on "Inspect views: service worker" and go to console
- refresh the bx and watch the logs flow in!!!
