### PR TITLE
Fixes broken messenger connection due to BFCache

### DIFF
--- a/src/core/messengers/initializeMessenger.ts
+++ b/src/core/messengers/initializeMessenger.ts
@@ -30,5 +30,16 @@ export function initializeMessenger({ connect }: InitializeMessengerArgs) {
     throw new Error(
       `No messenger found for connection ${source} <-> ${connect}.`,
     );
-  return messengersForConnection[connection];
+
+  const messenger = messengersForConnection[connection];
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        Object.assign(messenger, messengersForConnection[connection]);
+      }
+    });
+  }
+
+  return messenger;
 }

--- a/src/core/messengers/internal/bridge.ts
+++ b/src/core/messengers/internal/bridge.ts
@@ -23,6 +23,7 @@ const messenger = tabMessenger.available ? tabMessenger : windowMessenger;
 export const bridgeMessenger = createMessenger({
   available: messenger.available,
   name: 'bridgeMessenger',
+  _listeners: {}, // NOTE: Not used for this proxy messenger, but internally used by tab and window messengers
   async send(topic, payload, { id } = {}) {
     return messenger.send(topic, payload, { id });
   },

--- a/src/core/messengers/internal/createMessenger.ts
+++ b/src/core/messengers/internal/createMessenger.ts
@@ -21,6 +21,9 @@ export type Messenger = {
   available: boolean;
   /** Name of the messenger */
   name: string;
+  /** Listeners for topics */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _listeners: Record<string, ((...args: any[]) => any)[]>;
   /** Sends a message to the `reply` handler. */
   send: <TPayload, TResponse>(
     /** A scoped topic that the `reply` will listen for. */

--- a/src/core/messengers/internal/tab.ts
+++ b/src/core/messengers/internal/tab.ts
@@ -88,6 +88,8 @@ export const tabMessenger = createMessenger({
         chrome.runtime.onMessage.removeListener(listener);
       });
       this._listeners[topic] = [];
+    } else {
+      this._listeners[topic] = [];
     }
 
     const listener = async (

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -5,7 +5,18 @@ export const LocalStorage = {
     await chrome?.storage?.local?.clear();
   },
   async set<TValue = unknown>(key: string, value: TValue) {
-    await chrome?.storage?.local?.set({ [key]: value });
+    try {
+      await chrome?.storage?.local?.set({ [key]: value });
+    } catch (e) {
+      const chromeError = chrome.runtime.lastError?.message;
+      logger.error(new RainbowError('LocalStorage write error'), {
+        message:
+          e instanceof Error
+            ? e.message
+            : `Unknown error: ${JSON.stringify(e)}`,
+        extra: { chromeError },
+      });
+    }
   },
   async get<TValue = unknown>(key: string) {
     const result = await chrome?.storage?.local?.get(key);

--- a/src/entries/background/handlers/handleOpenExtensionShortcut.ts
+++ b/src/entries/background/handlers/handleOpenExtensionShortcut.ts
@@ -1,5 +1,6 @@
 import { event } from '~/analytics/event';
 import { queueEventTracking } from '~/analytics/queueEvent';
+import { RainbowError, logger } from '~/logger';
 
 /**
  * Handles keyboard commands for the extension
@@ -7,7 +8,15 @@ import { queueEventTracking } from '~/analytics/queueEvent';
 export const handleOpenExtensionShortcut = () => {
   // firefox maps chrome > browser, but it does still use
   // `browserAction` for manifest v2 & v3. in v3 chrome uses `action`
-  const openPopup = () => (chrome.action || chrome.browserAction).openPopup();
+  const openPopup = () => {
+    try {
+      (chrome.action || chrome.browserAction).openPopup();
+    } catch (error) {
+      logger.error(new RainbowError('Error opening extension popup'), {
+        error,
+      });
+    }
+  };
 
   chrome.commands.onCommand.addListener((command) => {
     if (command === 'open_rainbow') {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Adds reconnection logic to messengers so that we can restore connection when BFCache is triggered. I also added some logic to remove potential for duplicate listeners inside of messengers.

## Screen recordings / screenshots
n/a

## What to test
make sure messengers don't experience dropped data / can reconnect on BFCache