### PR TITLE
fix: resolve firebase background thread init

### DIFF
--- a/src/entries/background/handlers/handleProviderRequest.ts
+++ b/src/entries/background/handlers/handleProviderRequest.ts
@@ -6,7 +6,6 @@ import { Chain, UserRejectedRequestError } from 'viem';
 
 import { event } from '~/analytics/event';
 import { queueEventTracking } from '~/analytics/queueEvent';
-import config from '~/core/firebase/remoteConfig';
 import { hasVault, isInitialized, isPasswordSet } from '~/core/keychain';
 import { Messenger } from '~/core/messengers';
 import { CallbackOptions } from '~/core/messengers/internal/createMessenger';
@@ -264,7 +263,8 @@ export const handleProviderRequest = ({
       useNetworkStore.getState().getBackendSupportedChains(true)[chainId]
         ?.nativeCurrency,
     getFeatureFlags: () => ({
-      custom_rpc: config.custom_rpc_enabled,
+      // TODO: Populate with the remote config feature flag
+      custom_rpc: true,
     }),
     getProvider: getProvider,
     messengerProviderRequest: (request: ProviderRequestPayload) =>


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- fixed warning when firebase remote config is initialized from background thread
- hardcode feature flag for provider

```
Remote Config: Undefined window object. This SDK only supports usage in a browser environment. (remoteconfig/registration-window).
    at _.instanceFactory (index.esm2017.js:1129:33)
    at k.getOrInitializeService (index.esm2017.js:290:39)
    at k.getImmediate (index.esm2017.js:128:29)
    at index.esm2017.js:182:23
    at remoteConfig.ts:53:34
```

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
