### PR TITLE
feat: move settings messages to orpc

### DIFF
--- a/src/entries/background/handlers/handlePrefetchMetadata.ts
+++ b/src/entries/background/handlers/handlePrefetchMetadata.ts
@@ -3,6 +3,7 @@ import { prefetchDappMetadata } from '~/core/resources/metadata/dapp';
 
 const bridgeMessenger = initializeMessenger({ connect: 'inpage' });
 
+// This handler needs to stay, as it's triggered from the shared @rainbow/provider package
 export const handlePrefetchDappMetadata = () => {
   bridgeMessenger.reply(
     'rainbow_prefetchDappMetadata',

--- a/src/entries/background/handlers/handleTabAndWindowUpdates.ts
+++ b/src/entries/background/handlers/handleTabAndWindowUpdates.ts
@@ -5,7 +5,7 @@ import {
 } from '~/core/state';
 import { usePendingRequestStore } from '~/core/state/requests';
 
-const bridgeMessenger = initializeMessenger({ connect: 'inpage' });
+const inpageMessenger = initializeMessenger({ connect: 'inpage' });
 
 export const handleTabAndWindowUpdates = () => {
   // When a tab is removed, check if that was the last tab for that host
@@ -26,7 +26,7 @@ export const handleTabAndWindowUpdates = () => {
   });
 
   chrome.tabs.onActivated.addListener(() => {
-    bridgeMessenger.send('rainbow_setDefaultProvider', {
+    inpageMessenger.send('rainbow_setDefaultProvider', {
       rainbowAsDefault: useIsDefaultWalletStore.getState().isDefaultWallet,
     });
   });

--- a/src/entries/background/procedures/popup/state/index.ts
+++ b/src/entries/background/procedures/popup/state/index.ts
@@ -1,8 +1,10 @@
+import { rainbowRouter } from './rainbow';
 import { requestsRouter } from './requests';
 import { sessionsRouter } from './sessions';
 import { wagmiRouter } from './wagmi';
 
 export const stateRouter = {
+  rainbow: rainbowRouter,
   requests: requestsRouter,
   sessions: sessionsRouter,
   wagmi: wagmiRouter,

--- a/src/entries/background/procedures/popup/state/rainbow.ts
+++ b/src/entries/background/procedures/popup/state/rainbow.ts
@@ -1,0 +1,23 @@
+import { os } from '@orpc/server';
+import z from 'zod';
+
+import { initializeMessenger } from '~/core/messengers';
+
+const inpageMessenger = initializeMessenger({ connect: 'inpage' });
+
+const SetDefaultProviderInputSchema = z.object({
+  rainbowAsDefault: z.boolean(),
+});
+
+// Ping handler (equivalent to current keep alive)
+const setDefaultProviderHandler = os
+  .input(SetDefaultProviderInputSchema)
+  .handler(async ({ input: { rainbowAsDefault } }) => {
+    await inpageMessenger.send('rainbow_setDefaultProvider', {
+      rainbowAsDefault,
+    });
+  });
+
+export const rainbowRouter = {
+  setDefaultProvider: setDefaultProviderHandler,
+};

--- a/src/entries/popup/pages/settings/settings.tsx
+++ b/src/entries/popup/pages/settings/settings.tsx
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import { analytics } from '~/analytics';
 import { event } from '~/analytics/event';
 import { i18n, supportedLanguages } from '~/core/languages';
-import { initializeMessenger } from '~/core/messengers';
 import { supportedCurrencies } from '~/core/references';
 import {
   RAINBOW_FEEDBACK_URL,
@@ -35,13 +34,12 @@ import { MenuItem } from '~/entries/popup/components/Menu/MenuItem';
 import { SwitchMenu } from '~/entries/popup/components/SwitchMenu/SwitchMenu';
 
 import packageJson from '../../../../../package.json';
+import { popupClient } from '../../handlers/background';
 import { testSandbox } from '../../handlers/wallet';
 import { useDeviceUUID } from '../../hooks/useDeviceUUID';
 import { useRainbowNavigate } from '../../hooks/useRainbowNavigate';
 import { useWallets } from '../../hooks/useWallets';
 import { ROUTES } from '../../urls';
-
-const messenger = initializeMessenger({ connect: 'inpage' });
 
 export function Settings() {
   const navigate = useRainbowNavigate();
@@ -111,7 +109,8 @@ export function Settings() {
           : event.settingsRainbowDefaultProviderDisabled,
       );
       setIsDefaultWallet(rainbowAsDefault);
-      messenger.send('rainbow_setDefaultProvider', { rainbowAsDefault });
+      // dont wait
+      void popupClient.state.rainbow.setDefaultProvider({ rainbowAsDefault });
     },
     [setIsDefaultWallet],
   );


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `rainbowRouter` functionality by adding a new handler for setting a default provider and updating the messaging system to improve communication between components.

### Detailed summary
- Added `rainbowRouter` with `setDefaultProvider` handler in `src/entries/background/procedures/popup/state/rainbow.ts`.
- Updated `stateRouter` to include `rainbowRouter` in `src/entries/background/procedures/popup/state/index.ts`.
- Changed variable name from `bridgeMessenger` to `inpageMessenger` in various files to maintain consistency.
- Modified `handleTabAndWindowUpdates` to use `inpageMessenger` instead of `bridgeMessenger`.
- Updated `Settings` component to call `popupClient.state.rainbow.setDefaultProvider` instead of using `messenger`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->