### PR TITLE
Add Chrome flags to fix CI test startup

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -115,20 +115,11 @@ export async function initDriverWithOptions(opts: {
   let driver;
   const args = [
     'load-extension=build/',
-    // '--auto-open-devtools-for-tabs',
     '--log-level=0',
     '--enable-logging',
-    // test
     '--no-sandbox',
     '--disable-dev-shm-usage',
-    '--disable-background-networking',
-    '--disable-background-timer-throttling',
-    '--disable-backgrounding-occluded-windows',
-    '--disable-breakpad',
-    '--disable-component-extensions-with-background-pages',
     '--disable-extensions-except=build/',
-    '--disable-ipc-flooding-protection',
-    '--disable-renderer-backgrounding',
   ];
 
   if (opts.browser === 'firefox') {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -118,6 +118,17 @@ export async function initDriverWithOptions(opts: {
     // '--auto-open-devtools-for-tabs',
     '--log-level=0',
     '--enable-logging',
+    // test
+    '--no-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-background-networking',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-breakpad',
+    '--disable-component-extensions-with-background-pages',
+    '--disable-extensions-except=build/',
+    '--disable-ipc-flooding-protection',
+    '--disable-renderer-backgrounding',
   ];
 
   if (opts.browser === 'firefox') {


### PR DESCRIPTION
Chrome wasn't starting properly in CI last week. Added a couple flags to our chrome args seemed to fix it.

Added `--no-sandbox` and `--disable-dev-shm-usage` flags to Chrome test initialization to fix the "session not created" errors in CI. These flags are required for Chrome to run properly in containerized CI environments where the default sandbox permissions and shared memory settings are insufficient.

More about the flags:
- `--no-sandbox`: Disables Chrome's sandbox security feature which often can't get the necessary permissions in CI containers
- `--disable-dev-shm-usage`: Forces Chrome to use /tmp instead of /dev/shm for shared memory, preventing crashes from insufficient memory allocation in CI containers
- `--disable-extensions-except=build/`: Only leaves our extension enabled. Helps future proof tests a lil.

The error we were seeing:
```
SessionNotCreatedError: session not created: Chrome failed to start: exited normally.
(session not created: DevToolsActivePort file doesn't exist)
```