### PR TITLE
chore: bump @rainbow-me/provider to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@radix-ui/react-select": "1.2.1",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.3",
-    "@rainbow-me/provider": "0.1.2",
+    "@rainbow-me/provider": "0.1.3",
     "@rainbow-me/swaps": "0.36.0",
     "@rudderstack/analytics-js-service-worker": "3.0.6",
     "@scure/bip39": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5969,9 +5969,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rainbow-me/provider@npm:0.1.2":
-  version: 0.1.2
-  resolution: "@rainbow-me/provider@npm:0.1.2"
+"@rainbow-me/provider@npm:0.1.3":
+  version: 0.1.3
+  resolution: "@rainbow-me/provider@npm:0.1.3"
   dependencies:
     "@ethersproject/abstract-provider": "npm:5.7.0"
     "@ethersproject/bignumber": "npm:5.7.0"
@@ -5979,7 +5979,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:7.0.1"
     eventemitter3: "npm:5.0.1"
     viem: "npm:1.21.4"
-  checksum: 10c0/8dae49c22d64b3bec75bf0f0af3400b1b86a393914d7ec1f6be1462eb8920b89b7aeff6597292a930ba9232b862a3a0b048cfe0f6735d132c85123cb4d44b2bb
+  checksum: 10c0/8b320295a495457d5ad93f3b1e925d3650a1e42012014756399a82b3bea041dd150c5ce709292a50719eba09b5339609842a4f7aa995c2bb82cbc43caa21b377
   languageName: node
   linkType: hard
 
@@ -10030,7 +10030,7 @@ __metadata:
     "@radix-ui/react-select": "npm:1.2.1"
     "@radix-ui/react-tabs": "npm:1.0.4"
     "@radix-ui/react-tooltip": "npm:1.0.3"
-    "@rainbow-me/provider": "npm:0.1.2"
+    "@rainbow-me/provider": "npm:0.1.3"
     "@rainbow-me/swaps": "npm:0.36.0"
     "@rudderstack/analytics-js-service-worker": "npm:3.0.6"
     "@scure/bip39": "npm:1.2.1"


### PR DESCRIPTION
## Summary
- upgrade @rainbow-me/provider dependency to v0.1.3

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b1687148325bd5204d0c0c606c1