### PR TITLE
feat: add advances reporting for invalid address validation

### DIFF
--- a/src/core/keychain/keychainTypes/readOnlyKeychain.ts
+++ b/src/core/keychain/keychainTypes/readOnlyKeychain.ts
@@ -6,7 +6,7 @@ import { Wallet } from '@ethersproject/wallet';
 import { Address } from 'viem';
 
 import { KeychainType } from '~/core/types/keychainTypes';
-import { logger } from '~/logger';
+import { RainbowError, logger } from '~/logger';
 
 import { IKeychain, PrivateKey } from '../IKeychain';
 
@@ -43,8 +43,9 @@ export class ReadOnlyKeychain implements IKeychain {
 
   async deserialize(opts: SerializedReadOnlyKeychain) {
     if (!isAddress(opts.address)) {
-      logger.info('Invalid address:', { address: opts.address });
-      throw new Error(`Invalid address: ${opts.address}`);
+      const error = new RainbowError('Invalid address');
+      logger.error(error, { address: opts.address });
+      throw error;
     }
     this.address = opts.address;
   }

--- a/src/core/keychain/keychainTypes/readOnlyKeychain.ts
+++ b/src/core/keychain/keychainTypes/readOnlyKeychain.ts
@@ -44,7 +44,7 @@ export class ReadOnlyKeychain implements IKeychain {
   async deserialize(opts: SerializedReadOnlyKeychain) {
     if (!isAddress(opts.address)) {
       logger.info('Invalid address:', { address: opts.address });
-      throw new Error('Invalid address');
+      throw new Error(`Invalid address: ${opts.address}`);
     }
     this.address = opts.address;
   }


### PR DESCRIPTION
This will help to get more info re https://linear.app/rainbow/issue/BX-1841/error-invalid-address

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the error handling in the `ReadOnlyKeychain` class by replacing a generic `Error` with a custom `RainbowError`. It also changes the logging level from `info` to `error` for invalid addresses.

### Detailed summary
- Added `RainbowError` import from `~/logger`.
- Replaced the `Error` thrown for invalid addresses with a `RainbowError`.
- Changed the log level from `info` to `error` when logging invalid addresses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->