### PR TITLE
fix: invalidate gas estimate on chain switch

### DIFF
--- a/src/core/state/gas/index.ts
+++ b/src/core/state/gas/index.ts
@@ -24,6 +24,7 @@ export interface GasStore {
     gasFeeParamsBySpeed: GasFeeParamsBySpeed | GasFeeLegacyParamsBySpeed;
   }) => void;
   clearCustomGasModified: () => void;
+  clearGasData: () => void;
 }
 
 export const useGasStore = createRainbowStore<GasStore>(
@@ -63,6 +64,15 @@ export const useGasStore = createRainbowStore<GasStore>(
     },
     clearCustomGasModified: () => {
       set({ customGasModified: false });
+    },
+    clearGasData: () => {
+      set({
+        selectedGas: {} as GasFeeParams | GasFeeLegacyParams,
+        gasFeeParamsBySpeed: {} as
+          | GasFeeParamsBySpeed
+          | GasFeeLegacyParamsBySpeed,
+        customGasModified: false,
+      });
     },
   }),
   {

--- a/src/entries/background/index.ts
+++ b/src/entries/background/index.ts
@@ -4,6 +4,7 @@ import { initFCM } from '~/core/firebase/fcm';
 import { initializeMessenger } from '~/core/messengers';
 import { initializeSentry } from '~/core/sentry';
 import {
+  syncGasStoreOnChainSwitch,
   syncNetworksStore,
   syncStores,
 } from '~/core/state/internal/syncStores';
@@ -41,6 +42,7 @@ handleDisconnect();
 
 syncNetworksStore('background');
 syncStores();
+syncGasStoreOnChainSwitch();
 
 uuid4();
 // wait until the page is active to initialize FCM


### PR DESCRIPTION
Fixes BX-1819

## What changed

Gas has invalidate when sswitching chains, otherwise gas estimates from one chain may be used on another

## What to test

The issue is hard to reproduce, if you find a way to reprod BX-1819 on a build before this PR gets merged, let me know