### PR TITLE
fix: loading skeleton padding

### DIFF
--- a/src/entries/popup/pages/home/Skeletons.tsx
+++ b/src/entries/popup/pages/home/Skeletons.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from '~/design-system/components/Skeleton/Skeleton';
 export function TokensSkeleton() {
   const array = Array(6).fill(null);
   return (
-    <Box marginTop="-4px" style={{ height: 200, overflow: 'visible ' }}>
+    <Box paddingTop="10px" style={{ height: 200, overflow: 'visible' }}>
       <Inset horizontal="20px">
         <Stack space="16px">
           {array.map((_, index) => (
@@ -60,7 +60,7 @@ export function TokensSkeleton() {
 export function ActivitySkeleton() {
   const array = Array(5).fill(null);
   return (
-    <Box marginTop="-2px" style={{ height: 200, overflow: 'visible ' }}>
+    <Box paddingTop="10px" style={{ height: 200, overflow: 'visible' }}>
       <Inset horizontal="20px">
         <Stack space="20px">
           <Skeleton

--- a/src/entries/popup/pages/home/TabHeader.tsx
+++ b/src/entries/popup/pages/home/TabHeader.tsx
@@ -29,34 +29,40 @@ export function TabHeader({
   const { currentCurrency } = useCurrentCurrencyStore();
   const { visibleTokenCount } = useVisibleTokenCount();
 
-  const displayBalanceComponent = useMemo(
-    () =>
-      hideAssetBalances ? (
-        <Inline alignHorizontal="right" alignVertical="center">
-          <Text
-            testId={'balance-hidden'}
-            color={activeTab === 'tokens' ? 'label' : 'labelTertiary'}
-            size="16pt"
-            weight="bold"
-          >
-            {supportedCurrencies?.[currentCurrency]?.symbol}
-          </Text>
-          <Asterisks color="label" size={13} />
-        </Inline>
-      ) : (
+  const displayBalanceComponent = useMemo(() => {
+    if (isLoading) return <Skeleton width="62px" height="11px" />;
+
+    return hideAssetBalances ? (
+      <Inline alignHorizontal="right" alignVertical="center">
         <Text
-          testId={'balance-shown'}
+          testId={'balance-hidden'}
           color={activeTab === 'tokens' ? 'label' : 'labelTertiary'}
           size="16pt"
           weight="bold"
-          userSelect="all"
-          cursor="text"
         >
-          {userAssetsBalanceDisplay || ''}
+          {supportedCurrencies?.[currentCurrency]?.symbol}
         </Text>
-      ),
-    [activeTab, currentCurrency, hideAssetBalances, userAssetsBalanceDisplay],
-  );
+        <Asterisks color="label" size={13} />
+      </Inline>
+    ) : (
+      <Text
+        testId={'balance-shown'}
+        color={activeTab === 'tokens' ? 'label' : 'labelTertiary'}
+        size="16pt"
+        weight="bold"
+        userSelect="all"
+        cursor="text"
+      >
+        {userAssetsBalanceDisplay || ''}
+      </Text>
+    );
+  }, [
+    activeTab,
+    currentCurrency,
+    hideAssetBalances,
+    userAssetsBalanceDisplay,
+    isLoading,
+  ]);
 
   const tabTitle = useMemo(() => {
     const rewardsEnabled =

--- a/src/entries/popup/pages/home/TabHeader.tsx
+++ b/src/entries/popup/pages/home/TabHeader.tsx
@@ -101,17 +101,17 @@ export function TabHeader({
           >
             {tabTitle}
           </Text>
-          {activeTab === 'tokens' && visibleTokenCount > 0 && (
-            <Text color="labelQuaternary" size="14pt" weight="bold">
-              {visibleTokenCount}
-            </Text>
-          )}
+          {activeTab === 'tokens' &&
+            (isLoading ? (
+              <Skeleton width="48px" height="11px" />
+            ) : (
+              visibleTokenCount > 0 && (
+                <Text color="labelQuaternary" size="14pt" weight="bold">
+                  {visibleTokenCount}
+                </Text>
+              )
+            ))}
         </Inline>
-        {isLoading && (
-          <Inline alignVertical="center">
-            <Skeleton width="62px" height="11px" />
-          </Inline>
-        )}
 
         {shouldDisplayBalanceComponent && (
           <CursorTooltip


### PR DESCRIPTION
BX-1572

## Summary
- add top padding for wallet and activity loading skeletons
- added proper skeletons to token count and token balance in header rows
 
## Testing
- use `r` hotkey to refresh token and activity screens
- attempt continuous scroll on activity to ensure loading indicator is visible (and not covered by tab bar)

------
https://chatgpt.com/codex/tasks/task_e_6864bddc91d88325b8a7bb0416710be2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the UI components in `Skeletons.tsx` and `TabHeader.tsx` by adjusting styles, enhancing loading states, and ensuring better readability of balance information.

### Detailed summary
- In `Skeletons.tsx`, changed `marginTop` to `paddingTop` in `Box` components.
- In `TabHeader.tsx`, updated `displayBalanceComponent` logic to handle loading states and improved balance display.
- Adjusted test IDs for balance display elements.
- Added conditional rendering for loading states in the balance display.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->