### PR TITLE
fix: disable firefox for mobile side loading

### DIFF
--- a/scripts/firefox-manifest.js
+++ b/scripts/firefox-manifest.js
@@ -11,6 +11,10 @@ const manifestFF = {
         "id": "browserextension@rainbow.me",
         "strict_min_version": "116.0"
       },
+      "gecko_android": {
+        "id": "browserextension@rainbow.me",
+        "strict_max_version": "0"
+      },
     },
     host_permissions: [
       ...manifestBase.host_permissions,


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- Firefox for Mobile still allows sideloading unless we add a specific `gecko_android` manifest filter for versions above `0`

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Android by including a new `gecko_android` object in the `scripts/firefox-manifest.js` file, which specifies an `id` and `strict_max_version` for the browser extension.

### Detailed summary
- Added `gecko_android` object to `scripts/firefox-manifest.js`:
  - `id`: "browserextension@rainbow.me"
  - `strict_max_version`: "0"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->