### PR TITLE
fix: correct perceived finality API query parameter format

### DIFF
--- a/src/core/state/staleBalances/index.test.ts
+++ b/src/core/state/staleBalances/index.test.ts
@@ -55,7 +55,7 @@ test('should generate accurate stale balance query params and clear expired data
     useStaleBalancesStore.getState();
   clearExpiredData(TEST_ADDRESS_1);
   const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_1);
-  expect(queryParam).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+  expect(queryParam).toStrictEqual(`&tokens=${ChainId.mainnet}.${ETH_ADDRESS}`);
 });
 
 test('should be able to remove expired stale balance and preserve unexpired data', async () => {
@@ -144,7 +144,7 @@ test('should generate accurate stale balance query params and clear expired data
     useStaleBalancesStore.getState();
   clearExpiredData(TEST_ADDRESS_2);
   const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_2);
-  expect(queryParam).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+  expect(queryParam).toStrictEqual(`&tokens=${ChainId.mainnet}.${ETH_ADDRESS}`);
 });
 
 test('should generate accurate stale balance query params and clear expired data - case #3', async () => {
@@ -163,10 +163,12 @@ test('should generate accurate stale balance query params and clear expired data
   clearExpiredData(TEST_ADDRESS_1);
   const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_1);
   expect(queryParam).toStrictEqual(
-    `&token=${ChainId.mainnet}.${ETH_ADDRESS}&token=${ChainId.optimism}.${OP_ADDRESS}`,
+    `&tokens=${ChainId.mainnet}.${ETH_ADDRESS},${ChainId.optimism}.${OP_ADDRESS}`,
   );
 
   clearExpiredData(TEST_ADDRESS_2);
   const queryParam2 = getStaleBalancesQueryParam(TEST_ADDRESS_2);
-  expect(queryParam2).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+  expect(queryParam2).toStrictEqual(
+    `&tokens=${ChainId.mainnet}.${ETH_ADDRESS}`,
+  );
 });

--- a/src/core/state/staleBalances/index.ts
+++ b/src/core/state/staleBalances/index.ts
@@ -98,19 +98,21 @@ export const useStaleBalancesStore = createRainbowStore<StaleBalancesState>(
       });
     },
     getStaleBalancesQueryParam: (address: Address) => {
-      let queryStringFragment = '';
       const { staleBalances } = get();
       const staleBalancesForUser = staleBalances[address];
+      const tokenList: string[] = [];
+
       for (const c of Object.keys(staleBalancesForUser)) {
         const chainId = parseInt(c, 10);
         const staleBalancesForChain = staleBalancesForUser[chainId];
         for (const staleBalance of Object.values(staleBalancesForChain)) {
           if (typeof staleBalance.expirationTime === 'number') {
-            queryStringFragment += `&token=${chainId}.${staleBalance.address}`;
+            tokenList.push(`${chainId}.${staleBalance.address}`);
           }
         }
       }
-      return queryStringFragment;
+
+      return tokenList.length > 0 ? `&tokens=${tokenList.join(',')}` : '';
     },
     staleBalances: {},
   }),


### PR DESCRIPTION
Update staleBalances to use `tokens` parameter with comma-separated values instead of multiple `token` parameters. This aligns with the backend API expectations for the perceived finality system.

Changes:
- Change parameter name from `token` to `tokens`
- Format multiple tokens as comma-separated list
- Update tests to match new format


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `getStaleBalancesQueryParam` function to return a list of tokens instead of a single query string fragment. It also updates the corresponding tests to reflect this change in the expected output format.

### Detailed summary
- Changed `getStaleBalancesQueryParam` to build a `tokenList` instead of a `queryStringFragment`.
- Updated return value to `&tokens=${tokenList.join(',')}`.
- Modified tests to expect `&tokens=` format instead of `&token=` for query parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->