### PR TITLE
fix: [e2e] update send e2e test

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -151,10 +151,6 @@ export async function initDriverWithOptions(opts: {
     options.setChromeBinaryPath(chromeBinaryPath);
     options.addArguments(...args);
     options.setAcceptInsecureCerts(true);
-    options.setLoggingPrefs({
-      browser: 'ALL',
-      driver: 'ALL',
-    });
 
     const existingGoogChromeOptions = options.get('goog:chromeOptions') || {};
 

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -281,11 +281,7 @@ it('should be able to select token on send flow', async () => {
     id: 'token-input-asset-eth_1',
     driver,
   });
-  const inputMask = await findElementByTestId({
-    id: 'send-input-mask',
-    driver,
-  });
-  await inputMask.sendKeys('0.01');
+  await findElementByTestIdAndClick({ id: 'value-input-max', driver });
 });
 
 it('should be able to go to review on send flow', async () => {

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -1,6 +1,6 @@
 import 'chromedriver';
 import 'geckodriver';
-import { WebDriver } from 'selenium-webdriver';
+import { Key, WebDriver } from 'selenium-webdriver';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from 'vitest';
 
 import {
@@ -197,6 +197,20 @@ it('should be able to click max and switch on send flow', async () => {
   expect(switchButton).toBeTruthy();
 
   await findElementByTestIdAndClick({ id: 'value-input-max', driver });
+  const inputMask = await findElementByTestId({
+    id: 'send-input-mask',
+    driver,
+  });
+  await waitAndClick(inputMask, driver);
+  await driver
+    .actions()
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .perform();
 });
 
 it('should be able to go to review on send flow', async () => {
@@ -282,6 +296,20 @@ it('should be able to select token on send flow', async () => {
     driver,
   });
   await findElementByTestIdAndClick({ id: 'value-input-max', driver });
+  const inputMask = await findElementByTestId({
+    id: 'send-input-mask',
+    driver,
+  });
+  await waitAndClick(inputMask, driver);
+  await driver
+    .actions()
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .sendKeys(Key.BACK_SPACE)
+    .perform();
 });
 
 it('should be able to go to review on send flow', async () => {

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -1,6 +1,6 @@
 import 'chromedriver';
 import 'geckodriver';
-import { Key, WebDriver } from 'selenium-webdriver';
+import { WebDriver } from 'selenium-webdriver';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from 'vitest';
 
 import {
@@ -197,20 +197,8 @@ it('should be able to click max and switch on send flow', async () => {
   expect(switchButton).toBeTruthy();
 
   await findElementByTestIdAndClick({ id: 'value-input-max', driver });
-  const inputMask = await findElementByTestId({
-    id: 'send-input-mask',
-    driver,
-  });
-  await waitAndClick(inputMask, driver);
-  await driver
-    .actions()
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .perform();
+  await delayTime('long');
+  await findElementByTestIdAndClick({ id: 'value-input-max', driver });
 });
 
 it('should be able to go to review on send flow', async () => {
@@ -296,20 +284,8 @@ it('should be able to select token on send flow', async () => {
     driver,
   });
   await findElementByTestIdAndClick({ id: 'value-input-max', driver });
-  const inputMask = await findElementByTestId({
-    id: 'send-input-mask',
-    driver,
-  });
-  await waitAndClick(inputMask, driver);
-  await driver
-    .actions()
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .sendKeys(Key.BACK_SPACE)
-    .perform();
+  await delayTime('long');
+  await findElementByTestIdAndClick({ id: 'value-input-max', driver });
 });
 
 it('should be able to go to review on send flow', async () => {

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -234,6 +234,7 @@ it('should be able to interact with destination menu on review on send flow', as
 });
 
 it('should be able to send transaction on review on send flow', async () => {
+  await delayTime('very-long');
   await findElementByTestIdAndClick({ id: 'review-confirm-button', driver });
   const sendTransaction = await transactionStatus();
   expect(await sendTransaction).toBe('success');

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -197,13 +197,6 @@ it('should be able to click max and switch on send flow', async () => {
   expect(switchButton).toBeTruthy();
 
   await findElementByTestIdAndClick({ id: 'value-input-max', driver });
-
-  const inputMask = await findElementByTestId({
-    id: 'send-input-mask',
-    driver,
-  });
-  await inputMask.clear();
-  await inputMask.sendKeys('0.01');
 });
 
 it('should be able to go to review on send flow', async () => {


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- make it send max instead fo inputting an amount. Found this was the source of the flakiness.

## What to test
- does send pass?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the end-to-end testing for the send flow by adjusting interactions with the UI elements and introducing delays to ensure stability during tests.

### Detailed summary
- Removed `setLoggingPrefs` from `options` in `e2e/helpers.ts`.
- Added `await delayTime('long')` before clicking `value-input-max` in multiple test cases in `e2e/serial/send/1_sendFlow.test.ts`.
- Removed the clearing and sending keys to `send-input-mask` in favor of clicking `value-input-max`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->