### PR TITLE
fix: fallback to asset instead of change if needed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   extends: ['rainbow', 'plugin:prettier/recommended'],
   root: true,
   rules: {
+    'no-nested-ternary': 'off',
     'import/no-default-export': 'off',
     'react/react-in-jsx-scope': 'off',
     'import/order': [

--- a/src/core/utils/assets.ts
+++ b/src/core/utils/assets.ts
@@ -232,6 +232,12 @@ export function parseUserAssetBalances({
   };
 }
 
+export function isParsedUserAsset(
+  asset: ParsedAsset | ParsedUserAsset,
+): asset is ParsedUserAsset {
+  return 'balance' in asset;
+}
+
 export function parseParsedUserAsset({
   parsedAsset,
   currency,

--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -274,7 +274,7 @@ export function parseTransaction({
 
   const addressTo = getAddressTo(tx);
 
-  const direction = tx.direction || getDirection(type);
+  const direction = getDirection(type, changes, tx.direction);
 
   const description = getDescription(asset, type, meta);
 
@@ -614,7 +614,13 @@ const TransactionOutTypes = [
   'contract_interaction',
 ] as const;
 
-export const getDirection = (type: TransactionType) => {
+export const getDirection = (
+  type: TransactionType,
+  changes: RainbowTransaction['changes'],
+  txDirection?: TransactionDirection,
+) => {
+  if (type !== 'airdrop' && txDirection) return txDirection;
+  if (changes?.length === 1) return changes[0]?.direction;
   if (TransactionOutTypes.includes(type)) return 'out';
   return 'in';
 };


### PR DESCRIPTION
Fixes BX-1795

## What changed

Smarter way of determining change of a transaction relative to the user
For some events, like airdrops, the backend return a response that looks like this:
```
{
  ...
  direction: "out",
  changes [{
    ...
    direction: "in"
  }]
}
```

I guess this makes sense as the transaction was a claim transaction (sending a tx = out) but the effect (balance change) is that the token balance increases. The activities mostly reflect what happens to your balance, so this PR makes sure we use the direction of balance changes over the direction of the transaction. This fixed the mentioned issue

## Screen recordings / screenshots

<img width="369" height="602" alt="Bildschirmfoto 2025-07-16 um 13 07 31" src="https://github.com/user-attachments/assets/b902852a-6c06-486a-9d3c-d9ad5d2308fe" />


## What to test

Please test receiving, sending and bridging assets on different chains, and make sure the direction shown in rainbow activities matches the actual activity

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing transaction handling and asset validation in a React application. It modifies ESLint rules, introduces a new function for asset validation, and updates transaction direction logic, improving the accuracy and clarity of asset-related operations.

### Detailed summary
- Updated `.eslintrc.js` to turn off specific rules.
- Added `isParsedUserAsset` function to validate assets.
- Modified `getDirection` function to include transaction changes.
- Updated handling of transaction properties in `ActivityValue.tsx`.
- Improved asset extraction and validation logic in transaction processing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->