### PR TITLE
Remove smart contract send warning

### DIFF
--- a/src/core/network/rainbowTokenList.ts
+++ b/src/core/network/rainbowTokenList.ts
@@ -1,0 +1,4 @@
+export const RAINBOW_TOKEN_LIST: Record<string, boolean> = {
+  '0x6b175474e89094c44da98b954eedeac495271d0f': true, // DAI
+  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': true, // USDC
+};

--- a/src/entries/popup/hooks/send/useSendValidations.test.tsx
+++ b/src/entries/popup/hooks/send/useSendValidations.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react';
+import { Address } from 'viem';
+import { expect, test } from 'vitest';
+
+import { RAINBOW_TOKEN_LIST } from '~/core/network/rainbowTokenList';
+import { GasFeeParams } from '~/core/types/gas';
+import { TEST_ADDRESS_1, USDC_MAINNET_ASSET } from '~/test/utils';
+
+import { useSendValidations } from './useSendValidations';
+
+const GAS_PARAMS = {
+  gasFee: { amount: '1', display: '1' },
+} as unknown as GasFeeParams;
+
+test('detects token contract address', () => {
+  const { result } = renderHook(() =>
+    useSendValidations({
+      asset: USDC_MAINNET_ASSET,
+      assetAmount: '1',
+      selectedGas: GAS_PARAMS,
+      toAddress: USDC_MAINNET_ASSET.address as Address,
+    }),
+  );
+  expect(RAINBOW_TOKEN_LIST[USDC_MAINNET_ASSET.address.toLowerCase()]).toBe(
+    true,
+  );
+  expect(result.current.isTokenContractAddress).toBe(true);
+});
+
+test('detects self send to token contract', () => {
+  const { result } = renderHook(() =>
+    useSendValidations({
+      asset: USDC_MAINNET_ASSET,
+      assetAmount: '1',
+      selectedGas: GAS_PARAMS,
+      toAddress: USDC_MAINNET_ASSET.address as Address,
+    }),
+  );
+  expect(result.current.isSelfSend).toBe(true);
+});
+
+test('normal address passes validations', () => {
+  const { result } = renderHook(() =>
+    useSendValidations({
+      asset: USDC_MAINNET_ASSET,
+      assetAmount: '1',
+      selectedGas: GAS_PARAMS,
+      toAddress: TEST_ADDRESS_1 as Address,
+    }),
+  );
+  expect(result.current.isTokenContractAddress).toBe(false);
+  expect(result.current.isSelfSend).toBe(false);
+});

--- a/src/entries/popup/pages/send/index.tsx
+++ b/src/entries/popup/pages/send/index.tsx
@@ -78,7 +78,6 @@ import { useSendUniqueAsset } from '../../hooks/send/useSendUniqueAsset';
 import { useSendValidations } from '../../hooks/send/useSendValidations';
 import useKeyboardAnalytics from '../../hooks/useKeyboardAnalytics';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
-import usePrevious from '../../hooks/usePrevious';
 import { useRainbowNavigate } from '../../hooks/useRainbowNavigate';
 import { useTokenListSampling } from '../../hooks/useTokenListSampling';
 import { useWallets } from '../../hooks/useWallets';
@@ -191,20 +190,15 @@ export function Send() {
     setToAddressOrName,
   } = useSendState({ assetAmount, rawMaxAssetBalanceAmount, asset, nft });
 
-  const {
-    buttonLabel,
-    isValidToAddress,
-    readyForReview,
-    validateToAddress,
-    toAddressIsSmartContract,
-  } = useSendValidations({
-    asset,
-    assetAmount,
-    nft,
-    selectedGas,
-    toAddress,
-    toAddressOrName,
-  });
+  const { buttonLabel, isValidToAddress, readyForReview, validateToAddress } =
+    useSendValidations({
+      asset,
+      assetAmount,
+      nft,
+      selectedGas,
+      toAddress,
+      toAddressOrName,
+    });
 
   const controls = useAnimationControls();
   const transactionRequestForGas: TransactionRequest = useMemo(() => {
@@ -472,27 +466,7 @@ export function Send() {
     };
   }, [clearCustomGasModified]);
 
-  const { explainerSheetParams, showExplainerSheet, hideExplainerSheet } =
-    useExplainerSheetParams();
-
-  const showToContractExplainer = useCallback(() => {
-    showExplainerSheet({
-      show: true,
-      title: i18n.t('explainers.send.to_smart_contract.title'),
-      description: [
-        i18n.t('explainers.send.to_smart_contract.description_1'),
-        i18n.t('explainers.send.to_smart_contract.description_2'),
-        i18n.t('explainers.send.to_smart_contract.description_3'),
-      ],
-      actionButton: {
-        label: i18n.t('explainers.send.action_label'),
-        variant: 'tinted',
-        labelColor: 'blue',
-        action: hideExplainerSheet,
-      },
-      header: { emoji: '✋' },
-    });
-  }, [hideExplainerSheet, showExplainerSheet]);
+  const { explainerSheetParams } = useExplainerSheetParams();
 
   useEffect(() => {
     // navigating from token row
@@ -527,22 +501,6 @@ export function Send() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const prevToAddressIsSmartContract = usePrevious(toAddressIsSmartContract);
-  useEffect(() => {
-    if (
-      !prevToAddressIsSmartContract &&
-      toAddressIsSmartContract &&
-      !toEnsName?.includes('argent.xyz')
-    ) {
-      showToContractExplainer();
-    }
-  }, [
-    prevToAddressIsSmartContract,
-    showToContractExplainer,
-    toAddressIsSmartContract,
-    toEnsName,
-  ]);
 
   useKeyboardShortcut({
     handler: (e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- drop smart contract detection from `useSendValidations`
- clean up send page logic and imports for the warning sheet
- add token contract and self-send checks with a small token list
- add unit tests for new validation scenarios

## Testing
- `yarn lint` *(fails: no output)*
- `yarn typecheck` *(fails: no output)*
- `yarn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687165a376f0832593dd92ac032affa1