### PR TITLE
feat: hide NFT tab via config flag

### DIFF
--- a/src/core/firebase/remoteConfig.ts
+++ b/src/core/firebase/remoteConfig.ts
@@ -30,6 +30,7 @@ export interface RainbowConfig extends Record<string, any> {
   rewards_enabled: boolean;
   rewards_bridging_enabled: boolean;
   degen_mode: boolean;
+  nfts_enabled: boolean;
   // SWAPS
   default_slippage_bips: Partial<Record<ChainId, number>>;
 }
@@ -53,6 +54,7 @@ const DEFAULT_CONFIG = {
   tx_requests_enabled: true,
   rpc_proxy_enabled: true,
   points_enabled: true,
+  nfts_enabled: true,
   defi_positions_enabled: false,
   rewards_enabled: true,
   rewards_bridging_enabled: true,
@@ -113,7 +115,8 @@ export const init = async () => {
             key === 'BX_defi_positions_enabled' ||
             key === 'BX_rewards_enabled' ||
             key === 'BX_rewards_bridging_enabled' ||
-            key === 'BX_degen_mode'
+            key === 'BX_degen_mode' ||
+            key === 'BX_nfts_enabled'
           ) {
             config[realKey] = entry.asBoolean();
           } else {

--- a/src/entries/popup/components/Tabs/TabBar.tsx
+++ b/src/entries/popup/components/Tabs/TabBar.tsx
@@ -31,7 +31,7 @@ export const isValidTab = (value: unknown): value is Tab => {
   return typeof value === 'string' && TABS.includes(value);
 };
 
-const TABS = ['tokens', 'activity', 'nfts', 'points'] as const;
+const TABS = ['tokens', 'activity', 'nfts', 'points'];
 
 const TAB_HEIGHT = 32;
 const TAB_WIDTH = 42;
@@ -71,10 +71,6 @@ const tabConfig: TabConfigType[] = [
   },
 ];
 
-const visibleTabConfig = config.nfts_enabled
-  ? tabConfig
-  : tabConfig.filter((tab) => tab.name !== 'nfts');
-
 export const TabBar = memo(function TabBar() {
   const height = 44;
   const { selectedTab, setSelectedTab } = useTabNavigation();
@@ -91,11 +87,6 @@ export const TabBar = memo(function TabBar() {
   }, [avatar?.color, currentTheme]);
 
   const { isWatchingWallet } = useWallets();
-
-  const visibleSelectedIndex =
-    visibleTabConfig.findIndex((t) => t.name === selectedTab) === -1
-      ? 0
-      : visibleTabConfig.findIndex((t) => t.name === selectedTab);
 
   return (
     <Box
@@ -125,15 +116,16 @@ export const TabBar = memo(function TabBar() {
       }}
       transition={timingConfig(0.2)}
     >
-      <TabBackground selectedTabIndex={visibleSelectedIndex} />
+      <TabBackground selectedTabIndex={TABS.indexOf(selectedTab)} />
       <Inline
         alignHorizontal="center"
         alignVertical="center"
         height="full"
         space="4px"
       >
-        {visibleTabConfig.map((tab, index) => {
+        {tabConfig.map((tab, index) => {
           if (tab.name === 'points' && isWatchingWallet) return null;
+          if (tab.name === 'nfts' && !config.nfts_enabled) return null;
           return (
             <Tab
               Icon={tab.Icon}
@@ -144,7 +136,7 @@ export const TabBar = memo(function TabBar() {
               key={index}
               name={tab.name}
               onSelectTab={setSelectedTab}
-              selectedTabIndex={visibleSelectedIndex}
+              selectedTabIndex={TABS.indexOf(selectedTab)}
             />
           );
         })}


### PR DESCRIPTION
BX-1826

## Summary
- add `nfts_enabled` to remote config
- use flag to hide the NFT tab

## Testing
- `yarn eslint --cache --max-warnings 0`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687e5876003c8325963783ab2d28da87

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a feature toggle for NFT functionality in the `TabBar` component and updates the configuration to include `nfts_enabled`. It ensures that the NFT tab is only displayed if this feature is enabled.

### Detailed summary
- Added `nfts_enabled` boolean to the configuration in `src/core/firebase/remoteConfig.ts`.
- Updated `TabBar` in `src/entries/popup/components/Tabs/TabBar.tsx` to conditionally render the NFT tab based on `nfts_enabled`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->