### PR TITLE
feat(swap): indicate swap refetch

### DIFF
--- a/src/design-system/components/Input/Input.tsx
+++ b/src/design-system/components/Input/Input.tsx
@@ -56,6 +56,7 @@ export type InputProps = {
   textAlign?: TextStyles['textAlign'];
   tabIndex?: number;
   id?: string;
+  className?: string;
 };
 
 export const stylesForVariant: Record<
@@ -179,6 +180,7 @@ export function Input({
   enableAccentSelectionStyle,
   enableTapScale = true,
   spellCheck,
+  className,
   ...inputProps
 }: InputProps) {
   const {
@@ -230,6 +232,7 @@ export function Input({
           borderColor === 'accent' || enableAccentSelectionStyle
             ? accentSelectionStyle
             : null,
+          className,
         ]}
         paddingHorizontal={paddingHorizontal}
         paddingVertical={paddingVertical}

--- a/src/entries/popup/components/InputMask/SwapInputMask/SwapInputMask.css.ts
+++ b/src/entries/popup/components/InputMask/SwapInputMask/SwapInputMask.css.ts
@@ -1,0 +1,16 @@
+import { keyframes, style as vanillaStyle } from '@vanilla-extract/css';
+
+// Pulse animation for input text
+export const pulseText = keyframes({
+  '0%': { opacity: 1 },
+  '50%': { opacity: 0.5 },
+  '100%': { opacity: 1 },
+});
+export const pulseTextStyle = vanillaStyle({
+  animation: `${pulseText} 1s infinite`,
+  selectors: {
+    '&::placeholder': {
+      animation: 'none', // Don't pulse placeholder
+    },
+  },
+});

--- a/src/entries/popup/components/InputMask/SwapInputMask/SwapInputMask.tsx
+++ b/src/entries/popup/components/InputMask/SwapInputMask/SwapInputMask.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import React, { CSSProperties, RefObject, useCallback } from 'react';
 
@@ -12,6 +13,8 @@ import {
 import { InputHeight } from '../../../../../design-system/components/Input/Input.css';
 import { maskInput } from '../utils';
 
+import { pulseTextStyle } from './SwapInputMask.css';
+
 interface SwapInputMaskProps {
   borderColor: BoxStyles['borderColor'];
   decimals?: number;
@@ -24,6 +27,7 @@ interface SwapInputMaskProps {
   onChange: (value: string) => void;
   paddingHorizontal?: number;
   placeholder: string;
+  pulseText?: boolean;
   accentCaretColor?: boolean;
   testId: string;
 }
@@ -38,6 +42,7 @@ export const SwapInputMask = ({
   height,
   innerRef,
   placeholder,
+  pulseText = false,
   style,
   value,
   variant,
@@ -85,6 +90,7 @@ export const SwapInputMask = ({
             caretColor: accentCaretColor ? accentColorAsHsl : undefined,
             cursor: disabled ? 'not-allowed' : 'text',
           }}
+          className={clsx(pulseText && pulseTextStyle)}
           enableTapScale={false}
           testId={`${testId}-swap-input-mask`}
           disabled={disabled}

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenInput.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenInput.tsx
@@ -75,6 +75,7 @@ interface TokenInputProps {
   variant: 'surface' | 'bordered' | 'transparent' | 'tinted';
   inputRef: React.RefObject<HTMLInputElement>;
   inputDisabled?: boolean;
+  isRefetching?: boolean;
   value: string;
   testId: string;
   openDropdownOnMount?: boolean;
@@ -106,6 +107,7 @@ export const TokenInput = React.forwardRef<
     variant,
     inputRef,
     inputDisabled,
+    isRefetching,
     value,
     testId,
     openDropdownOnMount,
@@ -240,6 +242,7 @@ export const TokenInput = React.forwardRef<
                   paddingHorizontal={0}
                   innerRef={inputRef}
                   disabled={inputDisabled}
+                  pulseText={isRefetching}
                 />
               </Box>
             </SwapInputMaskWrapper>

--- a/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
+++ b/src/entries/popup/pages/swap/SwapTokenInput/TokenToBuyInput.tsx
@@ -31,6 +31,7 @@ interface TokenToBuyProps {
   assetToSellValue: string;
   inputRef: React.RefObject<HTMLInputElement>;
   inputDisabled?: boolean;
+  isRefetching?: boolean;
   openDropdownOnMount?: boolean;
   assetToBuyNativeDisplay: { amount: string; display: string } | null;
   assetToSellNativeDisplay: { amount: string; display: string } | null;
@@ -61,6 +62,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
     assetToSellValue,
     inputRef,
     inputDisabled,
+    isRefetching,
     openDropdownOnMount,
     assetsToBuyNetworkSearchStatus,
     onDropdownOpen,
@@ -156,6 +158,7 @@ export const TokenToBuyInput = forwardRef(function TokenToBuyInput(
       inputDisabled={inputDisabled}
       ref={mergeRefs(ref, dropdownRef)}
       onFocus={() => setIndependentField('buyField')}
+      isRefetching={isRefetching}
     />
   );
 });

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -521,6 +521,8 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
   const {
     data: quote,
     isLoading: isLoadingQuote,
+    isRefetchingAfterInputChange,
+    isRefetching,
     isCrosschainSwap,
     isWrapOrUnwrapEth,
   } = useSwapQuote({
@@ -921,6 +923,7 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                   assetToBuyNativeDisplay={assetToBuyNativeDisplay}
                   assetToSellNativeDisplay={assetToSellNativeDisplay}
                   setIndependentField={setIndependentField}
+                  isRefetching={isRefetching}
                 />
               </AccentColorProvider>
 
@@ -958,7 +961,9 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
                       <SwapButton
                         showSwapReviewSheet={showSwapReviewSheet}
                         quote={quote}
-                        isLoadingQuote={isLoadingQuote}
+                        isLoadingQuote={
+                          isLoadingQuote || isRefetchingAfterInputChange
+                        }
                         assetToSell={assetToSell}
                         assetToSellValue={assetToSellValue}
                         assetToBuy={assetToBuy}


### PR DESCRIPTION
Fixes BX-1895

## What changed
- output amount indicates when it's refeching
- wait for first fetch after input amount change


https://github.com/user-attachments/assets/4f76fdae-8cf8-438c-b27a-d958c3f8f378




<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a pulse animation effect for input fields, enhances the `Input` and `TokenInput` components by adding a `className` prop, and implements refetching logic in the swap quote hook for improved user experience during input changes.

### Detailed summary
- Added `pulseText` animation in `SwapInputMask.css.ts`.
- Enhanced `Input` component with `className` prop.
- Updated `TokenInput` to accept `isRefetching` prop.
- Modified `TokenToBuyInput` to accept `isRefetching` prop.
- Integrated `isRefetching` into `SwapInputMask`.
- Implemented `isRefetchingAfterInputChange` in `useSwapQuote` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->