### PR TITLE
feat: add 'Open in New Tab' context menu

### DIFF
--- a/src/entries/background/handlers/handleInstallExtension.ts
+++ b/src/entries/background/handlers/handleInstallExtension.ts
@@ -7,27 +7,25 @@ import { POPUP_URL, WELCOME_URL, goToNewTab } from '~/core/utils/tabs';
  */
 export const handleInstallExtension = () =>
   chrome.runtime.onInstalled.addListener(async (details) => {
-    if (process.env.IS_DEV === 'true') {
-      chrome.contextMenus.create({
-        id: 'open-tab',
-        title: 'Open Extension in a New Tab',
-        type: 'normal',
-        contexts: ['action'],
-      });
+    chrome.contextMenus.create({
+      id: 'open-tab',
+      title: 'Open in New Tab',
+      type: 'normal',
+      contexts: ['action'],
+    });
 
-      chrome.contextMenus.onClicked.addListener((info) => {
-        switch (info.menuItemId) {
-          case 'open-tab':
-            goToNewTab({
-              url: POPUP_URL,
-            });
-        }
-      });
-      // This breaks e2e!!
-    } else if (
-      process.env.IS_TESTING !== 'true' &&
-      details.reason === 'install'
-    ) {
+    chrome.contextMenus.onClicked.addListener((info) => {
+      switch (info.menuItemId) {
+        case 'open-tab':
+          goToNewTab({
+            url: POPUP_URL,
+          });
+          break;
+        default:
+      }
+    });
+    // This breaks e2e!!
+    if (process.env.IS_TESTING !== 'true' && details.reason === 'install') {
       // Only show onboarding on actual install, not on updates or browser restarts
       // wait till the keychain is initialized
       let ready = await isInitialized();


### PR DESCRIPTION
## Summary
- add "Open in New Tab" context menu item for extension icon in all environments

## Testing
- `yarn lint src/entries/background/handlers/handleInstallExtension.ts`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b9144c2208325b2847a7cfcd74928

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `handleInstallExtension` function to modify the context menu item and enhance code clarity. It removes the conditional check for the development environment and refines the context menu creation and click handling logic.

### Detailed summary
- Changed the context menu item's title from `Open Extension in a New Tab` to `Open in New Tab`.
- Removed the conditional check for `process.env.IS_DEV`.
- Added a `break` statement in the `switch` case for clarity.
- Adjusted the conditional check for showing onboarding to use a simplified syntax.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->