### PR TITLE
fix: use consistent number formatting in approval labels

### DIFF
--- a/src/core/utils/transactions.ts
+++ b/src/core/utils/transactions.ts
@@ -11,6 +11,7 @@ import { Address } from 'viem';
 
 import RainbowIcon from 'static/images/icon-16@2x.png';
 import { useNetworkStore } from '~/core/state/networks/networks';
+import { formatSignedToken } from '~/entries/popup/pages/home/Activity/ActivityValue';
 
 import { i18n } from '../languages';
 import {
@@ -692,7 +693,8 @@ export const getApprovalLabel = ({
   if (!approvalAmount || !asset) return;
   if (approvalAmount === 'UNLIMITED') return i18n.t('approvals.unlimited');
   if (type === 'revoke') return i18n.t('approvals.no_allowance');
-  return `${formatNumber(formatUnits(approvalAmount, asset.decimals))} ${
-    asset.symbol
-  }`;
+  return formatSignedToken(
+    formatUnits(approvalAmount, asset.decimals),
+    asset.symbol,
+  );
 };

--- a/src/entries/popup/pages/home/Activity/ActivityValue.tsx
+++ b/src/entries/popup/pages/home/Activity/ActivityValue.tsx
@@ -36,10 +36,10 @@ const getFormatOptions = (amount: string): Intl.NumberFormatOptions => {
   return num > 100_000 ? { notation: 'compact' } : {};
 };
 
-const formatSignedToken = (
+export const formatSignedToken = (
   amount: string,
   symbol: string,
-  sign: '+' | '-',
+  sign: '+' | '-' | '' = '',
 ): string => {
   if (isSuperTinyValue(amount)) {
     return `${sign} <${formatNumber(SUPER_TINY_THRESHOLD)} ${symbol}`;


### PR DESCRIPTION
Please merge #1920 first, it's easier to review after that

## Summary
- Export formatSignedToken function to be reusable across components
- Update getApprovalLabel to use formatSignedToken for consistent formatting
- Make sign parameter optional in formatSignedToken for flexibility

## Changes Made
- `src/core/utils/transactions.ts`: Import and use formatSignedToken in getApprovalLabel function
- `src/entries/popup/pages/home/Activity/ActivityValue.tsx`: Export formatSignedToken and make sign parameter optional

## Test Plan
- [x] Verify approval labels use consistent number formatting
- [x] Ensure formatSignedToken handles edge cases (super tiny values, large numbers)
- [x] Confirm lint and typecheck pass
- [x] Test approval flow displays correctly formatted amounts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the way token values are formatted in the application. It introduces a new utility function, `formatSignedToken`, to handle the formatting of token amounts with appropriate signs and thresholds.

### Detailed summary
- Added `formatSignedToken` function in `ActivityValue.tsx` for consistent token formatting.
- Replaced string interpolation for approval labels with `formatSignedToken`.
- Updated `swapTypeValues` to use `formatSignedToken` for token values.
- Enhanced asset value formatting in `activityValues` using `formatSignedToken`.
- Introduced `isSuperTinyValue` to handle very small amounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->