### PR TITLE
chore: cleanup selenium driver imports

### DIFF
--- a/e2e/parallel/LedgerImportFlow.test.ts
+++ b/e2e/parallel/LedgerImportFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/TrezorImportFlow.test.ts
+++ b/e2e/parallel/TrezorImportFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/commandKFlow.test.ts
+++ b/e2e/parallel/commandKFlow.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/importWalletFlow.test.ts
+++ b/e2e/parallel/importWalletFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 

--- a/e2e/parallel/importWalletFlowPkey.test.ts
+++ b/e2e/parallel/importWalletFlowPkey.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 

--- a/e2e/parallel/newWalletFlow.test.ts
+++ b/e2e/parallel/newWalletFlow.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/nftsFlow.test.ts
+++ b/e2e/parallel/nftsFlow.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/settingsFlows.test.ts
+++ b/e2e/parallel/settingsFlows.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/settingsPrivacyFlows.test.ts
+++ b/e2e/parallel/settingsPrivacyFlows.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/shortcuts-home.test.ts
+++ b/e2e/parallel/shortcuts-home.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/shortcuts-settings.test.ts
+++ b/e2e/parallel/shortcuts-settings.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/shortcuts-walletSwitcher.test.ts
+++ b/e2e/parallel/shortcuts-walletSwitcher.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/parallel/watchWalletFlow.test.ts
+++ b/e2e/parallel/watchWalletFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/serial/dappInteractions/1_appInteractionsFlow.test.ts
+++ b/e2e/serial/dappInteractions/1_appInteractionsFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { getAddress } from '@ethersproject/address';
 import { isHexString } from '@ethersproject/bytes';
 import { verifyMessage, verifyTypedData } from '@ethersproject/wallet';

