### PR TITLE
fix: addressless asset fetching

### DIFF
--- a/src/core/resources/assets/customNetworkAssets.ts
+++ b/src/core/resources/assets/customNetworkAssets.ts
@@ -371,6 +371,7 @@ export function useCustomNetworkAssets<
     }),
     queryFn: customNetworkAssetsFunction,
     ...config,
+    enabled: !!address && config.enabled !== false,
     refetchInterval: CUSTOM_NETWORK_ASSETS_REFETCH_INTERVAL,
     staleTime: process.env.IS_TESTING === 'true' ? 0 : 1000,
   });

--- a/src/core/resources/assets/userAssets.ts
+++ b/src/core/resources/assets/userAssets.ts
@@ -262,6 +262,7 @@ export function useUserAssets<TSelectResult = UserAssetsResult>(
     }),
     queryFn: userAssetsQueryFunction,
     ...config,
+    enabled: !!address && config.enabled !== false,
     refetchInterval: USER_ASSETS_REFETCH_INTERVAL,
     staleTime: process.env.IS_TESTING === 'true' ? 0 : 1000,
     placeholderData: (previousData) => previousData,
@@ -383,6 +384,7 @@ export function useUserAssetsByChain<TSelectResult = UserAssetsByChainResult>(
     }),
     queryFn: userAssetsByChainQueryFunction,
     ...config,
+    enabled: !!address && config.enabled !== false,
     refetchInterval: USER_ASSETS_REFETCH_INTERVAL,
   });
 }


### PR DESCRIPTION
# Prevent empty address fetches in asset queries

## What changed (plus any additional context for devs)

- Added conditional `enabled` property to asset query hooks to prevent API calls with empty addresses
- Prevents unnecessary network requests to endpoints like `https://addys.p.rainbow.me/v3/1,10,56,137,8453,42161//assets/?currency=usd` (note the double slash)
- The hooks will now only execute when an address is provided AND the config's enabled property isn't explicitly set to false

## What to test

- Verify that no asset queries are made when address is undefined/empty (i.e. switching balls)
- Confirm that queries still work properly when a valid address is provided

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding an `enabled` property to the configuration of queries in the `customNetworkAssets.ts` and `userAssets.ts` files, which determines if the query should run based on the presence of an `address` and the `enabled` state in the configuration.

### Detailed summary
- In `customNetworkAssets.ts`:
  - Added `enabled: !!address && config.enabled !== false` to the query configuration.
  
- In `userAssets.ts`:
  - Added `enabled: !!address && config.enabled !== false` to the query configuration.
  - Added `placeholderData: (previousData) => previousData` to the query configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->