### PR TITLE
chore: raise platform minimums

### DIFF
--- a/scripts/firefox-manifest.js
+++ b/scripts/firefox-manifest.js
@@ -9,7 +9,7 @@ const manifestFF = {
     browser_specific_settings: {
       "gecko": {
         "id": "browserextension@rainbow.me",
-        "strict_min_version": "115.0"
+        "strict_min_version": "116.0"
       },
     },
     host_permissions: [

--- a/src/entries/background/handlers/handleOpenExtensionShortcut.ts
+++ b/src/entries/background/handlers/handleOpenExtensionShortcut.ts
@@ -6,11 +6,9 @@ import { RainbowError, logger } from '~/logger';
  * Handles keyboard commands for the extension
  */
 export const handleOpenExtensionShortcut = () => {
-  // firefox maps chrome > browser, but it does still use
-  // `browserAction` for manifest v2 & v3. in v3 chrome uses `action`
   const openPopup = () => {
     try {
-      (chrome.action || chrome.browserAction).openPopup();
+      chrome.action.openPopup();
     } catch (error) {
       logger.error(new RainbowError('Error opening extension popup'), {
         error,

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -56,7 +56,7 @@
     "512": "images/icon-16@32x.png"
   },
   "manifest_version": 3,
-  "minimum_chrome_version": "88",
+  "minimum_chrome_version": "102",
   "name": "Rainbow DEVELOPMENT BUILD",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Fixes BX-1838
Figma link (if any):

## What changed (plus any additional context for devs)
- bumped chrome to 102 for `chrome.scripting.getRegisteredContentScripts` and `chrome.storage.session`
- bumped firefox to 116 for `chrome.action.openPopup`

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
