### PR TITLE
fix: preserve trailing newline in version bump

### DIFF
--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -11,12 +11,15 @@ console.log('bumping from v%s to v%s', currentVersion, newVersion);
 pkgJson.version = newVersion;
 
 // Update package.json
-require('fs').writeFileSync('./package.json', JSON.stringify(pkgJson, null, 2));
+require('fs').writeFileSync(
+  './package.json',
+  JSON.stringify(pkgJson, null, 2) + '\n',
+);
 // Update manifest.json
 manifest.version = newVersion;
 require('fs').writeFileSync(
   './static/manifest.json',
-  JSON.stringify(manifest, null, 2),
+  JSON.stringify(manifest, null, 2) + '\n',
 );
 
 console.log('Done.');


### PR DESCRIPTION
## Summary
- keep a newline when writing `package.json` and `manifest.json`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: NetworkError when attempting to fetch external resources)*

------
https://chatgpt.com/codex/tasks/task_e_6879b60ce01883259560b3b3f71c2d36

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `bump.js` script to ensure that the JSON files `package.json` and `manifest.json` are written with a newline character at the end, improving the formatting of these files.

### Detailed summary
- Added a newline character (`\n`) at the end of the `JSON.stringify` output for `package.json`.
- Added a newline character (`\n`) at the end of the `JSON.stringify` output for `manifest.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->