### PR TITLE
fix: allowlist ccip ENS endpoint

### DIFF
--- a/static/allowlist.json
+++ b/static/allowlist.json
@@ -39,6 +39,7 @@
     "https://alien-lively-thunder.optimism-sepolia.quiknode.pro",
     "https://rpc-amoy.polygon.technology",
     "https://nftp.rainbow.me/",
-    "https://gateway-arbitrum.network.thegraph.com"
+    "https://gateway-arbitrum.network.thegraph.com",
+    "https://ccip-v2.ens.xyz"
   ]
 }


### PR DESCRIPTION
## Summary
- allow https://ccip-v2.ens.xyz requests in extension CSP

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6879e623baec83259e5b28d3cca25d73