### PR TITLE
fix: delay in signing

### DIFF
--- a/src/core/state/index.ts
+++ b/src/core/state/index.ts
@@ -9,6 +9,7 @@ export {
   useCurrentThemeStore,
   useIsDefaultWalletStore,
 } from './currentSettings';
+export { usePendingRequestStore } from './requests';
 export { useColorCacheStore } from './dominantColor';
 export { useSavedEnsNamesStore } from './savedEnsNames';
 export { useStaleBalancesStore } from './staleBalances';

--- a/src/core/state/requests/index.ts
+++ b/src/core/state/requests/index.ts
@@ -5,9 +5,6 @@ import { onlyBackground } from '~/core/utils/onlyBackground';
 
 import { ProviderRequestPayload } from '../../transports/providerRequestTransport';
 
-// Throw an error if this file is loaded in the popup or inpage script
-onlyBackground('usePendingRequestStore');
-
 type Responses =
   | { status: 'APPROVED'; payload: unknown }
   | { status: 'REJECTED'; payload: null };
@@ -31,10 +28,14 @@ export const usePendingRequestStore = createRainbowStore<PendingRequestsStore>(
   (set, get) => ({
     pendingRequests: [],
     addPendingRequest: (newRequest) => {
+      onlyBackground('usePendingRequestStore.addPendingRequest()');
+
       const pendingRequests = get().pendingRequests;
       set({ pendingRequests: [...pendingRequests, newRequest] });
     },
     approvePendingRequest: (id, payload) => {
+      onlyBackground('usePendingRequestStore.approvePendingRequest()');
+
       const pendingRequests = get().pendingRequests;
       set({
         pendingRequests: pendingRequests.filter((request) => request.id !== id),
@@ -42,6 +43,8 @@ export const usePendingRequestStore = createRainbowStore<PendingRequestsStore>(
       eventEmitter.emit(id, { status: 'APPROVED', payload });
     },
     rejectPendingRequest: (id) => {
+      onlyBackground('usePendingRequestStore.rejectPendingRequest()');
+
       const pendingRequests = get().pendingRequests;
       set({
         pendingRequests: pendingRequests.filter((request) => request.id !== id),
@@ -49,6 +52,8 @@ export const usePendingRequestStore = createRainbowStore<PendingRequestsStore>(
       eventEmitter.emit(id, { status: 'REJECTED', payload: null });
     },
     waitForPendingRequest: (id: number): Promise<Responses> => {
+      onlyBackground('usePendingRequestStore.waitForPendingRequest()');
+
       return new Promise((resolve) => {
         const handler = (status: Responses) => {
           eventEmitter.off(id, handler);

--- a/src/entries/background/procedures/popup/state/requests.ts
+++ b/src/entries/background/procedures/popup/state/requests.ts
@@ -2,16 +2,10 @@ import { os } from '@orpc/server';
 import z from 'zod';
 
 import { usePendingRequestStore } from '~/core/state/requests';
-import { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
 
 // Define schema for type safety
-const requestSchema = z.custom<ProviderRequestPayload>();
 const approveInputSchema = z.object({ id: z.number(), payload: z.unknown() });
 const rejectInputSchema = z.object({ id: z.number() });
-
-const getAllHandler = os.output(z.array(requestSchema)).handler(async () => {
-  return usePendingRequestStore.getState().pendingRequests;
-});
 
 const approveHandler = os
   .input(approveInputSchema)
@@ -30,7 +24,6 @@ const rejectHandler = os
   });
 
 export const requestsRouter = {
-  getAll: getAllHandler,
   approve: approveHandler,
   reject: rejectHandler,
 };

--- a/src/entries/popup/ProtectedRoute.tsx
+++ b/src/entries/popup/ProtectedRoute.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 
+import { usePendingRequestStore } from '~/core/state/requests';
 import { WELCOME_URL, goToNewTab } from '~/core/utils/tabs';
 
-import { popupClientQueryUtils } from './handlers/background';
 import { UserStatusResult, useAuth } from './hooks/useAuth';
 import { useIsFullScreen } from './hooks/useIsFullScreen';
 import { ROUTES } from './urls';
@@ -26,9 +25,7 @@ export const ProtectedRoute = ({
   const { status, updateStatus } = useAuth();
   const isFullScreen = useIsFullScreen();
 
-  const { data: pendingRequests } = useQuery(
-    popupClientQueryUtils.state.requests.getAll.queryOptions(),
-  );
+  const pendingRequests = usePendingRequestStore((s) => s.pendingRequests);
 
   const [isStatusInitialized, setStatusInitialized] = React.useState(false);
   React.useEffect(() => {

--- a/src/entries/popup/pages/home/index.tsx
+++ b/src/entries/popup/pages/home/index.tsx
@@ -1,5 +1,4 @@
 import { debug as logger } from '@sentry/core';
-import { useQuery } from '@tanstack/react-query';
 import { motion, useMotionValueEvent } from 'framer-motion';
 import {
   memo,
@@ -19,6 +18,7 @@ import { shortcuts } from '~/core/references/shortcuts';
 import { useCurrentAddressStore } from '~/core/state';
 import { useTabNavigation } from '~/core/state/currentSettings';
 import { useErrorStore } from '~/core/state/error';
+import { usePendingRequestStore } from '~/core/state/requests';
 import { goToNewTab } from '~/core/utils/tabs';
 import { AccentColorProvider, Box, Separator } from '~/design-system';
 import { triggerAlert } from '~/design-system/components/Alert/Alert';
@@ -34,7 +34,6 @@ import { TabBar as NewTabBar, Tab } from '../../components/Tabs/TabBar';
 import { CursorTooltip } from '../../components/Tooltip/CursorTooltip';
 import { WalletAvatar } from '../../components/WalletAvatar/WalletAvatar';
 import { WalletContextMenu } from '../../components/WalletContextMenu';
-import { popupClientQueryUtils } from '../../handlers/background';
 import { removeImportWalletSecrets } from '../../handlers/importWalletSecrets';
 import { useAvatar } from '../../hooks/useAvatar';
 import { useCurrentHomeSheet } from '../../hooks/useCurrentHomeSheet';
@@ -150,9 +149,7 @@ export const Home = memo(function Home() {
   const { data: avatar } = useAvatar({ addressOrName: currentAddress });
   const { currentHomeSheet, isDisplayingSheet } = useCurrentHomeSheet();
   const navigate = useRainbowNavigate();
-  const { data: pendingRequests } = useQuery(
-    popupClientQueryUtils.state.requests.getAll.queryOptions(),
-  );
+  const pendingRequests = usePendingRequestStore((s) => s.pendingRequests);
   const prevPendingRequest = usePrevious(pendingRequests?.[0]);
   const { isWatchingWallet } = useWallets();
 

--- a/src/entries/popup/pages/messages/ApproveAppRequest.tsx
+++ b/src/entries/popup/pages/messages/ApproveAppRequest.tsx
@@ -1,8 +1,9 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import React, { useCallback, useEffect } from 'react';
 
 import { useTestnetModeStore } from '~/core/state/currentSettings/testnetMode';
 import { useNotificationWindowStore } from '~/core/state/notificationWindow';
+import { usePendingRequestStore } from '~/core/state/requests';
 import { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
 import { TESTNET_MODE_BAR_HEIGHT } from '~/core/utils/dimensions';
 import { Box } from '~/design-system';
@@ -46,17 +47,12 @@ const ApproveAppRequestWrapper = ({
 };
 
 export const ApproveAppRequest = () => {
-  const { data: pendingRequests = [], refetch: refetchPendingRequests } =
-    useQuery(popupClientQueryUtils.state.requests.getAll.queryOptions());
+  const pendingRequests = usePendingRequestStore((s) => s.pendingRequests);
   const { mutate: approvePendingRequest } = useMutation(
-    popupClientQueryUtils.state.requests.approve.mutationOptions({
-      onSuccess: () => refetchPendingRequests(),
-    }),
+    popupClientQueryUtils.state.requests.approve.mutationOptions(),
   );
   const { mutate: rejectPendingRequest } = useMutation(
-    popupClientQueryUtils.state.requests.reject.mutationOptions({
-      onSuccess: () => refetchPendingRequests(),
-    }),
+    popupClientQueryUtils.state.requests.reject.mutationOptions(),
   );
   const { notificationWindows } = useNotificationWindowStore();
   // If we're on an external popup, we only want to show the request that were sent from that tab

--- a/src/entries/popup/pages/welcome/index.tsx
+++ b/src/entries/popup/pages/welcome/index.tsx
@@ -1,22 +1,19 @@
-import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion, useAnimationControls } from 'framer-motion';
 import { useEffect, useState } from 'react';
 
 import { i18n } from '~/core/languages';
+import { usePendingRequestStore } from '~/core/state/requests';
 import { useWalletBackupsStore } from '~/core/state/walletBackups';
 import { Box, Stack, Text } from '~/design-system';
 
 import { FlyingRainbows } from '../../components/FlyingRainbows/FlyingRainbows';
 import { LogoWithLetters } from '../../components/LogoWithLetters/LogoWithLetters';
-import { popupClientQueryUtils } from '../../handlers/background';
 
 import { ImportOrCreateWallet } from './ImportOrCreateWallet';
 import { OnboardBeforeConnectSheet } from './OnboardBeforeConnectSheet';
 
 export function Welcome() {
-  const { data: pendingRequests = [] } = useQuery(
-    popupClientQueryUtils.state.requests.getAll.queryOptions(),
-  );
+  const pendingRequests = usePendingRequestStore((s) => s.pendingRequests);
   const [showOnboardBeforeConnectSheet, setShowOnboardBeforeConnectSheet] =
     useState(!!pendingRequests.length);
   const headerControls = useAnimationControls();


### PR DESCRIPTION
# Refactor Pending Request Store for Cross-Context Access

## What changed

- Modified `usePendingRequestStore` to be accessible from both background and popup contexts
- Moved the `onlyBackground` check from the store initialization to individual methods that should only be called from the background
- Exported the store from the main state index for easier imports
- Updated all popup components to directly use the store instead of querying the background via RPC
- Removed the now-unnecessary `getAll` handler from the requests router

## What to test

- Verify that pending requests still appear correctly in the popup
- Confirm that approving and rejecting requests still works properly
- Check that the background-only methods throw appropriate errors when called from the popup
- Ensure that the home screen, protected routes, and welcome page still display pending requests correctly