### PR TITLE
Feature/BX-1830-handle-loading-for-out-of-funds

### DIFF
--- a/src/entries/popup/hooks/approveAppRequest/useApproveAppRequestValidations.ts
+++ b/src/entries/popup/hooks/approveAppRequest/useApproveAppRequestValidations.ts
@@ -21,7 +21,8 @@ export const useApproveAppRequestValidations = ({
   const { connectedToHardhat, connectedToHardhatOp } =
     useConnectedToHardhatStore();
 
-  const enoughNativeAssetForGas = useHasEnoughGas(session);
+  const { hasEnough: enoughNativeAssetForGas, isLoading: isGasLoading } =
+    useHasEnoughGas(session);
 
   const buttonLabel = useMemo(() => {
     const activeChainId = chainIdToUse(
@@ -32,7 +33,8 @@ export const useApproveAppRequestValidations = ({
     if (dappStatus === DAppStatus.Scam)
       return i18n.t('approve_request.send_transaction_anyway');
 
-    if (!enoughNativeAssetForGas)
+    // Only show insufficient gas if we've confirmed they don't have enough (not loading)
+    if (!isGasLoading && enoughNativeAssetForGas === false)
       return i18n.t('approve_request.insufficient_native_asset_for_gas', {
         symbol: getChain({ chainId: activeChainId }).nativeCurrency.name,
       });
@@ -48,6 +50,7 @@ export const useApproveAppRequestValidations = ({
     session?.chainId,
     dappStatus,
     enoughNativeAssetForGas,
+    isGasLoading,
     signingWithDevice,
   ]);
 

--- a/src/entries/popup/hooks/useUserNativeAsset.ts
+++ b/src/entries/popup/hooks/useUserNativeAsset.ts
@@ -18,25 +18,29 @@ export const useUserNativeAsset = ({
 }: {
   address?: Address;
   chainId: ChainId;
-}): { nativeAsset?: ParsedUserAsset | null } => {
+}): { nativeAsset?: ParsedUserAsset | null; isLoading: boolean } => {
   const { currentAddress } = useCurrentAddressStore();
   const { currentCurrency } = useCurrentCurrencyStore();
   const { chains } = useConfig();
   const nativeAssetUniqueId = getNetworkNativeAssetUniqueId({
     chainId,
   });
-  const { data: userNativeAsset } = useUserAsset(
+  const { data: userNativeAsset, isLoading: isUserAssetLoading } = useUserAsset(
     nativeAssetUniqueId || '',
     address || currentAddress,
   );
 
-  const { data: testnetNativeAsset } = useUserTestnetNativeAsset({
-    address: address || currentAddress,
-    currency: currentCurrency,
-    chainId,
-  });
+  const { data: testnetNativeAsset, isLoading: isTestnetAssetLoading } =
+    useUserTestnetNativeAsset({
+      address: address || currentAddress,
+      currency: currentCurrency,
+      chainId,
+    });
 
-  const { data: customNetworkNativeAsset } = useCustomNetworkAsset({
+  const {
+    data: customNetworkNativeAsset,
+    isLoading: isCustomNetworkAssetLoading,
+  } = useCustomNetworkAsset({
     address: address || currentAddress,
     uniqueId: `${AddressZero}_${chainId}`,
     filterZeroBalance: false,
@@ -46,12 +50,16 @@ export const useUserNativeAsset = ({
   const isChainIdCustomNetwork = isCustomChain(chainId);
 
   let nativeAsset: ParsedUserAsset | undefined | null;
+  let isLoading = false;
   if (isChainIdCustomNetwork) {
     nativeAsset = customNetworkNativeAsset;
+    isLoading = isCustomNetworkAssetLoading;
   } else if (chain?.testnet) {
     nativeAsset = testnetNativeAsset;
+    isLoading = isTestnetAssetLoading;
   } else {
     nativeAsset = userNativeAsset;
+    isLoading = isUserAssetLoading;
   }
-  return { nativeAsset };
+  return { nativeAsset, isLoading };
 };

--- a/src/entries/popup/pages/messages/AccountSigningWith.tsx
+++ b/src/entries/popup/pages/messages/AccountSigningWith.tsx
@@ -3,6 +3,7 @@ import { ActiveSession } from '~/core/state/appSessions';
 import { ChainId } from '~/core/types/chains';
 import { getChain } from '~/core/utils/chains';
 import { Inline, Stack, Text } from '~/design-system';
+import { Skeleton } from '~/design-system/components/Skeleton/Skeleton';
 import { ChainBadge } from '~/entries/popup/components/ChainBadge/ChainBadge';
 import { WalletAvatar } from '~/entries/popup/components/WalletAvatar/WalletAvatar';
 
@@ -26,22 +27,27 @@ function WalletNativeBalance({ session }: { session: ActiveSession }) {
   });
   const balance = nativeAsset?.balance;
 
-  const hasEnoughGas = useHasEnoughGas(session);
+  const { hasEnough: hasEnoughGas, isLoading: isGasLoading } =
+    useHasEnoughGas(session);
 
   if (!balance) return null;
 
   return (
     <Inline alignVertical="center" space="6px">
       <ChainBadge chainId={chainId} size={14} />
-      <Text
-        size="12pt"
-        weight="bold"
-        color={hasEnoughGas ? 'labelTertiary' : 'red'}
-      >
-        {+balance.amount > 0
-          ? balance.display
-          : i18n.t('approve_request.no_token', { token: nativeAsset.symbol })}
-      </Text>
+      {isGasLoading ? (
+        <Skeleton width="60px" height="18px" />
+      ) : (
+        <Text
+          size="12pt"
+          weight="bold"
+          color={hasEnoughGas ? 'labelTertiary' : 'red'}
+        >
+          {+balance.amount > 0
+            ? balance.display
+            : i18n.t('approve_request.no_token', { token: nativeAsset.symbol })}
+        </Text>
+      )}
       <Text size="12pt" weight="semibold" color="labelQuaternary">
         {i18n.t('approve_request.on_chain', {
           chain: chainName,

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -579,7 +579,12 @@ export function SendTransactionInfo({
 
   const isScamDapp = dappMetadata?.status === DAppStatus.Scam;
 
-  const hasEnoughGas = useHasEnoughGas(activeSession);
+  const { hasEnough: hasEnoughGas, isLoading: isGasLoading } =
+    useHasEnoughGas(activeSession);
+
+  // Show transaction info while loading or if user has enough gas
+  // Only show insufficient funds if we've confirmed they don't have enough
+  const showInsufficientFunds = !isGasLoading && hasEnoughGas === false;
 
   return (
     <Box
@@ -627,7 +632,7 @@ export function SendTransactionInfo({
         )}
       </AnimatePresence>
 
-      {hasEnoughGas ? (
+      {!showInsufficientFunds ? (
         <TransactionInfo
           request={txRequest}
           dappMetadata={dappMetadata}

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -7,7 +7,11 @@ import { DAppStatus } from '~/core/graphql/__generated__/metadata';
 import { i18n } from '~/core/languages';
 import { useUserAssets } from '~/core/resources/assets';
 import { DappMetadata, useDappMetadata } from '~/core/resources/metadata/dapp';
-import { useCurrentCurrencyStore, useNonceStore } from '~/core/state';
+import {
+  useCurrentCurrencyStore,
+  useCurrentThemeStore,
+  useNonceStore,
+} from '~/core/state';
 import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
 import { useSelectedTokenStore } from '~/core/state/selectedToken';
 import { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
@@ -28,6 +32,7 @@ import {
   Symbol,
   Text,
 } from '~/design-system';
+import { Skeleton } from '~/design-system/components/Skeleton/Skeleton';
 import { SymbolName } from '~/design-system/styles/designTokens';
 import { AddressDisplay } from '~/entries/popup/components/AddressDisplay';
 import { ChainBadge } from '~/entries/popup/components/ChainBadge/ChainBadge';
@@ -45,6 +50,10 @@ import {
   MaliciousRequestWarning,
   getDappStatusBadge,
 } from '../DappScanStatus';
+import {
+  overflowGradientDark,
+  overflowGradientLight,
+} from '../OverflowGradient.css';
 import { SimulationOverview } from '../Simulation';
 import { CopyButton, TabContent, Tabs } from '../Tabs';
 import { useHasEnoughGas } from '../useHasEnoughGas';
@@ -287,6 +296,45 @@ const TransactionData = memo(function TransactionData({
     </Box>
   );
 });
+
+function BalanceLoadingSkeleton() {
+  const { currentTheme } = useCurrentThemeStore();
+  const overflowGradient =
+    currentTheme === 'dark' ? overflowGradientDark : overflowGradientLight;
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      padding="20px"
+      paddingBottom="2px"
+      background="surfaceSecondaryElevated"
+      borderRadius="20px"
+      borderColor="separatorSecondary"
+      borderWidth="1px"
+      width="full"
+      gap="16px"
+      className={overflowGradient}
+      style={{
+        position: 'relative',
+        overflowX: 'visible',
+        overflowY: 'hidden',
+      }}
+    >
+      <Inline alignVertical="center" space="12px">
+        <Skeleton width="16px" height="16px" circle />
+        <Skeleton width="200px" height="16px" />
+      </Inline>
+      <Skeleton width="100%" height="14px" />
+      <Stack marginHorizontal="-8px" space="8px">
+        <Separator color="separatorTertiary" />
+        <Skeleton width="100%" height="44px" />
+        <Separator color="separatorTertiary" />
+        <Skeleton width="100%" height="44px" />
+      </Stack>
+    </Box>
+  );
+}
 
 function TransactionInfo({
   request,
@@ -582,10 +630,6 @@ export function SendTransactionInfo({
   const { hasEnough: hasEnoughGas, isLoading: isGasLoading } =
     useHasEnoughGas(activeSession);
 
-  // Show transaction info while loading or if user has enough gas
-  // Only show insufficient funds if we've confirmed they don't have enough
-  const showInsufficientFunds = !isGasLoading && hasEnoughGas === false;
-
   return (
     <Box
       background="surfacePrimaryElevatedSecondary"
@@ -631,8 +675,18 @@ export function SendTransactionInfo({
           </motion.div>
         )}
       </AnimatePresence>
-
-      {!showInsufficientFunds ? (
+      {/* Show loading skeleton while balance is being fetched */}
+      {isGasLoading ? (
+        <BalanceLoadingSkeleton />
+      ) : /* Show insufficient funds if user doesn't have enough gas */ hasEnoughGas ===
+        false ? (
+        activeSession && (
+          <InsuficientGasFunds
+            session={activeSession}
+            onRejectRequest={onRejectRequest}
+          />
+        )
+      ) : (
         <TransactionInfo
           request={txRequest}
           dappMetadata={dappMetadata}
@@ -640,13 +694,6 @@ export function SendTransactionInfo({
           expanded={expanded}
           onExpand={() => setExpanded((e) => !e)}
         />
-      ) : (
-        activeSession && (
-          <InsuficientGasFunds
-            session={activeSession}
-            onRejectRequest={onRejectRequest}
-          />
-        )
       )}
     </Box>
   );

--- a/src/entries/popup/pages/messages/useHasEnoughGas.ts
+++ b/src/entries/popup/pages/messages/useHasEnoughGas.ts
@@ -11,16 +11,31 @@ import { useUserNativeAsset } from '../../hooks/useUserNativeAsset';
 export const useHasEnoughGas = (session: ActiveSession) => {
   const chainId = session?.chainId || ChainId.mainnet;
 
-  const { nativeAsset } = useUserNativeAsset({
+  const { nativeAsset, isLoading: isNativeAssetLoading } = useUserNativeAsset({
     address: session?.address,
     chainId,
   });
+
   const selectedGas = useGasStore((state) => state.selectedGas);
+
   const hasEnough = useMemo(() => {
+    // If balance is still loading, we don't know if user has enough gas yet
+    if (isNativeAssetLoading) {
+      return undefined; // Unknown state
+    }
+
     return lessThan(
       selectedGas?.gasFee?.amount || '0',
       toWei(nativeAsset?.balance?.amount || '0'),
     );
-  }, [selectedGas?.gasFee?.amount, nativeAsset?.balance?.amount]);
-  return hasEnough;
+  }, [
+    selectedGas?.gasFee?.amount,
+    nativeAsset?.balance?.amount,
+    isNativeAssetLoading,
+  ]);
+
+  return {
+    hasEnough,
+    isLoading: isNativeAssetLoading,
+  };
 };


### PR DESCRIPTION
Fixes BX-1830

## What changed

Added loading indicators if we cant determine if user has enough eth to pay for transaction yet or not

## What to test

Reprod in this ticket: https://linear.app/rainbow/issue/BX-1829/insufficient-eth-error-initially-when-reconnecting-to-dapp-after

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useHasEnoughGas` hook and its usage across various components to handle loading states more effectively. It introduces loading indicators and adjusts the logic for checking if users have enough gas, improving user experience during balance checks.

### Detailed summary
- Updated `useHasEnoughGas` to return `isLoading` alongside `hasEnough`.
- Added loading state checks in components using `useHasEnoughGas`.
- Introduced a `Skeleton` component for loading indicators in `SendTransactionInfo` and `WalletNativeBalance`.
- Adjusted conditional rendering logic to handle loading states in UI components.
- Modified `useUserNativeAsset` to return `isLoading` status for better asset fetching management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->