### PR TITLE
fix: cors issue

### DIFF
--- a/src/core/resources/assets/userAssets.ts
+++ b/src/core/resources/assets/userAssets.ts
@@ -143,7 +143,7 @@ async function userAssetsQueryFunction({
       .getStaleBalancesQueryParam(address as Address);
     const url = `/${supportedChainIds.join(
       ',',
-    )}/${address}/assets/?currency=${currency.toLowerCase()}${staleBalancesParam}`;
+    )}/${address}/assets?currency=${currency.toLowerCase()}${staleBalancesParam}`;
     const res = await addysHttp.get<AddressAssetsReceivedMessage>(url, {
       timeout: USER_ASSETS_TIMEOUT_DURATION,
     });
@@ -331,7 +331,7 @@ async function userAssetsByChainQueryFunction({
   })?.state?.data || {}) as ParsedAssetsDictByChain;
   const cachedDataForChain = cachedUserAssets?.[chainId];
   try {
-    const url = `/${chainId}/${address}/assets/?currency=${currency.toLowerCase()}`;
+    const url = `/${chainId}/${address}/assets?currency=${currency.toLowerCase()}`;
     const res = await addysHttp.get<AddressAssetsReceivedMessage>(url);
     const chainIdsInResponse = res?.data?.meta?.chain_ids || [];
     const assets = res?.data?.payload?.assets || [];


### PR DESCRIPTION
Fixes BX-1654

## What changed

Asset fetching was using a url suffixed with `/` which resulted in a 302 response, without the proper CORS headers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the URL structure for fetching user assets by removing the trailing slash in asset endpoints to ensure consistency in API requests.

### Detailed summary
- Updated the URL in `userAssets.ts` for the user assets endpoint by removing the trailing slash:
  - Changed from `/${supportedChainIds.join(',',-)}/${address}/assets/?currency=${currency.toLowerCase()}` to `/${supportedChainIds.join(',',-)}/${address}/assets?currency=${currency.toLowerCase()}`
  - Changed from `/${chainId}/${address}/assets/?currency=${currency.toLowerCase()}` to `/${chainId}/${address}/assets?currency=${currency.toLowerCase()}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->