### PR TITLE
Fix e2e flake without long timeout

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -28,6 +28,7 @@ const isFirefox = browser === 'firefox';
 
 // consts
 
+// Default Selenium wait timeout
 const waitUntilTime = 20_000;
 const testPassword = 'test1234';
 const BINARY_PATHS = {
@@ -1053,6 +1054,10 @@ export async function importWalletFlow(
   });
 
   if (!isPrivateKey) {
+    await waitUntilElementByTestIdIsPresent({
+      id: 'add-wallets-button',
+      driver,
+    });
     await findElementByTestIdAndClick({
       id: 'add-wallets-button',
       driver,


### PR DESCRIPTION
## Summary
- keep default 20s Selenium wait timeout
- wait for the `add-wallets-button` element before clicking during wallet import

## Testing
- `yarn test` *(failed: anvil not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871685d7c3083258d85158c2df8950a