### PR TITLE
fix: contract validation for smart contract sends

### DIFF
--- a/src/entries/popup/hooks/send/useSendValidations.test.ts
+++ b/src/entries/popup/hooks/send/useSendValidations.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react';
+import { Address } from 'viem';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useUserAssets } from '~/core/resources/assets';
+import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
+import { ChainId } from '~/core/types/chains';
+import {
+  DAI_MAINNET_ASSET,
+  TEST_ADDRESS_1,
+  USDC_MAINNET_ASSET,
+} from '~/test/utils';
+
+import { useSendValidations } from './useSendValidations';
+vi.mock('../useUserNativeAsset', () => ({
+  useUserNativeAsset: vi.fn().mockReturnValue({
+    nativeAsset: { balance: { amount: '0' } },
+  }),
+}));
+
+vi.mock('~/core/resources/assets', () => ({
+  useUserAssets: vi.fn(),
+}));
+
+const USER_ASSETS = {
+  [ChainId.mainnet]: {
+    [DAI_MAINNET_ASSET.uniqueId]: DAI_MAINNET_ASSET,
+    [USDC_MAINNET_ASSET.uniqueId]: USDC_MAINNET_ASSET,
+  },
+};
+
+beforeEach(() => {
+  vi.mocked(useUserAssets).mockReturnValue({ data: USER_ASSETS } as ReturnType<
+    typeof useUserAssets
+  >);
+  useCurrentAddressStore.setState({
+    currentAddress: TEST_ADDRESS_1 as Address,
+  });
+  useCurrentCurrencyStore.setState({ currentCurrency: 'USD' });
+});
+
+describe('validateToAddress', () => {
+  test('detects sending to the token contract', () => {
+    const { result } = renderHook(() =>
+      useSendValidations({
+        asset: DAI_MAINNET_ASSET,
+        toAddress: DAI_MAINNET_ASSET.address as Address,
+      }),
+    );
+    expect(result.current.validateToAddress()).toBe(true);
+  });
+
+  test('detects sending to a known token contract', () => {
+    const { result } = renderHook(() =>
+      useSendValidations({
+        asset: DAI_MAINNET_ASSET,
+        toAddress: USDC_MAINNET_ASSET.address as Address,
+      }),
+    );
+    expect(result.current.validateToAddress()).toBe(true);
+  });
+
+  test('allows normal recipient', () => {
+    const { result } = renderHook(() =>
+      useSendValidations({
+        asset: DAI_MAINNET_ASSET,
+        toAddress: TEST_ADDRESS_1 as Address,
+      }),
+    );
+    expect(result.current.validateToAddress()).toBe(false);
+  });
+});

--- a/src/entries/popup/pages/send/index.tsx
+++ b/src/entries/popup/pages/send/index.tsx
@@ -196,7 +196,7 @@ export function Send() {
     isValidToAddress,
     readyForReview,
     validateToAddress,
-    toAddressIsSmartContract,
+    toAddressIsTokenContract,
   } = useSendValidations({
     asset,
     assetAmount,
@@ -475,14 +475,14 @@ export function Send() {
   const { explainerSheetParams, showExplainerSheet, hideExplainerSheet } =
     useExplainerSheetParams();
 
-  const showToContractExplainer = useCallback(() => {
+  const showToTokenContractExplainer = useCallback(() => {
     showExplainerSheet({
       show: true,
-      title: i18n.t('explainers.send.to_smart_contract.title'),
+      title: i18n.t('explainers.send.to_token_contract.title'),
       description: [
-        i18n.t('explainers.send.to_smart_contract.description_1'),
-        i18n.t('explainers.send.to_smart_contract.description_2'),
-        i18n.t('explainers.send.to_smart_contract.description_3'),
+        i18n.t('explainers.send.to_token_contract.description_1'),
+        i18n.t('explainers.send.to_token_contract.description_2'),
+        i18n.t('explainers.send.to_token_contract.description_3'),
       ],
       actionButton: {
         label: i18n.t('explainers.send.action_label'),
@@ -528,20 +528,16 @@ export function Send() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const prevToAddressIsSmartContract = usePrevious(toAddressIsSmartContract);
+  const prevToAddressIsTokenContract = usePrevious(toAddressIsTokenContract);
+
   useEffect(() => {
-    if (
-      !prevToAddressIsSmartContract &&
-      toAddressIsSmartContract &&
-      !toEnsName?.includes('argent.xyz')
-    ) {
-      showToContractExplainer();
+    if (!prevToAddressIsTokenContract && toAddressIsTokenContract) {
+      showToTokenContractExplainer();
     }
   }, [
-    prevToAddressIsSmartContract,
-    showToContractExplainer,
-    toAddressIsSmartContract,
-    toEnsName,
+    prevToAddressIsTokenContract,
+    toAddressIsTokenContract,
+    showToTokenContractExplainer,
   ]);
 
   useKeyboardShortcut({

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -1712,8 +1712,8 @@
       "action_label": "Got it"
     },
     "send": {
-      "to_smart_contract": {
-        "description_1": "The address you entered is for a smart contract.",
+      "to_token_contract": {
+        "description_1": "The address you entered is for a token contract.",
         "description_2": "Except for rare situations, you probably shouldn't do this. You could lose your assets or they might go to the wrong place.",
         "description_3": "Double check the address, verify it with the recipient, or contact support first.",
         "title": "Hold your horses!"


### PR DESCRIPTION
BX-1808

## Summary
- added a token contract check using known asset list
- update explainer text for token contract warning
-  added unit tests for u`seSendValidation` hook

## Testing
- test a send to a smart contract and an ERC-20 contract
- test a send using an EOA address or contact/ENS
- you should only see the token contract warning for known ERC-20s

------
https://chatgpt.com/codex/tasks/task_e_6872c3ba3c408325be8b8bfe4749f9ca

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming and updating the handling of addresses related to smart contracts to token contracts, along with enhancing validation logic for sending assets.

### Detailed summary
- Renamed `to_smart_contract` to `to_token_contract` in `static/json/languages/en_US.json`.
- Updated descriptions related to token contracts.
- Changed variable names from `toAddressIsSmartContract` to `toAddressIsTokenContract` in `src/entries/popup/pages/send/index.tsx`.
- Modified the `showToContractExplainer` function to `showToTokenContractExplainer`.
- Adjusted validation logic in `useSendValidations` to identify token contracts.
- Added test cases for validating sending to token contracts in `src/entries/popup/hooks/send/useSendValidations.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->