### PR TITLE
fix message decoding

### DIFF
--- a/src/core/utils/signMessages.tsx
+++ b/src/core/utils/signMessages.tsx
@@ -24,12 +24,7 @@ export const getSigningRequestDisplayDetails = (
 
         let message, address;
 
-        // BUGFIX: Previous implementation used isAddress() which can incorrectly
-        // identify hex-encoded messages as addresses when they happen to match
-        // the address format (starting with 0x and passing hex validation).
-        //
-        // Instead, we now use stricter validation for Ethereum addresses
-        // and only swap parameters if param0 is definitely an address
+        // Only swap parameters if param0 is definitely an address
         // and param1 is not a hex string.
         if (
           param0?.startsWith('0x') &&


### PR DESCRIPTION
Fixes BX-1776 (CAAAW!!!! 🦅🇺🇸🎆)
Figma link (if any):

## What changed (plus any additional context for devs):

Fixes an issue where hex-encoded messages in personal_sign requests were being incorrectly identified as Ethereum addresses, causing the message and address parameters to be swapped. This resulted in unreadable text being displayed to users.

Before:
<img width="366" alt="Screenshot 2025-04-23 at 3 31 12 PM" src="https://github.com/user-attachments/assets/06839187-810e-4e17-beb5-2685c4a46f0c" />

After:
<img width="364" alt="Screenshot 2025-04-23 at 3 55 25 PM" src="https://github.com/user-attachments/assets/d95fd7ee-74ac-4649-9144-b4c8a54e3170" />