### PR TITLE
fix: test networks migration in e2e

### DIFF
--- a/src/core/state/rainbowChains/index.ts
+++ b/src/core/state/rainbowChains/index.ts
@@ -4,7 +4,6 @@ import { createRainbowStore } from '~/core/state/internal/createRainbowStore';
 import { ChainId } from '~/core/types/chains';
 
 import { runNetworksMigrationIfNeeded } from '../networks/migration';
-const IS_TESTING = process.env.IS_TESTING === 'true';
 
 export interface RainbowChain {
   activeRpcUrl: string;
@@ -118,7 +117,7 @@ export const useRainbowChainsStore = createRainbowStore<RainbowChainsState>(
     version: 13,
     onRehydrateStorage: () => {
       return (_, error) => {
-        if (!error && !IS_TESTING) {
+        if (!error) {
           runNetworksMigrationIfNeeded('rainbowChains');
         }
       };


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Remove unnecessary test divergence in network store migration

---

Removed the `IS_TESTING` environment variable check in the `onRehydrateStorage` callback of the Rainbow Chains store. This ensures that the network migration will always run when there's no error, regardless of whether the app is in testing mode or not.

## What to test

- Verify that network migrations run correctly in both testing and non-testing environments
- Ensure that the Rainbow Chains store initializes properly
- Check that there are no regressions in chain-related functionality

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the conditional check for the `IS_TESTING` environment variable when running the `runNetworksMigrationIfNeeded` function, ensuring that the migration runs regardless of the testing environment.

### Detailed summary
- Removed the constant `IS_TESTING` from `src/core/state/rainbowChains/index.ts`.
- Updated the condition in `onRehydrateStorage` to always run `runNetworksMigrationIfNeeded('rainbowChains')` if there is no error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->