### PR TITLE
fix: nft tab highlight overflow when nft tab is hidden

### DIFF
--- a/src/entries/popup/hooks/useRainbowNavigate.ts
+++ b/src/entries/popup/hooks/useRainbowNavigate.ts
@@ -8,7 +8,6 @@ import {
 
 import { useTabNavigation } from '~/core/state/currentSettings/tabNavigation';
 
-import { isValidTab } from '../components/Tabs/TabBar';
 import { ROUTES } from '../urls';
 
 export function useRainbowNavigate() {
@@ -23,11 +22,7 @@ export function useRainbowNavigate() {
         return;
       }
 
-      if (
-        to === ROUTES.HOME &&
-        options?.state?.tab &&
-        isValidTab(options?.state?.tab)
-      ) {
+      if (to === ROUTES.HOME && options?.state?.tab) {
         setSelectedTab(options.state.tab);
       }
 


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- resolved mismatch of visible tab indexes for highlight rendering

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test
- view tab bar with nfts visible, nfts hidden

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the tab navigation logic in the `useRainbowNavigate` and `TabBar` components, improving the handling of visible tabs based on feature flags and the wallet's status.

### Detailed summary
- Removed the `isValidTab` function and simplified its usage in `useRainbowNavigate`.
- Updated `TabBar` to derive visible tabs from `tabConfig` based on conditions.
- Enhanced `Tabs` component to accept `visibleTabs` as a prop.
- Implemented logic to determine visible tabs based on wallet status and feature flags.
- Adjusted tab selection logic in `Tabs` for better navigation experience.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->