### PR TITLE
Disable Dependabot in docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/src/design-system/docs"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary
- configure Dependabot
- disable Dependabot updates in `src/design-system/docs`

## Testing
- `yarn run test` *(fails: runNetworksMigrationIfNeeded is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6866abb8ea7c8325a960dc43badfedc7