### PR TITLE
chore: messenger import boundaries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,8 +21,33 @@ module.exports = {
         pattern: 'src/entries/inpage/**',
       },
       {
+        // Should more specifically use background-messenger-wallet instead, etc.
         type: 'entry-background',
         pattern: 'src/entries/background/**',
+      },
+      {
+        // Legacy background messenger handlers that will be deprecated
+        type: 'background-handlers',
+        pattern: 'src/entries/background/handlers/**',
+      },
+      {
+        // Legacy popup messenger handlers that will be deprecated
+        type: 'popup-handlers',
+        pattern: 'src/entries/popup/handlers/**',
+      },
+      {
+        // Specific messenger for the keychain and wallet interactions
+        type: 'background-messenger-wallet',
+        pattern: [
+          'src/entries/background/contracts/popup/wallet/**',
+          'src/entries/background/procedures/popup/wallet/**',
+        ],
+      },
+      {
+        // Specific messenger for dapp session and request lifecycle
+        // Wagmi and Rainbow toggle procedures will be deprecated
+        type: 'background-messenger-dapp-session',
+        pattern: ['src/entries/background/procedures/popup/state/**'],
       },
       {
         type: 'core-keychain',
@@ -45,19 +70,41 @@ module.exports = {
         default: 'disallow',
         rules: [
           {
-            // Allow messaging system to be typed, by allowing type imports from background for every entrypoint
+            // Allowing type imports from background for every entrypoint
             importKind: 'type',
             from: ['entry-popup', 'entry-content', 'entry-inpage'],
+            allow: [
+              'entry-background',
+              'background-handlers',
+              'background-messenger-wallet',
+              'background-messenger-dapp-session',
+            ],
+          },
+          {
+            // Popup can access background entry point for messaging
+            from: ['entry-popup'],
             allow: ['entry-background'],
           },
           {
-            // Only background is allowed to interact with keychain
-            from: ['entry-background'],
+            // Only background components are allowed to interact with keychain
+            // background-handlers will be deprecated
+            from: [
+              'entry-background',
+              'background-handlers',
+              'background-messenger-wallet',
+            ],
             allow: ['core-keychain'],
           },
           {
             // Only popup and background are allowed to interact with stores.
-            from: ['entry-popup', 'entry-background'],
+            from: [
+              'entry-popup',
+              'entry-background',
+              'popup-handlers',
+              'background-handlers',
+              'background-messenger-wallet',
+              'background-messenger-dapp-session',
+            ],
             allow: ['core-state'],
           },
           {
@@ -71,6 +118,9 @@ module.exports = {
               'entry-popup',
               'entry-content',
               'entry-background',
+              'popup-handlers',
+              'background-handlers',
+              'background-messenger-dapp-session',
               'core-state',
               'core-keychain',
             ],

--- a/src/entries/background/contracts/popup/index.ts
+++ b/src/entries/background/contracts/popup/index.ts
@@ -1,1 +1,0 @@
-export { walletContract } from './wallet';

--- a/src/entries/background/procedures/popup/os.ts
+++ b/src/entries/background/procedures/popup/os.ts
@@ -1,6 +1,6 @@
 import { implement } from '@orpc/server';
 
-import { walletContract } from '../../contracts/popup';
+import { walletContract } from '../../contracts/popup/wallet';
 
 interface PopupContext {
   sender: chrome.runtime.MessageSender | undefined;


### PR DESCRIPTION
Fixes BX-1950

## What changed

- Added more specific ESLint module types for background and popup messenger handlers
- Created dedicated types for wallet interactions (`background-messenger-wallet`) and dapp session management (`background-messenger-dapp-session`)
- Updated import rules to reflect the new module structure
- Fixed an import path in `procedures/popup/os.ts` to use the more specific wallet contract path

This change improves code organization by creating clearer boundaries between different messenger components, particularly distinguishing between wallet-related functionality and dapp session management.

## What to test

- Verify that existing imports still work correctly
- Check that the updated import in `procedures/popup/os.ts` functions properly
- Ensure ESLint rules are correctly enforced with the new module types

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restructuring the messaging system in the background and popup components by refining imports, adding new message handlers, and updating the rules for entry points to improve organization and prepare for deprecations.

### Detailed summary
- Deleted `src/entries/background/contracts/popup/index.ts`.
- Updated import path for `walletContract` to `../../contracts/popup/wallet`.
- Added new message handler types: `background-messenger-wallet`, `background-messenger-dapp-session`, and legacy handlers.
- Modified rules to allow specific entries for messaging interactions and marked some as deprecated.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->