### PR TITLE
fix: handle chart errors

### DIFF
--- a/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
+++ b/src/entries/popup/pages/home/TokenDetails/PriceChart.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from '@sentry/react';
 import { useQuery } from '@tanstack/react-query';
 import { memo, useReducer, useState } from 'react';
 
@@ -305,17 +306,38 @@ export function PriceChart({
       </Box>
       {((shouldHaveData && isLoading) || hasPriceData) && (
         <>
-          <Box style={{ height: '222px' }} marginHorizontal="-20px">
-            {data && (
-              <LineChart
-                data={data}
-                onMouseMove={setIndicatorPoint}
-                width={POPUP_DIMENSIONS.width}
-                height={222}
-                paddingY={40}
-              />
-            )}
-          </Box>
+          <ErrorBoundary
+            fallback={
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                flexDirection="column"
+                gap="10px"
+                style={{ height: '222px' }}
+                background="surfaceSecondary"
+                borderWidth="1px"
+                borderColor="surfaceSecondaryElevated"
+                marginHorizontal="-20px"
+              >
+                <Text size="14pt" weight="heavy" color="labelTertiary">
+                  Error while loading price chart.
+                </Text>
+              </Box>
+            }
+          >
+            <Box style={{ height: '222px' }} marginHorizontal="-20px">
+              {data && (
+                <LineChart
+                  data={data}
+                  onMouseMove={setIndicatorPoint}
+                  width={POPUP_DIMENSIONS.width}
+                  height={222}
+                  paddingY={40}
+                />
+              )}
+            </Box>
+          </ErrorBoundary>
           <SelectChartTime
             selectedTime={selectedTime}
             setSelectedTime={setSelectedTime}


### PR DESCRIPTION
Fixes BX-1833

## What changed

The underlying issue is not fixed, but also not reproducable and it looks like it was temporary. My guess is due to missing data or malformed data from backend.
This PR makes sure only the chart crashes next time, and the rest stays functional

## Screen recordings / screenshots

https://github.com/user-attachments/assets/11c7b458-22c2-49e6-8d4e-f07147f25519


