### PR TITLE
fix: allowlist ccip ENS endpoint

### DIFF
--- a/static/allowlist.json
+++ b/static/allowlist.json
@@ -39,6 +39,7 @@
     "https://alien-lively-thunder.optimism-sepolia.quiknode.pro",
     "https://rpc-amoy.polygon.technology",
     "https://nftp.rainbow.me/",
-    "https://gateway-arbitrum.network.thegraph.com"
+    "https://gateway-arbitrum.network.thegraph.com",
+    "https://ccip-v2.ens.xyz"
   ]
 }


### PR DESCRIPTION
## Summary
- allow https://ccip-v2.ens.xyz requests in extension CSP

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6879e623baec83259e5b28d3cca25d73

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `static/allowlist.json` file by modifying the list of allowed URLs. It adds a new URL and corrects the formatting of the existing entries.

### Detailed summary
- Added `https://ccip-v2.ens.xyz` to the allowlist.
- Corrected the formatting by adding a comma after `https://gateway-arbitrum.network.thegraph.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->