### PR TITLE
[bx-1748] [bx-1762] Fixes a couple of overflow issues

### DIFF
--- a/src/entries/popup/pages/messages/SignMessage/SignMessageInfo.tsx
+++ b/src/entries/popup/pages/messages/SignMessage/SignMessageInfo.tsx
@@ -40,6 +40,15 @@ function Overview({
   status: 'pending' | 'error' | 'success';
   error: SimulationError | null;
 }) {
+  function formatJSON(jsonString: string | undefined) {
+    try {
+      if (jsonString === undefined) return jsonString;
+      const parsed = JSON.parse(jsonString);
+      return JSON.stringify(parsed, null, 2);
+    } catch (e) {
+      return jsonString;
+    }
+  }
   return (
     <Stack space="16px" paddingTop="14px" marginTop="-14px">
       {typedData && (
@@ -66,7 +75,12 @@ function Overview({
           </Text>
         </Inline>
         <Box
-          style={{ overflowX: 'scroll', overflowY: 'hidden' }}
+          style={{
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            wordBreak: 'break-all',
+            overflowWrap: 'break-word',
+          }}
           paddingHorizontal="20px"
           marginHorizontal="-20px"
           paddingVertical="8px" // this is to not clip the ending of the message
@@ -80,7 +94,7 @@ function Overview({
             color="labelTertiary"
             whiteSpace="pre-wrap"
           >
-            {message}
+            {formatJSON(message)}
           </Text>
         </Box>
       </Stack>

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -50,8 +50,6 @@ export const SwapAssetCard = ({
     [asset.decimals, asset.price?.value, assetAmount, currentCurrency],
   );
 
-  // 🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹
-
   return (
     <AccentColorProvider
       color={asset?.colors?.primary || asset?.colors?.fallback}

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapAssetCard.tsx
@@ -13,7 +13,6 @@ import {
   Columns,
   Inline,
   Stack,
-  Text,
   TextOverflow,
 } from '~/design-system';
 import { AccentColorProvider } from '~/design-system/components/Box/ColorContext';
@@ -51,6 +50,8 @@ export const SwapAssetCard = ({
     [asset.decimals, asset.price?.value, assetAmount, currentCurrency],
   );
 
+  // 🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹🌹
+
   return (
     <AccentColorProvider
       color={asset?.colors?.primary || asset?.colors?.fallback}
@@ -80,9 +81,14 @@ export const SwapAssetCard = ({
                     </TextOverflow>
                   </Column>
                   <Column width="content">
-                    <Text color="label" size="14pt" weight="bold">
+                    <TextOverflow
+                      color="label"
+                      size="14pt"
+                      weight="bold"
+                      maxWidth={50}
+                    >
                       {`${asset?.symbol}`}
-                    </Text>
+                    </TextOverflow>
                   </Column>
                 </Columns>
 

--- a/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
+++ b/src/entries/popup/pages/swap/SwapReviewSheet/SwapReviewSheet.tsx
@@ -33,6 +33,7 @@ import {
   Stack,
   Symbol,
   Text,
+  TextOverflow,
 } from '~/design-system';
 import { BottomSheet } from '~/design-system/components/BottomSheet/BottomSheet';
 import { AccentColorProvider } from '~/design-system/components/Box/ColorContext';
@@ -434,9 +435,11 @@ const SwapReviewSheetWithQuote = ({
                     label={t('swap.review.minimum_received')}
                     testId="swap-review-swapping-route"
                   />
-                  <Text size="14pt" weight="semibold" color="label">
-                    {minimumReceived}
-                  </Text>
+                  <Box style={{ maxWidth: '150px' }}>
+                    <TextOverflow size="14pt" weight="semibold" color="label">
+                      {minimumReceived}
+                    </TextOverflow>
+                  </Box>
                 </ReviewDetailsRow>
                 {!isWrapOrUnwrapEth && (
                   <ReviewDetailsRow testId="swapping-via">
@@ -593,14 +596,14 @@ const SwapReviewSheetWithQuote = ({
                         <Spinner size={16} color="label" />
                       </Box>
                     )}
-                    <Text
+                    <TextOverflow
                       testId="swap-review-confirmation-text"
                       color="label"
                       size="16pt"
                       weight="bold"
                     >
                       {buttonLabel}
-                    </Text>
+                    </TextOverflow>
                   </Button>
                 </Row>
               </Rows>


### PR DESCRIPTION
Fixes bx-1748, bx-1762

## What changed (plus any additional context for devs)

Overflow issues with emoji tokens in review sheet:
- added text overflow where necessary
- limited max width of some components.

Before:
<img width="358" alt="Screenshot 2025-04-23 at 2 38 00 PM" src="https://github.com/user-attachments/assets/63e77eee-c693-4391-825d-84880eebcdc1" />

After:
<img width="361" alt="Screenshot 2025-04-23 at 2 09 44 PM" src="https://github.com/user-attachments/assets/9db44fc8-0ac7-402a-a3a5-9b7bc21a676d" />


x-overflow issues on message signing requests with long unbroken hashes:
- made the y-overflow scrollable
- formatted the json properly
- word-break applied as expected

Before:
<img width="353" alt="Screenshot 2025-04-23 at 2 35 09 PM" src="https://github.com/user-attachments/assets/b1c640c7-8df7-4188-9cd4-3f4ce484f344" />
(incredibly long x-overflow scrolling)

After:
<img width="364" alt="Screenshot 2025-04-23 at 2 34 32 PM" src="https://github.com/user-attachments/assets/be8284c7-67ec-4ada-89ce-3a7eb9809c26" />

