### PR TITLE
e2e: use cronos testnet for custom network stability

### DIFF
--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -117,14 +117,14 @@ it('should be able to add a custom testnet network', async () => {
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
 
   // fill out custom network form
-  await typeOnTextInput({ text: 'Telos EVM Testnet', driver });
+  await typeOnTextInput({ text: 'Cronos Testnet', driver });
   await executePerformShortcut({ driver, key: 'TAB' });
   await typeOnTextInput({
-    text: 'https://rpc.testnet.telos.net',
+    text: 'https://evm-t3.cronos.org',
     driver,
   });
   await executePerformShortcut({ driver, key: 'TAB' });
-  await typeOnTextInput({ text: 'ETH', driver });
+  await typeOnTextInput({ text: 'TCRO', driver });
   await findElementByTestIdAndClick({ driver, id: 'testnet-toggle' });
 
   // needs a couple seconds to validate the custom RPC
@@ -135,11 +135,11 @@ it('should be able to add a custom testnet network', async () => {
     id: 'add-custom-network-button',
   });
 
-  const telos = await findElementByTestId({
-    id: 'network-row-41',
+  const cronosTestnet = await findElementByTestId({
+    id: 'network-row-338',
     driver,
   });
-  expect(telos).toBeTruthy();
+  expect(cronosTestnet).toBeTruthy();
 });
 
 it('should be able to add a custom ETH RPC and switch to it', async () => {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

- using cronos for both mainnet, and testnet custom network flow tests

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the test for adding a custom network by changing the network details from `Telos EVM Testnet` to `Cronos Testnet`, reflecting new RPC URLs and identifiers.

### Detailed summary
- Changed network name from `Telos EVM Testnet` to `Cronos Testnet`.
- Updated RPC URL from `https://rpc.testnet.telos.net` to `https://evm-t3.cronos.org`.
- Modified token symbol from `ETH` to `TCRO`.
- Updated network row identifier from `network-row-41` to `network-row-338`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->