### PR TITLE
feat: orpc wagmi update

### DIFF
--- a/src/entries/background/index.ts
+++ b/src/entries/background/index.ts
@@ -6,9 +6,7 @@ import {
   syncNetworksStore,
   syncStores,
 } from '~/core/state/internal/syncStores';
-import { useNetworkStore } from '~/core/state/networks/networks';
 import { localStorageRecycler } from '~/core/storage/localStorageRecycler';
-import { updateWagmiConfig } from '~/core/wagmi';
 
 import { handleDisconnect } from './handlers/handleDisconnect';
 import { handleInstallExtension } from './handlers/handleInstallExtension';
@@ -43,9 +41,3 @@ syncNetworksStore('background');
 syncStores();
 
 uuid4();
-
-const popupMessenger = initializeMessenger({ connect: 'popup' });
-popupMessenger.reply('rainbow_updateWagmiClient', async () => {
-  const activeChains = useNetworkStore.getState().getAllActiveRpcChains();
-  updateWagmiConfig(activeChains);
-});

--- a/src/entries/background/procedures/popup/state/index.ts
+++ b/src/entries/background/procedures/popup/state/index.ts
@@ -1,7 +1,9 @@
 import { requestsRouter } from './requests';
 import { sessionsRouter } from './sessions';
+import { wagmiRouter } from './wagmi';
 
 export const stateRouter = {
   requests: requestsRouter,
   sessions: sessionsRouter,
+  wagmi: wagmiRouter,
 };

--- a/src/entries/background/procedures/popup/state/wagmi.ts
+++ b/src/entries/background/procedures/popup/state/wagmi.ts
@@ -1,0 +1,14 @@
+import { os } from '@orpc/server';
+import z from 'zod';
+
+import { useNetworkStore } from '~/core/state/networks/networks';
+import { updateWagmiConfig } from '~/core/wagmi';
+
+const updateClientHandler = os.output(z.void()).handler(async () => {
+  const activeChains = useNetworkStore.getState().getAllActiveRpcChains();
+  updateWagmiConfig(activeChains);
+});
+
+export const wagmiRouter = {
+  updateClient: updateClientHandler,
+};

--- a/src/entries/popup/App.tsx
+++ b/src/entries/popup/App.tsx
@@ -11,7 +11,6 @@ import { flushQueuedEvents } from '~/analytics/flushQueuedEvents';
 // !!!! DO NOT REMOVE THE NEXT 2 LINES BELOW !!!!
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import config from '~/core/firebase/remoteConfig';
-import { initializeMessenger } from '~/core/messengers';
 import { persistOptions, queryClient } from '~/core/react-query';
 import { initializeSentry } from '~/core/sentry';
 import { useCurrentLanguageStore, useCurrentThemeStore } from '~/core/state';
@@ -30,14 +29,13 @@ import { Routes } from './Routes';
 import { HWRequestListener } from './components/HWRequestListener/HWRequestListener';
 import { IdleTimer } from './components/IdleTimer/IdleTimer';
 import { OnboardingKeepAlive } from './components/OnboardingKeepAlive';
+import { popupClient } from './handlers/background';
 import { AuthProvider } from './hooks/useAuth';
 import { useExpiryListener } from './hooks/useExpiryListener';
 import { useIsFullScreen } from './hooks/useIsFullScreen';
 import usePrevious from './hooks/usePrevious';
 
 initializeSentry('popup');
-
-const backgroundMessenger = initializeMessenger({ connect: 'background' });
 
 export function App() {
   const { currentLanguage, setCurrentLanguage } = useCurrentLanguageStore();
@@ -53,9 +51,7 @@ export function App() {
 
   React.useEffect(() => {
     if (!isEqual(prevChains, activeChains)) {
-      backgroundMessenger.send('rainbow_updateWagmiClient', {
-        rpcProxyEnabled: config.rpc_proxy_enabled,
-      });
+      void popupClient.state.wagmi.updateClient();
       setWagmiConfig(
         createConfig({
           chains: createChains(activeChains),


### PR DESCRIPTION
# Refactor Wagmi Client Update Mechanism

Fixes BX-1891

## What changed (plus any additional context for devs)

- Migrated the Wagmi client update mechanism from using a messenger-based approach to using ORPC router
- Removed the direct messenger implementation in the background script
- Created a new dedicated Wagmi router in the background procedures
- Updated the popup to use the new ORPC client instead of the messenger

This change improves the architecture by using a more structured approach with ORPC for communication between popup and background contexts.

## What to test

- Verify that the Wagmi client updates correctly when network chains change
- Ensure that all network-related functionality continues to work properly
- Test switching between different networks to confirm the client updates appropriately

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `wagmiRouter` to manage updates related to the `wagmi` configuration, refactoring how active RPC chains are handled. It also removes old messenger interactions for updating the `wagmi` client in the `App` component.

### Detailed summary
- Added `wagmiRouter` in `src/entries/background/procedures/popup/state/wagmi.ts` for handling `updateClient`.
- Integrated `wagmiRouter` into `stateRouter` in `src/entries/background/procedures/popup/state/index.ts`.
- Removed `popupMessenger.reply` for `rainbow_updateWagmiClient` in `src/entries/background/index.ts`.
- Updated `App` component to call `popupClient.state.wagmi.updateClient()` instead of using the messenger.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->