### PR TITLE
chore: chrome 139

### DIFF
--- a/e2e/browsers.json
+++ b/e2e/browsers.json
@@ -1,7 +1,7 @@
 {
     "mac": {
       "chrome": {
-        "version": "138.0.7204.183",
+        "version": "139.0.7258.138",
         "path": "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
         "extension_scheme": "chrome-extension://"
       },
@@ -13,7 +13,7 @@
     },
     "linux": {
       "chrome": {
-        "version": "138.0.7204.183",
+        "version": "139.0.7258.138",
         "path": "/opt/google/chrome/chrome",
         "extension_scheme": "chrome-extension://"
       },

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -108,12 +108,14 @@ export async function initDriverWithOptions(opts: {
     '--disable-extensions-except=build/',
     '--disable-popup-blocking',
     '--remote-debugging-port=9222',
+    // BX-1923: localhost network access is permissioned in dev 139, and prod 141
+    '--disable-features=LocalNetworkAccessChecks,LocalNetworkAccessForWorkers',
   ];
 
   if (opts.browser === 'firefox') {
     const options = new firefox.Options()
       .setBinary(browserBinaryPath)
-      .addArguments(...args.slice(1))
+      .addArguments(...args.slice(1, -1))
       .setPreference('xpinstall.signatures.required', false)
       .setPreference('extensions.langpacks.signatures.required', false)
       .addExtensions('rainbowbx.xpi');

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "browserify": "17.0.0",
     "buffer": "6.0.3",
     "bundlewatch": "0.4.1",
-    "chromedriver": "138.0.5",
+    "chromedriver": "139.0.2",
     "circular-dependency-plugin": "5.2.2",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.1",

--- a/scripts/setup-chrome.sh
+++ b/scripts/setup-chrome.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-# Setup Chrome 138 for testing
-# This script downloads Chrome 138 for testing binary and installs it to /Applications
+# This script downloads Chrome for Testing binary and installs it to /Applications
 
 set -e
 
-CHROME_VERSION="138.0.7204.183"
+CHROME_VERSION=$(node -p "require('./e2e/browsers.json').mac.chrome.version")
 TEMP_DIR="/tmp/chrome-testing-download"
 APP_NAME="Google Chrome for Testing.app"
 INSTALL_PATH="/Applications/$APP_NAME"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10398,7 +10398,7 @@ __metadata:
     bundlewatch: "npm:0.4.1"
     check-password-strength: "npm:2.0.7"
     chroma-js: "npm:2.4.2"
-    chromedriver: "npm:138.0.5"
+    chromedriver: "npm:139.0.2"
     circular-dependency-plugin: "npm:5.2.2"
     clsx: "npm:1.2.1"
     copy-webpack-plugin: "npm:11.0.0"
@@ -11265,9 +11265,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:138.0.5":
-  version: 138.0.5
-  resolution: "chromedriver@npm:138.0.5"
+"chromedriver@npm:139.0.2":
+  version: 139.0.2
+  resolution: "chromedriver@npm:139.0.2"
   dependencies:
     "@testim/chrome-version": "npm:^1.1.4"
     axios: "npm:^1.7.4"
@@ -11278,7 +11278,7 @@ __metadata:
     tcp-port-used: "npm:^1.0.2"
   bin:
     chromedriver: bin/chromedriver
-  checksum: 10c0/b814df6ce699c37fa3d9b5c7be099c6f82923db5e5a56d7a979b09c320e51b345fb623ef264b82b2ef39e959163f892e19480eb96270b571ce89d16b439ab212
+  checksum: 10c0/e8dc51bc1483c438a14a12daaa68416a55310d80aa5f041a8d996bdfb681cc3e81451f978b6a611e3feb52c3a559b601fa2c203e883140ef7fda410e6c9bb152
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BX-1923 

# Update Chrome and chromedriver to version 139

## What changed

- Updated Chrome version from 138.0.7204.183 to 139.0.7258.138 in e2e/browsers.json for both mac and linux environments
- Updated chromedriver from 138.0.5 to 139.0.2 in package.json and yarn.lock
- Improved setup-chrome.sh script to dynamically read the Chrome version from browsers.json instead of hardcoding it

## What to test

- Verify that e2e tests run successfully with the updated Chrome version
- Confirm that the setup-chrome.sh script correctly installs the specified Chrome version
- Check that there are no compatibility issues between the updated chromedriver and the application

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading the `chromedriver` version and updating related configurations in the project to ensure compatibility with the latest Chrome versions.

### Detailed summary
- Updated `chromedriver` version from `138.0.5` to `139.0.2` in `package.json` and `yarn.lock`.
- Changed Chrome version in `e2e/browsers.json` from `138.0.7204.183` to `139.0.7258.138` for both macOS and Linux.
- Modified `scripts/setup-chrome.sh` to dynamically set the `CHROME_VERSION`.
- Added a new argument to the Firefox options in `e2e/helpers.ts`.
- Updated the checksum for `chromedriver` in `yarn.lock`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->