### PR TITLE
fix: firefox android max version

### DIFF
--- a/scripts/firefox-manifest.js
+++ b/scripts/firefox-manifest.js
@@ -11,9 +11,10 @@ const manifestFF = {
       id: 'browserextension@rainbow.me',
       strict_min_version: '116.0',
     },
+    // We don't want to allow sideloading on Firefox Android
+    // Don't support version >120 where Add-ons were introduced
     gecko_android: {
-      id: 'browserextension@rainbow.me',
-      strict_max_version: '0',
+      strict_max_version: '119.*',
     },
   },
   host_permissions: [...manifestBase.host_permissions, '<all_urls>'],


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)

- alterated max version to pass validation test on Add-on store

```
"/browser_specific_settings/gecko_android/strict_max_version" must match pattern "^[0-9]{1,3}(\.[a-z0-9*]+)+$"
Error: Your JSON file could not be parsed.
```

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `scripts/firefox-manifest.js` file to restrict sideloading on Firefox Android and adjusts the maximum supported version for the add-on.

### Detailed summary
- Added comments explaining the intent to disallow sideloading on Firefox Android and to not support versions greater than `120`.
- Changed `strict_max_version` from `'0'` to `'119.*'` for the `gecko_android` configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->