### PR TITLE
fix: testing, dev network list alignment

### DIFF
--- a/src/core/state/favorites/index.ts
+++ b/src/core/state/favorites/index.ts
@@ -8,13 +8,12 @@ type UpdateFavoritesArgs = {
   chainId: ChainId;
 };
 
-const IS_DEV = process.env.IS_DEV === 'true';
 const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
 
 const getInitialFavorites = () => {
   return buildTimeNetworks.backendNetworks.networks.reduce(
     (acc, network) => {
-      if (network.internal && !(INTERNAL_BUILD || IS_DEV)) return acc;
+      if (network.internal && !INTERNAL_BUILD) return acc;
 
       return {
         ...acc,

--- a/src/core/state/networks/constants.ts
+++ b/src/core/state/networks/constants.ts
@@ -3,8 +3,5 @@ import buildTimeNetworks from 'static/data/networks.json';
 export const DEFAULT_PRIVATE_MEMPOOL_TIMEOUT = 2 * 60 * 1_000; // 2 minutes
 
 export const RPC_PROXY_API_KEY = process.env.RPC_PROXY_API_KEY;
-export const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
-export const IS_DEV = process.env.IS_DEV === 'true';
-export const IS_TESTING = process.env.IS_TESTING === 'true';
 
 export { buildTimeNetworks };

--- a/src/core/state/networks/utils.ts
+++ b/src/core/state/networks/utils.ts
@@ -14,9 +14,6 @@ import { logger } from '~/logger';
 
 import {
   DEFAULT_PRIVATE_MEMPOOL_TIMEOUT,
-  INTERNAL_BUILD,
-  IS_DEV,
-  IS_TESTING,
   RPC_PROXY_API_KEY,
   buildTimeNetworks,
 } from './constants';
@@ -24,6 +21,9 @@ import { NetworkState, NetworkUserPreferences } from './types';
 
 // Export the constant for backward compatibility
 export { DEFAULT_PRIVATE_MEMPOOL_TIMEOUT };
+
+const IS_TESTING = process.env.IS_TESTING === 'true';
+const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
 
 export function getBadgeUrl({
   chainBadges,
@@ -84,7 +84,7 @@ export function transformBackendNetworksToChains(
   }
   // include all networks for internal builds, otherwise filter out flagged as internal
   return networks
-    .filter((network) => !network.internal || INTERNAL_BUILD || IS_DEV)
+    .filter((network) => !network.internal || INTERNAL_BUILD)
     .map((network) => transformBackendNetworkToChain(network));
 }
 
@@ -193,7 +193,7 @@ export const buildInitialUserPreferences = (
   const userPreferences: Record<number, ChainPreferences> = {};
   const initialNonInternalNetworks =
     initialSupportedNetworks.backendNetworks.networks.filter(
-      (network) => !network.internal || INTERNAL_BUILD || IS_DEV,
+      (network) => !network.internal || INTERNAL_BUILD,
     );
 
   logger.debug('[buildInitialUserPreferences] Filtered non-internal networks', {


### PR DESCRIPTION
## BX-1901

What changed

- Matching `IS_DEV`​ and `IS_TESTING`​ and prod network lists to be more closely aligned with a prod environment and reduce network divergence variables; internal builds now contain a larger set of networks
- Removed the `IS_DEV` environment variable check when determining whether to show internal networks
- Now internal networks will only be shown in internal builds, not in development environments
- Moved environment variable constants from global exports to local usage where needed

## What to test

- Verify that internal networks are only visible in internal builds
- Confirm that development environments no longer show internal networks
- Check that favorites functionality works correctly with the updated network filtering logic

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the conditional logic in the handling of internal networks by removing the `IS_DEV` and `IS_TESTING` checks from several parts of the code, ensuring that only the `INTERNAL_BUILD` variable is used for filtering.

### Detailed summary
- Removed `IS_DEV` and `IS_TESTING` checks from `src/core/state/networks/constants.ts`.
- Updated the `getInitialFavorites` function in `src/core/state/favorites/index.ts` to only check `INTERNAL_BUILD`.
- Adjusted the filtering logic in `src/core/state/networks/utils.ts` to remove `IS_DEV`.
- Reintroduced `IS_TESTING` and `INTERNAL_BUILD` constants in `src/core/state/networks/utils.ts` for backward compatibility.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->