### PR TITLE
[fix] configure anvil with consistent gas parameters

### DIFF
--- a/e2e/serial/swap/1_swapFlow1.test.ts
+++ b/e2e/serial/swap/1_swapFlow1.test.ts
@@ -802,9 +802,10 @@ it('should be able to go to review a swap', async () => {
     driver,
   });
 
-  await delay(10_000);
-
+  await delay(5_000);
   toSellInputEthSelected.clear();
+  toSellInputEthSelected.clear();
+  await delay(5_000);
   toSellInputEthSelected.sendKeys('1');
   await findElementByTestIdAndClick({
     id: 'swap-confirmation-button-ready',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "// Build and zip": "",
     "bundle": "yarn build && yarn zip",
     "// Runs tests": "",
-    "anvil": "anvil --fork-url $(./scripts/get-rpc-url.sh mainnet) --fork-block-number 21574102",
+    "anvil": "anvil --fork-url $(./scripts/get-rpc-url.sh mainnet) --fork-block-number 21574102 --block-base-fee-per-gas 5000000000 --block-gas-limit 30000000",
     "anvil:optimism": "anvil --fork-url $(./scripts/get-rpc-url.sh optimism)",
     "anvil:kill": "lsof -i :8545|tail -n +2|awk '{print $2}'|xargs -r kill -s SIGINT",
     "test": "./scripts/unit-tests.sh",


### PR DESCRIPTION
Updates the anvil command configuration to provide more stable and predictable gas behavior during local testing.

Changes:
- Added `--block-base-fee-per-gas 5000000000` (5 gwei) to set a consistently low base fee.
- Added `--block-gas-limit 30000000` to fully mock the gas params we can control.
- Changed how we clear the input. Saw some flakiness around that as well.

This change addresses transaction failures related to gas price fluctuations in our test environment and provides a more reliable setup for local development and testing.