### PR TITLE
Fix flakey shortcut e2e test

### DIFF
--- a/e2e/serial/send/2_shortcuts-sendFlow.test.ts
+++ b/e2e/serial/send/2_shortcuts-sendFlow.test.ts
@@ -102,11 +102,14 @@ describe('Complete send flow via shortcuts and keyboard navigation', () => {
     await executePerformShortcut({ driver, key: 'DECIMAL' });
     await driver.actions().sendKeys('0xtester.eth').perform();
     await executePerformShortcut({ driver, key: 'ENTER' });
-    await delayTime('long');
+    await findElementByTestId({ id: 'to-address-input-display', driver });
   });
 
   it('should be able to open contact menu', async () => {
-    await findElementByTestIdAndClick({ id: 'send-input-mask', driver });
+    await findElementByTestIdAndClick({
+      id: 'to-address-input-display',
+      driver,
+    });
     await executePerformShortcut({ driver, key: 'DECIMAL' });
     await delayTime('long');
     const copyOption = await findElementByText(driver, 'Copy Address');


### PR DESCRIPTION
## Summary
- improve reliability for keyboard shortcuts send flow test

## Testing
- `yarn vitest:send` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866a95996e0832587f8e243639aa747