### PR TITLE
network menus ui polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ screenshots/
 
 # Static data
 static/data
+
+# e2e test browser
+chrome/

--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -10,7 +10,6 @@ import {
   executePerformShortcut,
   findElementByTestId,
   findElementByTestIdAndClick,
-  findElementByTextAndClick,
   getExtensionIdByName,
   getRootUrl,
   importWalletFlow,
@@ -56,34 +55,77 @@ it('should be able to naviagate to network settings', async () => {
   await checkExtensionURL(driver, 'networks');
 });
 
-it('should be able to add an auto-complete network', async () => {
+it('should be able to search and filter networks', async () => {
   await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
-  await checkExtensionURL(driver, 'custom-chain');
-  await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
-  await findElementByTextAndClick(driver, 'Arbitrum Nova');
-  const symbol = await findElementByTestId({
-    id: 'custom-network-symbol',
+  await checkExtensionURL(driver, 'custom-networks');
+
+  // Test search functionality
+  await typeOnTextInput({
+    text: 'Arbitrum',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
+
+  // Should show Arbitrum networks
+  const arbitrumNova = await findElementByTestId({
+    id: 'custom-network-42170',
     driver,
   });
-  const symbolValue = await symbol.getAttribute('value');
-  expect(symbolValue).toContain('ETH');
+  expect(arbitrumNova).toBeTruthy();
 
-  // needs a couple seconds to validate the custom RPC
-  await delayTime('very-long');
+  // Test no results scenario
+  const searchInput = await findElementByTestId({
+    id: 'search-networks-input',
+    driver,
+  });
+  await searchInput.clear();
+  await typeOnTextInput({
+    text: 'nonexistentnetwork',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
 
+  // Should show no results message and manual form link
+  const noResults = await findElementByTestId({
+    id: 'no-networks-found',
+    driver,
+  });
+  expect(noResults).toBeTruthy();
+
+  const manualLink = await findElementByTestId({
+    id: 'add-custom-network-manual',
+    driver,
+  });
+  expect(manualLink).toBeTruthy();
+
+  // Clear search and go back to full list
+  await searchInput.clear();
+  await delayTime('medium');
+});
+
+it('should be able to navigate from list to manual form', async () => {
+  // Click on the manual form link
+  await checkExtensionURL(driver, 'custom-networks');
   await findElementByTestIdAndClick({
     driver,
-    id: 'add-custom-network-button',
+    id: 'add-custom-network-manual',
   });
-  const novaChain = await findElementByTestId({
-    id: 'network-row-42170',
-    driver,
-  });
-  expect(novaChain).toBeTruthy();
+
+  // Should navigate to the manual form
+  await checkExtensionURL(driver, 'custom-chain');
+
+  // Navigate back to continue with other tests
+  await executePerformShortcut({ driver, key: 'ARROW_LEFT' });
+  await checkExtensionURL(driver, 'custom-networks');
 });
 
 it('should be able to add a custom network', async () => {
-  await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await findElementByTestIdAndClick({
+    driver,
+    id: 'add-custom-network-manual',
+  });
   await checkExtensionURL(driver, 'custom-chain');
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
 
@@ -104,15 +146,24 @@ it('should be able to add a custom network', async () => {
     id: 'add-custom-network-button',
   });
 
+  await delayTime('very-long');
+
   const cronos = await findElementByTestId({
     id: 'network-row-25',
     driver,
   });
   expect(cronos).toBeTruthy();
+
+  await delayTime('long'); // wait for confirm toast to disappear
 });
 
 it('should be able to add a custom testnet network', async () => {
   await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await checkExtensionURL(driver, 'custom-networks');
+  await findElementByTestIdAndClick({
+    driver,
+    id: 'add-custom-network-manual',
+  });
   await checkExtensionURL(driver, 'custom-chain');
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
 
@@ -135,11 +186,43 @@ it('should be able to add a custom testnet network', async () => {
     id: 'add-custom-network-button',
   });
 
+  await delayTime('very-long');
+
   const cronosTestnet = await findElementByTestId({
     id: 'network-row-338',
     driver,
   });
   expect(cronosTestnet).toBeTruthy();
+
+  await delayTime('long'); // wait for confirm toast to disappear
+});
+
+it('should be able to add a known custom network from list', async () => {
+  await findElementByTestIdAndClick({ driver, id: 'custom-chain-link' });
+  await checkExtensionURL(driver, 'custom-networks');
+
+  // Search for Arbitrum Nova
+  await typeOnTextInput({
+    text: 'Arbitrum Nova',
+    driver,
+    id: 'search-networks-input',
+  });
+  await delayTime('medium');
+
+  // Click on Arbitrum Nova network directly from the list
+  await findElementByTestIdAndClick({ driver, id: 'custom-network-42170' });
+
+  // Should navigate back to networks page after adding
+  await checkExtensionURL(driver, 'networks');
+
+  // Verify the network was added
+  const novaChain = await findElementByTestId({
+    id: 'network-row-42170',
+    driver,
+  });
+  expect(novaChain).toBeTruthy();
+
+  await delayTime('very-long'); // wait for confirm toast to disappear
 });
 
 it('should be able to add a custom ETH RPC and switch to it', async () => {
@@ -147,6 +230,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
   await checkExtensionURL(driver, 'rpcs');
 
   await findElementByTestIdAndClick({ driver, id: 'custom-rpc-button' });
+  await checkExtensionURL(driver, 'custom-chain');
 
   // fill out custom network form
   await findElementByTestIdAndClick({ driver, id: 'network-name-field' });
@@ -157,7 +241,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
     // RPC URL
     await findElementByTestIdAndClick({ driver, id: 'custom-network-rpc-url' });
     await typeOnTextInput({
-      text: 'https://rpc.ankr.com/eth',
+      text: 'https://eth.llamarpc.com',
       driver,
     });
 
@@ -186,7 +270,7 @@ it('should be able to add a custom ETH RPC and switch to it', async () => {
       timesToPress: 30,
     });
     await typeOnTextInput({
-      text: 'https://eth.llamarpc.com',
+      text: 'https://eth.drpc.org',
       driver,
     });
 

--- a/src/entries/popup/Routes.tsx
+++ b/src/entries/popup/Routes.tsx
@@ -66,6 +66,7 @@ import { Send } from './pages/send';
 import { Currency } from './pages/settings/currency';
 import { SettingsCustomChain } from './pages/settings/customChain';
 import { AddAsset } from './pages/settings/customChain/addAsset';
+import { SettingsCustomChainsList } from './pages/settings/customChain/list';
 import { Language } from './pages/settings/language';
 import { SettingsNetworks } from './pages/settings/networks';
 import { AutoLockTimer } from './pages/settings/privacy/autoLockTimer';
@@ -569,6 +570,21 @@ const ROUTE_DATA = [
         background="surfaceSecondary"
       >
         <SettingsNetworksRPCs />
+      </AnimatedRoute>
+    ),
+  },
+  {
+    path: ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS,
+    element: (
+      <AnimatedRoute
+        direction="right"
+        navbar
+        navbarIcon="arrow"
+        title="Custom Networks"
+        protectedRoute
+        background="surfaceSecondary"
+      >
+        <SettingsCustomChainsList />
       </AnimatedRoute>
     ),
   },

--- a/src/entries/popup/pages/settings/customChain/addAsset.tsx
+++ b/src/entries/popup/pages/settings/customChain/addAsset.tsx
@@ -8,7 +8,7 @@ import { i18n } from '~/core/languages';
 import { useAssetMetadata } from '~/core/resources/assets/assetMetadata';
 import { usePopupInstanceStore } from '~/core/state/popupInstances';
 import { useRainbowChainAssetsStore } from '~/core/state/rainbowChainAssets';
-import { Box, Button, Inline, Stack } from '~/design-system';
+import { Box, Button, Inset, Stack } from '~/design-system';
 import { Form } from '~/entries/popup/components/Form/Form';
 import { FormInput } from '~/entries/popup/components/Form/FormInput';
 import { maskInput } from '~/entries/popup/components/InputMask/utils';
@@ -271,17 +271,18 @@ export function AddAsset() {
             tabIndex={0}
           />
 
-          <Inline alignHorizontal="right">
+          <Inset top="10px">
             <Button
               onClick={addAsset}
               color="accent"
               height="36px"
               variant="raised"
               tabIndex={0}
+              width="full"
             >
               {i18n.t('settings.networks.watch_asset.add_token')}
             </Button>
-          </Inline>
+          </Inset>
         </Form>
       </Stack>
     </Box>

--- a/src/entries/popup/pages/settings/customChain/addAsset.tsx
+++ b/src/entries/popup/pages/settings/customChain/addAsset.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Address } from 'viem';
 
+import { i18n } from '~/core/languages';
 import { useAssetMetadata } from '~/core/resources/assets/assetMetadata';
 import { usePopupInstanceStore } from '~/core/state/popupInstances';
 import { useRainbowChainAssetsStore } from '~/core/state/rainbowChainAssets';
@@ -223,7 +224,9 @@ export function AddAsset() {
             onChange={(t) =>
               onInputChange<string>(t.target.value, 'string', 'address')
             }
-            placeholder="Address"
+            placeholder={i18n.t(
+              'settings.networks.watch_asset.address_placeholder',
+            )}
             value={asset.address}
             loading={assetMetadataIsFetching}
             onBlur={onAddressBlur}
@@ -234,7 +237,9 @@ export function AddAsset() {
             onChange={(t) =>
               onInputChange<string>(t.target.value, 'string', 'name')
             }
-            placeholder="Name"
+            placeholder={i18n.t(
+              'settings.networks.watch_asset.name_placeholder',
+            )}
             value={asset.name || assetMetadata?.name}
             onBlur={onNameBlur}
             borderColor={validations.name ? 'accent' : 'red'}
@@ -245,7 +250,9 @@ export function AddAsset() {
             onChange={(t) =>
               onInputChange<number>(t.target.value, 'number', 'decimals')
             }
-            placeholder="Decimals"
+            placeholder={i18n.t(
+              'settings.networks.watch_asset.decimals_placeholder',
+            )}
             value={asset.decimals || assetMetadata?.decimals}
             onBlur={onDecimalsBlur}
             borderColor={validations.decimals ? 'accent' : 'red'}
@@ -255,7 +262,9 @@ export function AddAsset() {
             onChange={(t) =>
               onInputChange<string>(t.target.value, 'string', 'symbol')
             }
-            placeholder="Symbol"
+            placeholder={i18n.t(
+              'settings.networks.watch_asset.symbol_placeholder',
+            )}
             value={asset.symbol || assetMetadata?.symbol}
             onBlur={onSymbolBlur}
             borderColor={validations.symbol ? 'accent' : 'red'}
@@ -270,7 +279,7 @@ export function AddAsset() {
               variant="raised"
               tabIndex={0}
             >
-              Add
+              {i18n.t('settings.networks.watch_asset.add_token')}
             </Button>
           </Inline>
         </Form>

--- a/src/entries/popup/pages/settings/customChain/addAsset.tsx
+++ b/src/entries/popup/pages/settings/customChain/addAsset.tsx
@@ -230,7 +230,7 @@ export function AddAsset() {
             value={asset.address}
             loading={assetMetadataIsFetching}
             onBlur={onAddressBlur}
-            borderColor={validations.address ? 'accent' : 'red'}
+            borderColor={validations.address ? 'transparent' : 'red'}
             tabIndex={0}
           />
           <FormInput
@@ -242,7 +242,7 @@ export function AddAsset() {
             )}
             value={asset.name || assetMetadata?.name}
             onBlur={onNameBlur}
-            borderColor={validations.name ? 'accent' : 'red'}
+            borderColor={validations.name ? 'transparent' : 'red'}
             tabIndex={0}
             testId={'token-name-field'}
           />
@@ -255,7 +255,7 @@ export function AddAsset() {
             )}
             value={asset.decimals || assetMetadata?.decimals}
             onBlur={onDecimalsBlur}
-            borderColor={validations.decimals ? 'accent' : 'red'}
+            borderColor={validations.decimals ? 'transparent' : 'red'}
             tabIndex={0}
           />
           <FormInput
@@ -267,7 +267,7 @@ export function AddAsset() {
             )}
             value={asset.symbol || assetMetadata?.symbol}
             onBlur={onSymbolBlur}
-            borderColor={validations.symbol ? 'accent' : 'red'}
+            borderColor={validations.symbol ? 'transparent' : 'red'}
             tabIndex={0}
           />
 

--- a/src/entries/popup/pages/settings/customChain/index.tsx
+++ b/src/entries/popup/pages/settings/customChain/index.tsx
@@ -387,7 +387,7 @@ export function SettingsCustomChain() {
               width="full"
               testId={'add-custom-network-button'}
             >
-              {i18n.t('settings.networks.custom_rpc.add_network')}
+              {i18n.t('settings.networks.custom_rpc.add_rpc')}
             </Button>
           </Inset>
         </Form>

--- a/src/entries/popup/pages/settings/customChain/index.tsx
+++ b/src/entries/popup/pages/settings/customChain/index.tsx
@@ -37,7 +37,6 @@ export function SettingsCustomChain() {
   const draftKey = chain?.id ?? 'new';
   const savedDraft = customNetworkDrafts[draftKey];
   const [customRPC, setCustomRPC] = useState<{
-    active?: boolean;
     testnet?: boolean;
     rpcUrl?: string;
     chainId?: number;
@@ -50,7 +49,6 @@ export function SettingsCustomChain() {
       chainId: chain?.id,
       symbol: chain?.nativeCurrency.symbol,
       explorerUrl: chain?.blockExplorers?.default.url,
-      active: !chain, // True only if adding a new network
     },
   );
   const [validations, setValidations] = useState<{
@@ -93,7 +91,6 @@ export function SettingsCustomChain() {
         | 'name'
         | 'symbol'
         | 'explorerUrl'
-        | 'active'
         | 'testnet',
     ) => {
       if (type === 'number' && typeof value === 'string') {
@@ -245,7 +242,7 @@ export function SettingsCustomChain() {
         },
         testnet: customRPC.testnet,
       };
-      addCustomChain(chainId, chain, rpcUrl, customRPC.active ?? false);
+      addCustomChain(chainId, chain, rpcUrl, true); // active by default
       triggerToast({
         title: i18n.t('settings.networks.custom_rpc.network_added'),
         description: i18n.t(
@@ -356,25 +353,6 @@ export function SettingsCustomChain() {
             spellCheck={false}
             tabIndex={4}
           />
-          <Box padding="10px">
-            <Inline alignHorizontal="justify" alignVertical="center">
-              <Text
-                align="center"
-                weight="semibold"
-                size="12pt"
-                color="labelSecondary"
-              >
-                {i18n.t('settings.networks.custom_rpc.active')}
-              </Text>
-              <Checkbox
-                borderColor="accent"
-                onClick={() =>
-                  onInputChange<boolean>(!customRPC.active, 'boolean', 'active')
-                }
-                selected={!!customRPC.active}
-              />
-            </Inline>
-          </Box>
           <Box padding="10px">
             <Inline alignHorizontal="justify" alignVertical="center">
               <Text

--- a/src/entries/popup/pages/settings/customChain/index.tsx
+++ b/src/entries/popup/pages/settings/customChain/index.tsx
@@ -8,7 +8,7 @@ import { useChainMetadata } from '~/core/resources/chains/chainMetadata';
 import { useNetworkStore } from '~/core/state/networks/networks';
 import { usePopupInstanceStore } from '~/core/state/popupInstances';
 import { getDappHostname, isValidUrl } from '~/core/utils/connectedApps';
-import { Box, Button, Inline, Stack, Text } from '~/design-system';
+import { Box, Button, Inline, Inset, Stack, Text } from '~/design-system';
 import { Form } from '~/entries/popup/components/Form/Form';
 import { FormInput } from '~/entries/popup/components/Form/FormInput';
 import { triggerToast } from '~/entries/popup/components/Toast/Toast';
@@ -399,7 +399,7 @@ export function SettingsCustomChain() {
               />
             </Inline>
           </Box>
-          <Inline alignHorizontal="right">
+          <Inset top="10px">
             <Button
               onClick={addCustomRpc}
               color="accent"
@@ -411,7 +411,7 @@ export function SettingsCustomChain() {
             >
               {i18n.t('settings.networks.custom_rpc.add_network')}
             </Button>
-          </Inline>
+          </Inset>
         </Form>
       </Stack>
     </Box>

--- a/src/entries/popup/pages/settings/customChain/list.tsx
+++ b/src/entries/popup/pages/settings/customChain/list.tsx
@@ -1,0 +1,181 @@
+import { AddressZero } from '@ethersproject/constants';
+import { useCallback, useMemo, useState } from 'react';
+
+import { i18n } from '~/core/languages';
+import { useDeveloperToolsEnabledStore } from '~/core/state/currentSettings/developerToolsEnabled';
+import { useNetworkStore } from '~/core/state/networks/networks';
+import { getCustomChainIconUrl } from '~/core/utils/assets';
+import { Box, Stack, Symbol, Text } from '~/design-system';
+import { Input } from '~/design-system/components/Input/Input';
+import { Menu } from '~/entries/popup/components/Menu/Menu';
+import { MenuContainer } from '~/entries/popup/components/Menu/MenuContainer';
+import { MenuItem } from '~/entries/popup/components/Menu/MenuItem';
+import { triggerToast } from '~/entries/popup/components/Toast/Toast';
+import { useRainbowNavigate } from '~/entries/popup/hooks/useRainbowNavigate';
+
+import ExternalImage from '../../../components/ExternalImage/ExternalImage';
+import { ROUTES } from '../../../urls';
+
+export function SettingsCustomChainsList() {
+  const navigate = useRainbowNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { developerToolsEnabled } = useDeveloperToolsEnabledStore();
+  const customNetworks = useNetworkStore((state) =>
+    state.getSupportedCustomNetworks(),
+  );
+  const addCustomChain = useNetworkStore((state) => state.addCustomChain);
+
+  const filteredNetworks = useMemo(() => {
+    const networks = customNetworks.filter((network) =>
+      developerToolsEnabled ? true : !network.testnet.isTestnet,
+    );
+
+    if (!searchTerm.trim()) {
+      return networks;
+    }
+
+    return networks.filter((network) =>
+      network.name.toLowerCase().includes(searchTerm.toLowerCase()),
+    );
+  }, [customNetworks, searchTerm, developerToolsEnabled]);
+
+  const handleNetworkSelect = useCallback(
+    (network: (typeof customNetworks)[0]) => {
+      // Create a chain object similar to what the form creates
+      const chain = {
+        id: network.id,
+        name: network.name,
+        nativeCurrency: {
+          symbol: network.nativeAsset.symbol,
+          decimals: 18,
+          name: network.nativeAsset.symbol,
+        },
+        rpcUrls: {
+          default: { http: [network.defaultRPCURL] },
+          public: { http: [network.defaultRPCURL] },
+        },
+        blockExplorers: {
+          default: {
+            name: network.defaultExplorerURL
+              ? new URL(network.defaultExplorerURL).hostname
+              : '',
+            url: network.defaultExplorerURL || '',
+          },
+        },
+        testnet: network.testnet.isTestnet,
+      };
+
+      addCustomChain(network.id, chain, network.defaultRPCURL, true);
+
+      triggerToast({
+        title: i18n.t('settings.networks.custom_rpc.network_added'),
+        description: i18n.t(
+          'settings.networks.custom_rpc.network_added_correctly',
+          { networkName: network.name },
+        ),
+      });
+
+      navigate(ROUTES.SETTINGS__NETWORKS, {
+        state: { backTo: ROUTES.SETTINGS },
+      });
+    },
+    [addCustomChain, navigate],
+  );
+
+  const handleAddCustomNetwork = useCallback(() => {
+    navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC);
+  }, [navigate]);
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchTerm(e.target.value);
+    },
+    [],
+  );
+
+  const showNoResults = searchTerm.trim() && filteredNetworks.length === 0;
+
+  return (
+    <Box paddingHorizontal="20px">
+      <Stack space="20px">
+        {/* Search Input */}
+        <Input
+          placeholder="Search networks..."
+          value={searchTerm}
+          onChange={handleSearchChange}
+          variant="surfaceBordered"
+          height="32px"
+          autoFocus
+          testId="search-networks-input"
+        />
+
+        {/* Networks List */}
+        <MenuContainer>
+          <Menu>
+            {filteredNetworks.map((network, index) => (
+              <MenuItem
+                key={network.id}
+                first={index === 0}
+                last={!showNoResults && index === filteredNetworks.length - 1}
+                leftComponent={
+                  <ExternalImage
+                    borderRadius="10px"
+                    customFallbackSymbol="globe"
+                    height={20}
+                    src={getCustomChainIconUrl(network.id, AddressZero)}
+                    width={20}
+                  />
+                }
+                titleComponent={<MenuItem.Title text={network.name} />}
+                labelComponent={
+                  network.testnet.isTestnet ? (
+                    <Text color="labelQuaternary" size="11pt" weight="medium">
+                      {i18n.t('settings.networks.testnet')}
+                    </Text>
+                  ) : null
+                }
+                onClick={() => handleNetworkSelect(network)}
+                testId={`custom-network-${network.id}`}
+              />
+            ))}
+
+            {showNoResults && (
+              <MenuItem
+                first
+                titleComponent={<MenuItem.Title text="No networks found" />}
+                disabled
+                testId="no-networks-found"
+              />
+            )}
+
+            {/* Add Custom Network Button */}
+            {(filteredNetworks.length > 0 || showNoResults) && (
+              <MenuItem
+                last
+                leftComponent={
+                  <Symbol
+                    symbol="plus.circle.fill"
+                    weight="medium"
+                    size={18}
+                    color="blue"
+                  />
+                }
+                titleComponent={
+                  <MenuItem.Title
+                    color="blue"
+                    text={i18n.t(
+                      'settings.networks.custom_rpc.add_custom_network',
+                    )}
+                  />
+                }
+                onClick={handleAddCustomNetwork}
+                testId="add-custom-network-manual"
+              />
+            )}
+          </Menu>
+        </MenuContainer>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/entries/popup/pages/settings/networks.tsx
+++ b/src/entries/popup/pages/settings/networks.tsx
@@ -111,37 +111,6 @@ export function SettingsNetworks() {
 
   return (
     <Box paddingHorizontal="20px">
-      {config.custom_rpc_enabled && (
-        <MenuContainer>
-          <Menu>
-            <MenuItem
-              testId={'custom-chain-link'}
-              first
-              last
-              leftComponent={
-                <Symbol
-                  symbol="plus.circle.fill"
-                  weight="medium"
-                  size={18}
-                  color="blue"
-                />
-              }
-              onClick={() =>
-                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS)
-              }
-              titleComponent={
-                <MenuItem.Title
-                  color="blue"
-                  text={i18n.t(
-                    'settings.networks.custom_rpc.add_custom_network',
-                  )}
-                />
-              }
-            />
-          </Menu>
-        </MenuContainer>
-      )}
-
       {!seenPromos[promoTypes.network_settings] && (
         <Inset bottom="20px">
           <QuickPromo
@@ -282,6 +251,34 @@ export function SettingsNetworks() {
             </Text>
           </Box>
         </Menu>
+
+        {config.custom_rpc_enabled && (
+          <Menu>
+            <MenuItem
+              testId={'custom-chain-link'}
+              first
+              last
+              leftComponent={
+                <Symbol
+                  symbol="plus.circle.fill"
+                  weight="medium"
+                  size={18}
+                  color="blue"
+                />
+              }
+              onClick={() =>
+                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS)
+              }
+              titleComponent={
+                <MenuItem.Title
+                  color="blue"
+                  text={i18n.t('settings.networks.custom_rpc.add_network')}
+                />
+              }
+            />
+          </Menu>
+        )}
+
         <Menu>
           <MenuItem
             leftComponent={

--- a/src/entries/popup/pages/settings/networks.tsx
+++ b/src/entries/popup/pages/settings/networks.tsx
@@ -127,13 +127,7 @@ export function SettingsNetworks() {
                 />
               }
               onClick={() =>
-                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC, {
-                  state: {
-                    title: i18n.t(
-                      'settings.networks.custom_rpc.add_custom_network',
-                    ),
-                  },
-                })
+                navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_NETWORKS)
               }
               titleComponent={
                 <MenuItem.Title

--- a/src/entries/popup/pages/settings/rpcs.tsx
+++ b/src/entries/popup/pages/settings/rpcs.tsx
@@ -22,7 +22,6 @@ import {
   Inline,
   Row,
   Rows,
-  Separator,
   Symbol,
   Text,
   TextOverflow,
@@ -326,13 +325,8 @@ export function SettingsNetworksRPCs() {
                 </Box>
               ))}
             </Box>
-          </Menu>
-        ) : null}
-
-        {config.custom_rpc_enabled &&
-        (activeChain?.name || supportedChain?.name) ? (
-          <>
-            <Menu>
+            {config.custom_rpc_enabled &&
+            (activeChain?.name || supportedChain?.name) ? (
               <MenuItem
                 first
                 last
@@ -365,9 +359,8 @@ export function SettingsNetworksRPCs() {
                 }
                 testId={'custom-rpc-button'}
               />
-            </Menu>
-            <Separator color="separatorTertiary" strokeWeight="1px" />
-          </>
+            ) : null}
+          </Menu>
         ) : null}
 
         {config.custom_rpc_enabled && customNetworkAssetsForChain.length ? (
@@ -470,7 +463,6 @@ export function SettingsNetworksRPCs() {
                 }
               />
             </Menu>
-            <Separator color="separatorTertiary" strokeWeight="1px" />
           </>
         )}
 
@@ -537,7 +529,6 @@ export function SettingsNetworksRPCs() {
                 ))}
               </Box>
             </Menu>
-            <Separator color="separatorTertiary" strokeWeight="1px" />
           </>
         ) : null}
 

--- a/src/entries/popup/pages/settings/rpcs.tsx
+++ b/src/entries/popup/pages/settings/rpcs.tsx
@@ -433,39 +433,6 @@ export function SettingsNetworksRPCs() {
           </Menu>
         ) : null}
 
-        {config.custom_rpc_enabled && (
-          <>
-            <Menu>
-              <MenuItem
-                testId={'custom-token-link'}
-                first
-                last
-                leftComponent={
-                  <Symbol
-                    color="blue"
-                    symbol="plus.circle.fill"
-                    weight="medium"
-                    size={18}
-                  />
-                }
-                onClick={() =>
-                  navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC__DETAILS, {
-                    state: {
-                      chainId,
-                    },
-                  })
-                }
-                titleComponent={
-                  <MenuItem.Title
-                    color="blue"
-                    text={i18n.t('settings.networks.custom_rpc.add_asset')}
-                  />
-                }
-              />
-            </Menu>
-          </>
-        )}
-
         {developerToolsEnabled && testnetChains().length ? (
           <>
             <Menu>
@@ -531,6 +498,39 @@ export function SettingsNetworksRPCs() {
             </Menu>
           </>
         ) : null}
+
+        {config.custom_rpc_enabled && (
+          <>
+            <Menu>
+              <MenuItem
+                testId={'custom-token-link'}
+                first
+                last
+                leftComponent={
+                  <Symbol
+                    color="blue"
+                    symbol="plus.circle.fill"
+                    weight="medium"
+                    size={18}
+                  />
+                }
+                onClick={() =>
+                  navigate(ROUTES.SETTINGS__NETWORKS__CUSTOM_RPC__DETAILS, {
+                    state: {
+                      chainId,
+                    },
+                  })
+                }
+                titleComponent={
+                  <MenuItem.Title
+                    color="blue"
+                    text={i18n.t('settings.networks.custom_rpc.add_asset')}
+                  />
+                }
+              />
+            </Menu>
+          </>
+        )}
 
         {!supportedChains[chainId] ? (
           <Menu>

--- a/src/entries/popup/urls.ts
+++ b/src/entries/popup/urls.ts
@@ -35,6 +35,7 @@ export const ROUTES = {
   SETTINGS__NETWORKS: '/settings/networks', // Networks
   SETTINGS__APPROVALS: '/settings/approvals', // Approvals
   SETTINGS__NETWORKS__RPCS: '/settings/networks/rpcs', // RPCs per network
+  SETTINGS__NETWORKS__CUSTOM_NETWORKS: '/settings/networks/custom-networks', // Custom Networks List
   SETTINGS__NETWORKS__CUSTOM_RPC: '/settings/networks/custom-chain', // Networks Custom Chain
   SETTINGS__NETWORKS__CUSTOM_RPC__DETAILS:
     '/settings/networks/custom-chain/details', // Networks Custom Chain details

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -132,7 +132,12 @@
       },
       "rpc_endpoints": "RPCs",
       "watch_asset": {
-        "title": "Add Token"
+        "title": "Add Token",
+        "add_token": "Add Token",
+        "address_placeholder": "Address",
+        "name_placeholder": "Name",
+        "decimals_placeholder": "Decimals",
+        "symbol_placeholder": "Symbol"
       }
     },
     "privacy_and_security": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -98,7 +98,7 @@
       "disabled": "Disabled",
       "enable": "Enable",
       "enabled": "Network Enabled",
-      "description": "Choose which networks and tokens to display. You can connect to any networks supported by Rainbow, even if they’re unchecked.",
+      "description": "Choose which networks and tokens to display. You can still connect to any network supported by Rainbow, even if they’re disabled.",
       "developer_tools": {
         "title": "Enable Developer Tools",
         "toggle_explainer": "Enables the Testnet Mode shortcut (T) and adds a toggle to the home screen’s top-right menu."

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -118,7 +118,7 @@
         "add_network": "Add Network",
         "add_rpc": "Add Custom RPC",
         "add_network_rpc": "Add %{rpcName} RPC",
-        "add_asset": "Add Custom Token",
+        "add_asset": "Add Token",
         "network_added": "Network Added",
         "network_added_correctly": "%{networkName}",
         "remove_token": "Remove Token",
@@ -132,7 +132,7 @@
       },
       "rpc_endpoints": "RPCs",
       "watch_asset": {
-        "title": "Add Custom Token"
+        "title": "Add Token"
       }
     },
     "privacy_and_security": {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -116,7 +116,7 @@
         "testnet": "Testnet",
         "block_explorer_url": "Block Explorer URL",
         "add_network": "Add Network",
-        "add_rpc": "Add RPC Endpoint",
+        "add_rpc": "Add Custom RPC",
         "add_network_rpc": "Add %{rpcName} RPC",
         "add_asset": "Add Custom Token",
         "network_added": "Network Added",
@@ -125,12 +125,12 @@
         "remove_rpc": "Remove RPC",
         "remove_network": "Remove Network",
         "tokens": "Tokens",
-        "cant_connect": "Can't connect to this RPC endpoint",
-        "rpc_not_responding": "The provided RPC endpoint is not responding",
+        "cant_connect": "Can't connect to this RPC",
+        "rpc_not_responding": "The provided RPC is not responding",
         "rainbow_default_rpc": "Rainbow",
         "rainbow_default": "Rainbow"
       },
-      "rpc_endpoints": "RPC Endpoints",
+      "rpc_endpoints": "RPCs",
       "watch_asset": {
         "title": "Add Custom Token"
       }

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -104,7 +104,7 @@
         "toggle_explainer": "Enables the Testnet Mode shortcut (T) and adds a toggle to the home screen’s top-right menu."
       },
       "custom_rpc": {
-        "title": "Add Custom RPC",
+        "title": "Add RPC",
         "add_custom_network": "Add Custom Network",
         "networks": "Networks",
         "network_name": "Network Name",
@@ -116,7 +116,7 @@
         "testnet": "Testnet",
         "block_explorer_url": "Block Explorer URL",
         "add_network": "Add Network",
-        "add_rpc": "Add Custom RPC",
+        "add_rpc": "Add RPC",
         "add_network_rpc": "Add %{rpcName} RPC",
         "add_asset": "Add Token",
         "network_added": "Network Added",


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- added i18n for custom token flow
- removed 'active' checkbox for rpcs (default active)
- standardized the add buttons
- improved custom rpc, custom network, custom token jargon
- improved add asset form colors
- moved add rpc button for network into the menu item bubble
- shifted "Add Custom Network" to below the network list; renamed to "Add Network"

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on modifying the user interface for managing custom RPC networks and assets in the settings of a popup. It includes updates to menu items, translations, and component layouts to enhance user experience.

### Detailed summary
- Removed and added `Menu` components for custom RPC management.
- Updated translation keys for clarity (e.g., changed "Add Custom RPC" to "Add RPC").
- Adjusted button placeholders and labels in forms for adding assets.
- Refined layout components from `Inline` to `Inset` for better spacing.
- Changed logic to set `active` status of custom chains to true by default.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->