### PR TITLE
Feature/BX-1832-custom-network-flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ screenshots/
 
 # Static data
 static/data
+
+# e2e test browser
+chrome/

--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -232,10 +232,6 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
   await findElementByTestIdAndClick({ driver, id: 'custom-rpc-button' });
   await checkExtensionURL(driver, 'custom-chain');
 
-  // fill out custom network form
-  await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
-  await typeOnTextInput({ text: 'Mainnet (alt RPC)', driver });
-
   // sometimes certain RPCs can fail to validate, adding a fallback
   try {
     // RPC URL

--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -10,7 +10,6 @@ import {
   executePerformShortcut,
   findElementByTestId,
   findElementByTestIdAndClick,
-  findElementByTextAndClick,
   getExtensionIdByName,
   getRootUrl,
   importWalletFlow,
@@ -56,34 +55,77 @@ it('should be able to naviagate to network settings', async () => {
   await checkExtensionURL(driver, 'networks');
 });
 
-it('should be able to add an auto-complete network', async () => {
+it('should be able to search and filter networks', async () => {
   await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
-  await checkExtensionURL(driver, 'custom-chain');
-  await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
-  await findElementByTextAndClick(driver, 'Arbitrum Nova');
-  const symbol = await findElementByTestId({
-    id: 'custom-network-symbol',
+  await checkExtensionURL(driver, 'custom-networks');
+
+  // Test search functionality
+  await typeOnTextInput({
+    text: 'Arbitrum',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
+
+  // Should show Arbitrum networks
+  const arbitrumNova = await findElementByTestId({
+    id: 'custom-network-42170',
     driver,
   });
-  const symbolValue = await symbol.getAttribute('value');
-  expect(symbolValue).toContain('ETH');
+  expect(arbitrumNova).toBeTruthy();
 
-  // needs a couple seconds to validate the custom RPC
-  await delayTime('very-long');
+  // Test no results scenario
+  const searchInput = await findElementByTestId({
+    id: 'search-networks-input',
+    driver,
+  });
+  await searchInput.clear();
+  await typeOnTextInput({
+    text: 'nonexistentnetwork',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
 
+  // Should show no results message and manual form link
+  const noResults = await findElementByTestId({
+    id: 'no-networks-found',
+    driver,
+  });
+  expect(noResults).toBeTruthy();
+
+  const manualLink = await findElementByTestId({
+    id: 'add-custom-network-manual',
+    driver,
+  });
+  expect(manualLink).toBeTruthy();
+
+  // Clear search and go back to full list
+  await searchInput.clear();
+  await delayTime('medium');
+});
+
+it('should be able to navigate from list to manual form', async () => {
+  // Click on the manual form link
+  await checkExtensionURL(driver, 'custom-networks');
   await findElementByTestIdAndClick({
     driver,
-    id: 'add-custom-network-button',
+    id: 'add-custom-network-manual',
   });
-  const novaChain = await findElementByTestId({
-    id: 'network-row-42170',
-    driver,
-  });
-  expect(novaChain).toBeTruthy();
+
+  // Should navigate to the manual form
+  await checkExtensionURL(driver, 'custom-chain');
+
+  // Navigate back to continue with other tests
+  await executePerformShortcut({ driver, key: 'ARROW_LEFT' });
+  await checkExtensionURL(driver, 'custom-networks');
 });
 
 it('should be able to add a custom network', async () => {
-  await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await findElementByTestIdAndClick({
+    driver,
+    id: 'add-custom-network-manual',
+  });
   await checkExtensionURL(driver, 'custom-chain');
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
 
@@ -104,15 +146,24 @@ it('should be able to add a custom network', async () => {
     id: 'add-custom-network-button',
   });
 
+  await delayTime('very-long');
+
   const cronos = await findElementByTestId({
     id: 'network-row-25',
     driver,
   });
   expect(cronos).toBeTruthy();
+
+  await delayTime('long'); // wait for confirm toast to disappear
 });
 
 it('should be able to add a custom testnet network', async () => {
   await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await checkExtensionURL(driver, 'custom-networks');
+  await findElementByTestIdAndClick({
+    driver,
+    id: 'add-custom-network-manual',
+  });
   await checkExtensionURL(driver, 'custom-chain');
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
 
@@ -135,11 +186,43 @@ it('should be able to add a custom testnet network', async () => {
     id: 'add-custom-network-button',
   });
 
+  await delayTime('very-long');
+
   const cronosTestnet = await findElementByTestId({
     id: 'network-row-338',
     driver,
   });
   expect(cronosTestnet).toBeTruthy();
+
+  await delayTime('long'); // wait for confirm toast to disappear
+});
+
+it('should be able to add a known custom network from list', async () => {
+  await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await checkExtensionURL(driver, 'custom-networks');
+
+  // Search for Arbitrum Nova
+  await typeOnTextInput({
+    text: 'Arbitrum Nova',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
+
+  // Click on Arbitrum Nova network directly from the list
+  await findElementByTestIdAndClick({ driver, id: 'custom-network-42170' });
+
+  // Should navigate back to networks page after adding
+  await checkExtensionURL(driver, 'networks');
+
+  // Verify the network was added
+  const novaChain = await findElementByTestId({
+    id: 'network-row-42170',
+    driver,
+  });
+  expect(novaChain).toBeTruthy();
+
+  await delayTime('very-long'); // wait for confirm toast to disappear
 });
 
 it('should be able to add a custom ETH RPC and switch to it', async () => {
@@ -147,6 +230,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
   await checkExtensionURL(driver, 'rpcs');
 
   await findElementByTestIdAndClick({ driver, id: 'custom-rpc-button' });
+  await checkExtensionURL(driver, 'custom-chain');
 
   // fill out custom network form
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
@@ -157,7 +241,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
     // RPC URL
     await findElementByTestIdAndClick({ driver, id: 'custom-network-rpc-url' });
     await typeOnTextInput({
-      text: 'https://rpc.ankr.com/eth',
+      text: 'https://eth.llamarpc.com',
       driver,
     });
 
@@ -186,7 +270,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
       timesToPress: 30,
     });
     await typeOnTextInput({
-      text: 'https://eth.llamarpc.com',
+      text: 'https://eth.drpc.org',
       driver,
     });
 

--- a/src/core/state/networks/utils.ts
+++ b/src/core/state/networks/utils.ts
@@ -494,7 +494,11 @@ export const mergeChainData = (
     // case where we have user preferences on top of backend networks
     mergedChainData[chainId] = {
       ...chain,
-      ...userPrefs,
+      rpcs: {
+        ...userPrefs.rpcs,
+        [chain.rpcUrls.default.http[0]]: chain,
+      },
+      activeRpcUrl: userPrefs.activeRpcUrl,
       type: 'supported',
       order: order === -1 ? undefined : order,
       enabled: enabledChainIds.has(chainId),

--- a/src/entries/popup/Routes.tsx
+++ b/src/entries/popup/Routes.tsx
@@ -66,6 +66,7 @@ import { Send } from './pages/send';
 import { Currency } from './pages/settings/currency';
 import { SettingsCustomChain } from './pages/settings/customChain';
 import { AddAsset } from './pages/settings/customChain/addAsset';
+import { SettingsCustomChainsList } from './pages/settings/customChain/list';
 import { Language } from './pages/settings/language';
 import { SettingsNetworks } from './pages/settings/networks';
 import { AutoLockTimer } from './pages/settings/privacy/autoLockTimer';
@@ -569,6 +570,21 @@ const ROUTE_DATA = [
         background="surfaceSecondary"
       >
         <SettingsNetworksRPCs />
+      </AnimatedRoute>
+    ),
+  },
+  {
+    path: ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS,
+    element: (
+      <AnimatedRoute
+        direction="right"
+        navbar
+        navbarIcon="arrow"
+        title="Custom Networks"
+        protectedRoute
+        background="surfaceSecondary"
+      >
+        <SettingsCustomChainsList />
       </AnimatedRoute>
     ),
   },

--- a/src/entries/popup/pages/settings/customChain/list.tsx
+++ b/src/entries/popup/pages/settings/customChain/list.tsx
@@ -1,0 +1,181 @@
+import { AddressZero } from '@ethersproject/constants';
+import { useCallback, useMemo, useState } from 'react';
+
+import { i18n } from '~/core/languages';
+import { useDeveloperToolsEnabledStore } from '~/core/state/currentSettings/developerToolsEnabled';
+import { useNetworkStore } from '~/core/state/networks/networks';
+import { getCustomChainIconUrl } from '~/core/utils/assets';
+import { Box, Stack, Symbol, Text } from '~/design-system';
+import { Input } from '~/design-system/components/Input/Input';
+import { Menu } from '~/entries/popup/components/Menu/Menu';
+import { MenuContainer } from '~/entries/popup/components/Menu/MenuContainer';
+import { MenuItem } from '~/entries/popup/components/Menu/MenuItem';
+import { triggerToast } from '~/entries/popup/components/Toast/Toast';
+import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
+
+import ExternalImage from '../../../components/ExternalImage/ExternalImage';
+import { ROUTES } from '../../../urls';
+
+export function SettingsCustomChainsList() {
+  const navigate = useRainbowNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { developerToolsEnabled } = useDeveloperToolsEnabledStore();
+  const customNetworks = useNetworkStore((state) =>
+    state.getSupportedCustomNetworks(),
+  );
+  const addCustomChain = useNetworkStore((state) => state.addCustomChain);
+
+  const filteredNetworks = useMemo(() => {
+    const networks = customNetworks.filter((network) =>
+      developerToolsEnabled ? true : !network.testnet.isTestnet,
+    );
+
+    if (!searchTerm.trim()) {
+      return networks;
+    }
+
+    return networks.filter((network) =>
+      network.name.toLowerCase().includes(searchTerm.toLowerCase()),
+    );
+  }, [customNetworks, searchTerm, developerToolsEnabled]);
+
+  const handleNetworkSelect = useCallback(
+    (network: (typeof customNetworks)[0]) => {
+      // Create a chain object similar to what the form creates
+      const chain = {
+        id: network.id,
+        name: network.name,
+        nativeCurrency: {
+          symbol: network.nativeAsset.symbol,
+          decimals: 18,
+          name: network.nativeAsset.symbol,
+        },
+        rpcUrls: {
+          default: { http: [network.defaultRPCURL] },
+          public: { http: [network.defaultRPCURL] },
+        },
+        blockExplorers: {
+          default: {
+            name: network.defaultExplorerURL
+              ? new URL(network.defaultExplorerURL).hostname
+              : '',
+            url: network.defaultExplorerURL || '',
+          },
+        },
+        testnet: network.testnet.isTestnet,
+      };
+
+      addCustomChain(network.id, chain, network.defaultRPCURL, true);
+
+      triggerToast({
+        title: i18n.t('settings.networks.custom_rpc.network_added'),
+        description: i18n.t(
+          'settings.networks.custom_rpc.network_added_correctly',
+          { networkName: network.name },
+        ),
+      });
+
+      navigate(ROUTES.SETTINGS__NETWORKS, {
+        state: { backTo: ROUTES.SETTINGS },
+      });
+    },
+    [addCustomChain, navigate],
+  );
+
+  const handleAddCustomNetwork = useCallback(() => {
+    navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC);
+  }, [navigate]);
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchTerm(e.target.value);
+    },
+    [],
+  );
+
+  const showNoResults = searchTerm.trim() && filteredNetworks.length === 0;
+
+  return (
+    <Box paddingHorizontal="20px">
+      <Stack space="20px">
+        {/* Search Input */}
+        <Input
+          placeholder="Search networks..."
+          value={searchTerm}
+          onChange={handleSearchChange}
+          variant="surfaceBordered"
+          height="32px"
+          autoFocus
+          testId="search-networks-input"
+        />
+
+        {/* Networks List */}
+        <MenuContainer>
+          <Menu>
+            {filteredNetworks.map((network, index) => (
+              <MenuItem
+                key={network.id}
+                first={index === 0}
+                last={!showNoResults && index === filteredNetworks.length - 1}
+                leftComponent={
+                  <ExternalImage
+                    borderRadius="10px"
+                    customFallbackSymbol="globe"
+                    height={20}
+                    src={getCustomChainIconUrl(network.id, AddressZero)}
+                    width={20}
+                  />
+                }
+                titleComponent={<MenuItem.Title text={network.name} />}
+                labelComponent={
+                  network.testnet.isTestnet ? (
+                    <Text color="labelQuaternary" size="11pt" weight="medium">
+                      {i18n.t('settings.networks.testnet')}
+                    </Text>
+                  ) : null
+                }
+                onClick={() => handleNetworkSelect(network)}
+                testId={`custom-network-${network.id}`}
+              />
+            ))}
+
+            {showNoResults && (
+              <MenuItem
+                first
+                titleComponent={<MenuItem.Title text="No networks found" />}
+                disabled
+                testId="no-networks-found"
+              />
+            )}
+
+            {/* Add Custom Network Button */}
+            {(filteredNetworks.length > 0 || showNoResults) && (
+              <MenuItem
+                last
+                leftComponent={
+                  <Symbol
+                    symbol="plus.circle.fill"
+                    weight="medium"
+                    size={18}
+                    color="blue"
+                  />
+                }
+                titleComponent={
+                  <MenuItem.Title
+                    color="blue"
+                    text={i18n.t(
+                      'settings.networks.custom_rpc.add_custom_network',
+                    )}
+                  />
+                }
+                onClick={handleAddCustomNetwork}
+                testId="add-custom-network-manual"
+              />
+            )}
+          </Menu>
+        </MenuContainer>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/entries/popup/pages/settings/networks.tsx
+++ b/src/entries/popup/pages/settings/networks.tsx
@@ -127,13 +127,7 @@ export function SettingsNetworks() {
                 />
               }
               onClick={() =>
-                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC, {
-                  state: {
-                    title: i18n.t(
-                      'settings.networks.custom_rpc.add_custom_network',
-                    ),
-                  },
-                })
+                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS)
               }
               titleComponent={
                 <MenuItem.Title

--- a/src/entries/popup/urls.ts
+++ b/src/entries/popup/urls.ts
@@ -35,6 +35,7 @@ export const ROUTES = {
   SETTINGS__NETWORKS: '/settings/networks', // Networks
   SETTINGS__APPROVALS: '/settings/approvals', // Approvals
   SETTINGS__NETWORKS__RPCS: '/settings/networks/rpcs', // RPCs per network
+  SETTINGS__NETWORKS__CUSTOM_NETWORKS: '/settings/networks/custom-networks', // Custom Networks List
   SETTINGS__NETWORKS__CUSTOM_RPC: '/settings/networks/custom-chain', // Networks Custom Chain
   SETTINGS__NETWORKS__CUSTOM_RPC__DETAILS:
     '/settings/networks/custom-chain/details', // Networks Custom Chain details


### PR DESCRIPTION
Fixes BX-1832

## What changed

Custom networks are now handled in 2 different screens, one for the known networks and one for user networks
It also adds and adapts the e2e tests

## What to test

Adding and removing custom networks from list and user input, adding and removing rpc etc

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the custom networks feature in the application, allowing users to add and manage custom networks more effectively. It introduces new components and improves navigation and filtering functionality.

### Detailed summary
- Updated `networks.tsx` to navigate to `ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS`.
- Introduced `SettingsCustomChainsList` component for listing custom networks.
- Added handling for searching and filtering custom networks.
- Modified `addCustomChain` logic to include backend support.
- Enhanced `SettingsCustomChain` with improved input handling and validations.
- Updated tests to cover new search and filter functionalities for custom networks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->