### PR TITLE
fix: use 'd' shortcut for network disconnect

### DIFF
--- a/src/entries/popup/components/SwitchMenu/SwitchNetworkMenu.tsx
+++ b/src/entries/popup/components/SwitchMenu/SwitchNetworkMenu.tsx
@@ -103,13 +103,18 @@ export const SwitchNetworkMenuSelector = ({
           });
           onShortcutPress(String(chain.id));
           onNetworkSelect?.();
-        } else if (showDisconnect && chainNumber === chains.length + 1) {
-          trackShortcut({
-            key: chainNumber.toString(),
-            type: 'switchNetworkMenu.disconnect',
-          });
-          disconnect?.();
         }
+      }
+
+      if (
+        showDisconnect &&
+        e.key.toLowerCase() === shortcuts.home.DISCONNECT_APP.key
+      ) {
+        trackShortcut({
+          key: shortcuts.home.DISCONNECT_APP.display,
+          type: 'switchNetworkMenu.disconnect',
+        });
+        disconnect?.();
       }
     },
     [
@@ -180,7 +185,7 @@ export const SwitchNetworkMenuSelector = ({
       {showDisconnect && disconnect && (
         <SwitchNetworkMenuDisconnect
           onDisconnect={disconnect}
-          shortcutLabel={String(chains.length + 1)}
+          shortcutLabel={shortcuts.home.DISCONNECT_APP.display}
         />
       )}
     </Box>


### PR DESCRIPTION
Fixes BX-1887

## Summary
- use `d` key to trigger disconnect in network switcher
- show `D` as shortcut hint for disconnect option

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test` *(fails: snapshots 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c058e70b78832588517d1c5966eb26

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `SwitchNetworkMenu` component to improve the handling of the disconnect shortcut, enhancing user experience by using a specific key binding instead of relying on chain numbers.

### Detailed summary
- Changed the condition for disconnecting to check if the pressed key matches `shortcuts.home.DISCONNECT_APP.key`.
- Updated the `trackShortcut` function to use `shortcuts.home.DISCONNECT_APP.display` for the `key`.
- Modified the `shortcutLabel` prop of `SwitchNetworkMenuDisconnect` to use `shortcuts.home.DISCONNECT_APP.display`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->