### PR TITLE
chore: set indefinite nft cache time [BX-1789]

### DIFF
--- a/src/core/resources/nfts/collections.ts
+++ b/src/core/resources/nfts/collections.ts
@@ -166,6 +166,9 @@ export function useNftCollections<TSelectData = NftCollectionsResult>(
     getNextPageParam: (lastPage) => lastPage?.nextPage,
     initialPageParam: undefined,
     refetchInterval: 60000,
-    retry: 3,
+    // TODO: restore this when we find a SimpleHash replacement
+    // retry: 3,
+    gcTime: Infinity, // Keep data in cache indefinitely
+    staleTime: Infinity, // Keep data in cache indefinitely
   });
 }

--- a/src/core/resources/nfts/galleryNfts.ts
+++ b/src/core/resources/nfts/galleryNfts.ts
@@ -106,8 +106,10 @@ export function useGalleryNfts<TSelectData = GalleryNftsResult>(
     getNextPageParam: (lastPage) => lastPage?.nextPage,
     initialPageParam: null,
     refetchInterval: 60000,
-    retry: 3,
-    staleTime: 60000,
+    // TODO: restore this when we find a SimpleHash replacement
+    // retry: 3,
+    staleTime: Infinity, // Keep data in cache indefinitely
+    gcTime: Infinity, // Keep data in cache indefinitely
   });
 }
 

--- a/src/core/resources/nfts/nftsForCollection.ts
+++ b/src/core/resources/nfts/nftsForCollection.ts
@@ -164,7 +164,9 @@ export function useNftsForCollection<TSelectData = NftsForCollectionResult>(
     getNextPageParam: (lastPage) => lastPage?.nextPage,
     initialPageParam: null,
     refetchInterval: 60000,
-    retry: 3,
-    staleTime: 60000,
+    // TODO: restore this when we find a SimpleHash replacement
+    // retry: 3,
+    staleTime: Infinity, // Keep data in cache indefinitely
+    gcTime: Infinity, // Keep data in cache indefinitely
   });
 }

--- a/src/core/resources/nfts/useNft.ts
+++ b/src/core/resources/nfts/useNft.ts
@@ -28,7 +28,9 @@ export function useNft(
     initialData,
     initialDataUpdatedAt: initialData !== undefined ? Date.now() : 0,
     enabled: !!contractAddress && !!chainId && !!tokenId,
-    retry: 3,
-    staleTime: 24 * 60 * 60 * 1000, // 1 day
+    // TODO: restore this when we find a SimpleHash replacement
+    // retry: 3,
+    staleTime: Infinity, // Keep data in cache indefinitely
+    gcTime: Infinity, // Keep data in cache indefinitely
   });
 }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I bumped the nft cache to hold data indefinitely in preparation for Simplehash going down.

## What to test
Ensure NFTs still appear, evaluate whether these changes may have any unintended consequences that I may have missed
