### PR TITLE
fix: chrome.commands registration on Firefox Mobile

### DIFF
--- a/src/entries/background/handlers/handleOpenExtensionShortcut.ts
+++ b/src/entries/background/handlers/handleOpenExtensionShortcut.ts
@@ -16,7 +16,7 @@ export const handleOpenExtensionShortcut = () => {
     }
   };
 
-  chrome.commands.onCommand.addListener((command) => {
+  chrome.commands?.onCommand.addListener((command) => {
     if (command === 'open_rainbow') {
       openPopup();
 

--- a/src/entries/background/handlers/handleOpenExtensionShortcut.ts
+++ b/src/entries/background/handlers/handleOpenExtensionShortcut.ts
@@ -16,6 +16,8 @@ export const handleOpenExtensionShortcut = () => {
     }
   };
 
+  // chrome.commands may not be available in incompatible browsers
+  // this handler executes before we gate mobile users in onboarding
   chrome.commands?.onCommand.addListener((command) => {
     if (command === 'open_rainbow') {
       openPopup();


### PR DESCRIPTION
Fixes BX-1869
Figma link (if any):

## What changed (plus any additional context for devs)

Resolves a `.onCommand is undefined` error on Firefox Mobile. User encounters the `isMobile()` flow to block Onboarding, but the shortcut handler still attempts to register this command

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `handleOpenExtensionShortcut.ts` file to add a safety check for `chrome.commands` before adding an event listener. This change ensures compatibility with browsers that may not support the `chrome.commands` API, particularly for mobile users during onboarding.

### Detailed summary
- Added comments explaining the potential unavailability of `chrome.commands` in incompatible browsers.
- Implemented optional chaining (`?.`) for `chrome.commands.onCommand.addListener` to prevent errors in unsupported environments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->