### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Changed
 
-- dApps can now leverage the `wallet_revokePermissions` RPC call to disconnect from Rainbow programatically. When disconnecting from a dApp, the wallet will now remember your preference on the next visit.  #1575
+- dApps can now leverage the `wallet_revokePermissions` RPC call to disconnect from Rainbow programmatically. When disconnecting from a dApp, the wallet will now remember your preference on the next visit.  #1575
 
 ### Fixed
 


### PR DESCRIPTION
## Pull Request: Fix Typo in `CHANGELOG.md`

### Summary
This pull request corrects a typo in the `CHANGELOG.md` file. The word "programatically" was changed to "programmatically" for correct spelling.

### Changes
- Fixed the spelling of "programatically" to "programmatically" in the "Changed" section of the changelog.