--- a/e2e/serial/dappInteractions/2_dappInteractionFlow.test.ts
+++ b/e2e/serial/dappInteractions/2_dappInteractionFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { getAddress } from '@ethersproject/address';
 import { WebDriver } from 'selenium-webdriver';
 import {

--- a/e2e/serial/dappInteractions/3_dappAccountsSwitcher.test.ts
+++ b/e2e/serial/dappInteractions/3_dappAccountsSwitcher.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/dappInteractions/4_networksAndTestnetModeFlow.test.ts
+++ b/e2e/serial/dappInteractions/4_networksAndTestnetModeFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/dappInteractions/5_maliciousDapp.test.ts
+++ b/e2e/serial/dappInteractions/5_maliciousDapp.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/optimismTransactions/1_sendFlow.test.ts
+++ b/e2e/serial/optimismTransactions/1_sendFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/send/1_sendFlow.test.ts
+++ b/e2e/serial/send/1_sendFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from 'vitest';
 

--- a/e2e/serial/send/2_shortcuts-sendFlow.test.ts
+++ b/e2e/serial/send/2_shortcuts-sendFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { Key, WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/send/3_customNetworks.test.ts
+++ b/e2e/serial/send/3_customNetworks.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 
 import { WebDriver } from 'selenium-webdriver';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from 'vitest';

--- a/e2e/serial/send/4_nft-sendFlow.test.ts
+++ b/e2e/serial/send/4_nft-sendFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { WebDriver } from 'selenium-webdriver';
 import {
   afterAll,

--- a/e2e/serial/swap/1_swapFlow1.test.ts
+++ b/e2e/serial/swap/1_swapFlow1.test.ts
@@ -1,6 +1,4 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import 'chromedriver';
-import 'geckodriver';
 import { Key, WebDriver } from 'selenium-webdriver';
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from 'vitest';
 

--- a/e2e/serial/swap/2_swapFlow2.test.ts
+++ b/e2e/serial/swap/2_swapFlow2.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { ChainId } from '@rainbow-me/swaps';

--- a/e2e/serial/swap/3_shortcuts-swapFlow.test.ts
+++ b/e2e/serial/swap/3_shortcuts-swapFlow.test.ts
@@ -1,5 +1,3 @@
-import 'chromedriver';
-import 'geckodriver';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { WebDriver } from 'selenium-webdriver';
 import {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "audit-ci": "6.3.0",
     "browserify": "17.0.0",
     "chalk": "5.3.0",
-    "chromedriver": "138",
+    "chromedriver": "138.0.5",
     "circular-dependency-plugin": "5.2.2",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@types/react": "18.0.21",
     "@types/react-beautiful-dnd": "13.1.3",
     "@types/react-dom": "18.0.6",
-    "@types/selenium-webdriver": "4.1.15",
+    "@types/selenium-webdriver": "4.1.28",
     "@types/semver": "7.3.13",
     "@types/validator": "13.7.12",
     "@typescript-eslint/eslint-plugin": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "@testing-library/react": "13.4.0",
     "@total-typescript/ts-reset": "0.4.2",
     "@types/chroma-js": "2.1.4",
-    "@types/chrome": "0.0.237",
+    "@types/chrome": "0.1.1",
     "@types/fs-extra": "9.0.13",
     "@types/lodash": "4.14.186",
     "@types/node": "18.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10059,7 +10059,7 @@ __metadata:
     chalk: "npm:5.3.0"
     check-password-strength: "npm:2.0.7"
     chroma-js: "npm:2.4.2"
-    chromedriver: "npm:138"
+    chromedriver: "npm:138.0.5"
     circular-dependency-plugin: "npm:5.2.2"
     clsx: "npm:1.2.1"
     cmdk: "npm:0.2.0"
@@ -10877,9 +10877,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:138":
-  version: 138.0.3
-  resolution: "chromedriver@npm:138.0.3"
+"chromedriver@npm:138.0.5":
+  version: 138.0.5
+  resolution: "chromedriver@npm:138.0.5"
   dependencies:
     "@testim/chrome-version": "npm:^1.1.4"
     axios: "npm:^1.7.4"
@@ -10890,7 +10890,7 @@ __metadata:
     tcp-port-used: "npm:^1.0.2"
   bin:
     chromedriver: bin/chromedriver
-  checksum: 10c0/f532a98d208c40e2cf54a18460b52634bde047ca409502a5ad9c63ac4e233a014d722838d2ab12371f7d585adcbac92fdf848bd70bf389c098db7a998f27e2b2
+  checksum: 10c0/b814df6ce699c37fa3d9b5c7be099c6f82923db5e5a56d7a979b09c320e51b345fb623ef264b82b2ef39e959163f892e19480eb96270b571ce89d16b439ab212
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7078,13 +7078,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chrome@npm:0.0.237":
-  version: 0.0.237
-  resolution: "@types/chrome@npm:0.0.237"
+"@types/chrome@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@types/chrome@npm:0.1.1"
   dependencies:
     "@types/filesystem": "npm:*"
     "@types/har-format": "npm:*"
-  checksum: 10c0/1e28700c935d019c31bd556986a10384b855ee0b02fb3520966d49945ce223fcca6cf9c1b93ae21cb624c8c6fbc54ea0e78e07a6e52d33aaf84d987008825bdf
+  checksum: 10c0/e497e3c78dc4078d5517970acf2e890ab6ef51d03d1ad34639015e314cffbb0b681c99b9a20a03aeb35fc2cc9d8d3d6c2c25037d940ea1cd79c289a84342de90
   languageName: node
   linkType: hard
 
@@ -10029,7 +10029,7 @@ __metadata:
     "@trezor/connect-plugin-ethereum": "npm:9.0.2"
     "@trezor/connect-web": "npm:9.4.2"
     "@types/chroma-js": "npm:2.1.4"
-    "@types/chrome": "npm:0.0.237"
+    "@types/chrome": "npm:0.1.1"
     "@types/fs-extra": "npm:9.0.13"
     "@types/lodash": "npm:4.14.186"
     "@types/node": "npm:18.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7404,12 +7404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/selenium-webdriver@npm:4.1.15":
-  version: 4.1.15
-  resolution: "@types/selenium-webdriver@npm:4.1.15"
+"@types/selenium-webdriver@npm:4.1.28":
+  version: 4.1.28
+  resolution: "@types/selenium-webdriver@npm:4.1.28"
   dependencies:
+    "@types/node": "npm:*"
     "@types/ws": "npm:*"
-  checksum: 10c0/1cc11bb4a3aab7d6a2fc15dc4101eaa0daf5fa3e77a705e52350bc90b8a8d537e85c82feef8bcf0d85f3944ec501404373bb080be01f18ce8134bc99f6a12475
+  checksum: 10c0/69a0eba9376d676299ee73384a4ff2bb1b35d926ec72e380281fd8cee53777baa01cb8040e3ba2665c547bbe4faf8fc5ca69e07f0b95bd7079bb1ac27fe53de8
   languageName: node
   linkType: hard
 
@@ -10039,7 +10040,7 @@ __metadata:
     "@types/react": "npm:18.0.21"
     "@types/react-beautiful-dnd": "npm:13.1.3"
     "@types/react-dom": "npm:18.0.6"
-    "@types/selenium-webdriver": "npm:4.1.15"
+    "@types/selenium-webdriver": "npm:4.1.28"
     "@types/semver": "npm:7.3.13"
     "@types/validator": "npm:13.7.12"
     "@typescript-eslint/eslint-plugin": "npm:6.4.1"


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- Upgraded chrome/selenium types
- Removed driver imports that are no longer required as of selenium-webdriver v4

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating various test files by removing the import of `geckodriver` from multiple test files and updating dependencies in `package.json` and `yarn.lock`.

### Detailed summary
- Removed `import 'geckodriver';` from multiple test files across different directories.
- Updated `@types/chrome` from version `0.0.237` to `0.1.1` in `package.json`.
- Updated `@types/selenium-webdriver` from version `4.1.15` to `4.1.28` in `package.json`.
- Updated `chromedriver` from version `138` to `138.0.5` in `package.json`.
- Adjusted corresponding entries in `yarn.lock` for the above dependency changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->