### PR TITLE
crash fix when bridging to Ink

### DIFF
--- a/src/design-system/styles/designTokens.ts
+++ b/src/design-system/styles/designTokens.ts
@@ -701,6 +701,7 @@ export const textColors = selectForegroundColors(
   'zora',
   'bsc',
   'avalanche',
+  'ink',
   ...genericColors,
 );
 export type TextColor = (typeof textColors)[number];


### PR DESCRIPTION
Fixes BX-1786

## What changed (plus any additional context for devs)
- 'ink' was missing from the `textColors` array in our `design/Tokens` causing a crash when a user went to bridge to ink chain.
- checked all our other rainbow chains manually and didnt see the issue anywhere else.

## Screen recordings / screenshots

Before:
<video src="https://github.com/user-attachments/assets/6b297806-01d0-4942-8fe1-d8e22fc686fb" ></video>

After:
<video src="https://github.com/user-attachments/assets/554dc2da-0f82-47ec-8b63-9ed6c6d6b5d2" ></video>