### PR TITLE
move gwei conversion to our UI layer

### DIFF
--- a/src/entries/popup/components/TransactionFee/CustomGasSheet.tsx
+++ b/src/entries/popup/components/TransactionFee/CustomGasSheet.tsx
@@ -8,6 +8,7 @@ import { shortcuts } from '~/core/references/shortcuts';
 import { txSpeedEmoji } from '~/core/references/txSpeed';
 import { useGasStore } from '~/core/state';
 import { GasFeeLegacyParams, GasFeeParams, GasSpeed } from '~/core/types/gas';
+import { weiToGwei } from '~/core/utils/ethereum';
 import { getBaseFeeTrendParams } from '~/core/utils/gas';
 import { isZero, lessThan, toFixedDecimals } from '~/core/utils/numbers';
 import {
@@ -183,6 +184,10 @@ export const CustomGasSheet = ({
     setSelectedGas,
   } = useGasStore();
 
+  const convertedCurrentBaseFee = useMemo(() => {
+    return weiToGwei(currentBaseFee);
+  }, [currentBaseFee]);
+
   const [selectedSpeedOption, setSelectedSpeedOption] = useState<GasSpeed>(
     selectedGas?.option,
   );
@@ -248,14 +253,14 @@ export const CustomGasSheet = ({
       setMaxBaseFee(maxBaseFee);
       if (!maxBaseFee || isZero(maxBaseFee)) {
         setMaxBaseFeeWarning('fail');
-      } else if (lessThan(maxBaseFee, currentBaseFee)) {
+      } else if (lessThan(maxBaseFee, convertedCurrentBaseFee)) {
         setMaxBaseFeeWarning('stuck');
       } else {
         setMaxBaseFeeWarning(undefined);
       }
     },
     [
-      currentBaseFee,
+      convertedCurrentBaseFee,
       gasFeeParamsBySpeed,
       prevSelectedGasOption,
       setCustomMaxBaseFee,
@@ -329,7 +334,7 @@ export const CustomGasSheet = ({
     setSelectedSpeed(selectedSpeedOption);
     closeCustomGasSheet();
     analytics.track(event.dappPromptSendTransactionCustomGasSet, {
-      baseFee: Number(currentBaseFee),
+      baseFee: Number(convertedCurrentBaseFee),
       maxBaseFee: Number(maxBaseFee),
       minerTip: Number(maxPriorityFee),
       maxFee: Number(maxBaseFee) + Number(maxPriorityFee),
@@ -340,7 +345,7 @@ export const CustomGasSheet = ({
     });
   }, [
     closeCustomGasSheet,
-    currentBaseFee,
+    convertedCurrentBaseFee,
     maxBaseFee,
     maxBaseFeeWarning,
     maxPriorityFee,
@@ -393,7 +398,7 @@ export const CustomGasSheet = ({
           <ExplainerHeaderPill
             color={trendParams.color}
             label={trendParams.label}
-            gwei={currentBaseFee}
+            gwei={convertedCurrentBaseFee}
             symbol={trendParams.symbol}
             borderColor={trendParams.borderColor}
           />
@@ -410,7 +415,12 @@ export const CustomGasSheet = ({
         labelColor: 'label',
       },
     });
-  }, [baseFeeTrend, currentBaseFee, hideExplainerSheet, showExplainerSheet]);
+  }, [
+    baseFeeTrend,
+    convertedCurrentBaseFee,
+    hideExplainerSheet,
+    showExplainerSheet,
+  ]);
 
   const showMaxBaseFeeExplainer = useCallback(
     () =>
@@ -535,7 +545,10 @@ export const CustomGasSheet = ({
                           size="14pt"
                           weight="semibold"
                         >
-                          {`${toFixedDecimals(currentBaseFee, 2)} Gwei`}
+                          {`${toFixedDecimals(
+                            convertedCurrentBaseFee,
+                            2,
+                          )} Gwei`}
                         </Text>
                       </Inline>
                     </Stack>

--- a/src/entries/popup/hooks/useGas.ts
+++ b/src/entries/popup/hooks/useGas.ts
@@ -23,7 +23,7 @@ import {
   GasFeeParamsBySpeed,
   GasSpeed,
 } from '~/core/types/gas';
-import { gweiToWei, weiToGwei } from '~/core/utils/ethereum';
+import { gweiToWei } from '~/core/utils/ethereum';
 import {
   gasFeeParamsChanged,
   parseCustomGasFeeLegacyParams,
@@ -353,9 +353,7 @@ const useGas = ({
     setCustomMaxPriorityFee,
     setCustomGasPrice,
     clearCustomGasModified,
-    currentBaseFee: weiToGwei(
-      (gasData as MeteorologyResponse)?.data?.currentBaseFee,
-    ),
+    currentBaseFee: (gasData as MeteorologyResponse)?.data?.currentBaseFee,
     baseFeeTrend: (gasData as MeteorologyResponse)?.data?.baseFeeTrend,
     feeType: (gasData as MeteorologyResponse)?.meta?.feeType,
   };


### PR DESCRIPTION
## What changed (plus any additional context for devs)
 
 We were previously converting our base fee in the useGas hook which would return an incredibly low value for base fee. i moved the conversion to the UI layer as opposed to the useGas hook. Comparison of logs:
 
```
 // Meteorology service logs
Meteorology currentBaseFee: 100000000000

// Our UI component logs (after going through useGas)
[useSwapGas] Returning gas result: {
  currentBaseFee: '100',  // <-- PROBLEM: Should be 100000000000
  selectedSpeed: 'normal',
  feeType: 'eip1559'
}
```

After my changes:

```
// Meteorology service logs 
Meteorology currentBaseFee: 100000000000

// Our UI component logs (after going through useGas)
[useSwapGas] Returning gas result: {
  currentBaseFee: '100000000000',  // <-- FIXED: Properly maintained as wei
  selectedSpeed: 'normal',
  feeType: 'eip1559'
}
```

UI should be unchanged, but swaps should succeed more often.

Could this be a race condition with `parseGasFeeParams` ? I am confused on how our gas flow works lol