### PR TITLE
e2e: test expansion for custom networks, rpcs

### DIFF
--- a/e2e/serial/dappInteractions/PROMPT.md
+++ b/e2e/serial/dappInteractions/PROMPT.md
@@ -1,0 +1,23 @@
+We need to add more test coverage for adding RPCs and custom networks. we have a test dapp we are currently using in e2e/serial/dappInteractions/1_appInteractionsFlow.test.ts which covers other flows and interacts with this dapp. can we add tests which meet the following goals and use the correct elements laid out below? The tests should:
+- start in the extension like the other tests
+- go to the dapp
+- interact with the elements
+- go back to the extension and have assertions that show the correct behavior from interacting with the dapp elements
+
+Feel free to research through our app, come up with a strategy and then implement it as best as you can. run the test locally to assure correct implementation. feel free to ask me questions as we go. no other part of the extension should need to be changed apart from this specific test file and potentially our helpers file in e2e/helpers.ts
+
+
+Here is the linear ticket:
+
+Goal:
+
+add e2e test to add custom network
+
+add e2e test to add custom rpc for mainnet
+
+Test dapp: https://bx-test-dapp.vercel.app/
+
+relevent elements: 
+
+element: <button class="Home_button__G93Ef" id="addRPC">add rpc</button>
+element: <button class="Home_button__G93Ef" id="addNetwork">add network</button>


### PR DESCRIPTION
Fixes BX-1853

## What changed (plus any additional context for devs)

- added e2e test to add custom network
- added e2e test to add custom rpc for mainnet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing test coverage for adding RPCs and custom networks within the application. It proposes the creation of new end-to-end tests that interact with a test dapp, ensuring proper functionality when adding these elements.

### Detailed summary
- Added a request to increase test coverage for adding RPCs and custom networks.
- Proposed the implementation of new tests in `e2e/serial/dappInteractions/1_appInteractionsFlow.test.ts`.
- Specified test goals, including interactions with specific buttons in the test dapp.
- Provided a link to the test dapp and relevant elements for interaction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->