### PR TITLE
fix: prevent shortcuts during network switch and backup reminder

### DIFF
--- a/src/design-system/components/Box/Box.tsx
+++ b/src/design-system/components/Box/Box.tsx
@@ -39,7 +39,6 @@ export type BoxProps = Omit<BoxStyles, 'background'> & {
       };
   className?: ClassValue;
   isModal?: boolean;
-  isExplainerSheet?: boolean;
   testId?: string;
   translate?: HTMLAttributes<unknown>['translate'];
   onKeyDown?: React.KeyboardEventHandler;
@@ -49,15 +48,7 @@ export type BoxProps = Omit<BoxStyles, 'background'> & {
 type PolymorphicBox = Polymorphic.ForwardRefComponent<'div', BoxProps>;
 
 export const Box = forwardRef(function Box(
-  {
-    as: Component = 'div',
-    className,
-    isModal,
-    isExplainerSheet,
-    testId,
-    translate,
-    ...props
-  },
+  { as: Component = 'div', className, isModal, testId, translate, ...props },
   ref,
 ) {
   let hasBoxStyles = false;
@@ -124,7 +115,6 @@ export const Box = forwardRef(function Box(
         className,
       )}
       data-is-modally-presented={isModal || undefined}
-      data-is-explainer-sheet={isExplainerSheet || undefined}
       data-testid={testId}
       translate={translate}
       // Since Box is a primitive component, it needs to spread props

--- a/src/entries/popup/Routes.tsx
+++ b/src/entries/popup/Routes.tsx
@@ -99,7 +99,7 @@ import { NewWatchWallet } from './pages/walletSwitcher/newWatchWallet';
 import { WatchWallet } from './pages/watchWallet';
 import { Welcome } from './pages/welcome';
 import { ROUTES } from './urls';
-import { getInputIsFocused } from './utils/activeElement';
+import { inputIsFocused } from './utils/activeElement';
 import { simulateTab } from './utils/simulateTab';
 import { zIndexes } from './utils/zIndexes';
 
@@ -1052,7 +1052,7 @@ const useGlobalShortcuts = () => {
     handler: (e: KeyboardEvent) => {
       // prevent scrolling with space
       if (e.key === shortcuts.global.OPEN_CONTEXT_MENU.key) {
-        if (!getInputIsFocused()) {
+        if (!inputIsFocused()) {
           e.preventDefault();
         }
       }

--- a/src/entries/popup/components/BackupReminder/BackupReminder.tsx
+++ b/src/entries/popup/components/BackupReminder/BackupReminder.tsx
@@ -41,7 +41,7 @@ export const BackupReminder = () => {
       zIndex={zIndexes.APP_CONNECTION_WALLET_SWITCHER}
       onClickOutside={closeBackupReminder}
     >
-      <Box id="wallet-backup-reminder-sheet" isExplainerSheet>
+      <Box>
         <Navbar
           leftComponent={
             <Navbar.CloseButton

--- a/src/entries/popup/components/ExplainerSheet/ExplainerSheet.tsx
+++ b/src/entries/popup/components/ExplainerSheet/ExplainerSheet.tsx
@@ -136,7 +136,7 @@ export const ExplainerSheet = ({
       zIndex={zIndexes.EXPLAINER_BOTTOM_SHEET}
       show={show}
     >
-      <Box testId={`explainer-sheet-${testId}`} isExplainerSheet>
+      <Box testId={`explainer-sheet-${testId}`}>
         <Box paddingVertical="44px" paddingHorizontal="32px">
           <Stack alignHorizontal="center" space="20px">
             {header?.emoji ? (

--- a/src/entries/popup/components/Navbar/Navbar.tsx
+++ b/src/entries/popup/components/Navbar/Navbar.tsx
@@ -13,8 +13,8 @@ import useKeyboardAnalytics from '../../hooks/useKeyboardAnalytics';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 import { useRainbowNavigate } from '../../hooks/useRainbowNavigate';
 import {
-  getActiveModal,
-  getInputIsFocused,
+  inputIsFocused,
+  modalIsActive,
   radixIsActive,
 } from '../../utils/activeElement';
 import {
@@ -193,9 +193,9 @@ function NavbarButtonWithBack({
       const closeWithEscape =
         e.key === shortcuts.global.CLOSE.key &&
         !radixIsActive() &&
-        (withinModal || !getActiveModal());
+        (withinModal || !modalIsActive());
       const closeWithArrow =
-        !getInputIsFocused() && e.key === shortcuts.global.BACK.key;
+        !inputIsFocused() && e.key === shortcuts.global.BACK.key;
 
       if (closeWithEscape || closeWithArrow) {
         trackShortcut({

--- a/src/entries/popup/hooks/useCommandKShortcuts.ts
+++ b/src/entries/popup/hooks/useCommandKShortcuts.ts
@@ -4,7 +4,11 @@ import { shortcuts } from '~/core/references/shortcuts';
 
 import { useCommandKStatus } from '../components/CommandK/useCommandKStatus';
 import { ROUTES } from '../urls';
-import { getInputIsFocused, radixIsActive } from '../utils/activeElement';
+import {
+  inputIsFocused,
+  modalIsActive,
+  radixIsActive,
+} from '../utils/activeElement';
 
 import { useKeyboardShortcut } from './useKeyboardShortcut';
 
@@ -36,14 +40,18 @@ export function useCommandKShortcuts() {
   );
 
   const getCommandKTriggerIsActive = React.useCallback(() => {
-    return !disableOnCurrentRoute;
-  }, [disableOnCurrentRoute]);
+    if (isCommandKVisible) {
+      return true;
+    }
+    return !disableOnCurrentRoute && !modalIsActive();
+  }, [disableOnCurrentRoute, isCommandKVisible]);
 
   const handleCommandKShortcutPress = React.useCallback(
     (e: KeyboardEvent) => {
+      e.preventDefault();
+
       if (!isCommandKVisible) {
-        e.preventDefault();
-        if (getInputIsFocused()) {
+        if (inputIsFocused()) {
           setLastActiveElement(document.activeElement as HTMLElement);
         }
         if (radixIsActive()) {
@@ -51,7 +59,6 @@ export function useCommandKShortcuts() {
         }
         openCommandK();
       } else {
-        e.preventDefault();
         closeCommandK();
       }
     },
@@ -79,7 +86,7 @@ export function useCommandKShortcuts() {
   // Allow opening ⌘K with K alone if an input is not focused
   useKeyboardShortcut({
     handler: (e: KeyboardEvent) => {
-      if (e.key === shortcuts.global.COMMAND_K.key && !getInputIsFocused()) {
+      if (e.key === shortcuts.global.COMMAND_K.key && !inputIsFocused()) {
         handleCommandKShortcutPress(e);
       }
     },

--- a/src/entries/popup/hooks/useHomeShortcuts.ts
+++ b/src/entries/popup/hooks/useHomeShortcuts.ts
@@ -26,8 +26,8 @@ import { ROUTES } from '../urls';
 import {
   appConnectionMenuIsActive,
   appConnectionSwitchWalletsPromptIsActive,
-  getExplainerSheet,
-  getInputIsFocused,
+  inputIsFocused,
+  modalIsActive,
 } from '../utils/activeElement';
 import {
   clickHeaderLeft,
@@ -114,10 +114,11 @@ export function useHomeShortcuts() {
       const activeAppConnectionMenu = appConnectionMenuIsActive();
       const activeAppWalletSwitcher =
         appConnectionSwitchWalletsPromptIsActive();
-      const inputIsFocused = getInputIsFocused();
-      const isExplainerSheet = getExplainerSheet();
-      if (inputIsFocused) return;
-      if (isExplainerSheet) return;
+
+      // Block shortcuts when overlays are active
+      if (inputIsFocused() || modalIsActive()) {
+        return;
+      }
       switch (e.key) {
         case shortcuts.home.BUY.key:
           trackShortcut({

--- a/src/entries/popup/hooks/useKeyboardShortcut.ts
+++ b/src/entries/popup/hooks/useKeyboardShortcut.ts
@@ -28,15 +28,20 @@ export function useKeyboardShortcut({
   const isCommandKVisible = useCommandKStatus((s) => s.isCommandKVisible);
 
   const shouldListen = useMemo(() => {
-    if (!isCommandKVisible || enableWithinCommandK) {
-      return condition?.() || condition === undefined;
-    }
-    return false;
-  }, [condition, enableWithinCommandK, isCommandKVisible]);
+    return !isCommandKVisible || enableWithinCommandK;
+  }, [enableWithinCommandK, isCommandKVisible]);
 
   useEffect(() => {
     const systemSpecificModifierKey = getSystemSpecificModifierKey(modifierKey);
     const modifiedHandler = (e: KeyboardEvent) => {
+      // Block when CommandK is open unless explicitly allowed
+      if (isCommandKVisible && !enableWithinCommandK) {
+        return;
+      }
+      // Check condition on every keypress, not just at registration time
+      if (condition && !condition()) {
+        return;
+      }
       // If a modifierKey is specified, check if it's being held down
       if (systemSpecificModifierKey && !e[systemSpecificModifierKey]) {
         return;
@@ -58,5 +63,12 @@ export function useKeyboardShortcut({
     return () => {
       removeHandler();
     };
-  }, [handler, modifierKey, shouldListen]);
+  }, [
+    condition,
+    enableWithinCommandK,
+    handler,
+    isCommandKVisible,
+    modifierKey,
+    shouldListen,
+  ]);
 }

--- a/src/entries/popup/hooks/useSwitchWalletShortcuts.ts
+++ b/src/entries/popup/hooks/useSwitchWalletShortcuts.ts
@@ -1,7 +1,8 @@
 import { useCurrentAddressStore } from '~/core/state';
 
 import {
-  getInputIsFocused,
+  inputIsFocused,
+  modalIsActive,
   switchNetworkMenuIsActive,
 } from '../utils/activeElement';
 
@@ -18,7 +19,11 @@ export function useSwitchWalletShortcuts(disable?: boolean) {
 
   useKeyboardShortcut({
     handler: (e: KeyboardEvent) => {
-      if (!switchNetworkMenuIsActive() && !getInputIsFocused()) {
+      if (
+        !switchNetworkMenuIsActive() &&
+        !modalIsActive() &&
+        !inputIsFocused()
+      ) {
         const regex = /^[1-9]$/;
         if (regex.test(e.key)) {
           const accountIndex = parseInt(e.key, 10) - 1;

--- a/src/entries/popup/pages/messages/BottomActions/index.tsx
+++ b/src/entries/popup/pages/messages/BottomActions/index.tsx
@@ -34,7 +34,7 @@ import useKeyboardAnalytics from '~/entries/popup/hooks/useKeyboardAnalytics';
 import { useKeyboardShortcut } from '~/entries/popup/hooks/useKeyboardShortcut';
 import { useWalletInfo } from '~/entries/popup/hooks/useWalletInfo';
 import {
-  getInputIsFocused,
+  inputIsFocused,
   radixIsActive,
   switchNetworkMenuIsActive,
 } from '~/entries/popup/utils/activeElement';
@@ -164,7 +164,7 @@ export const BottomSwitchWallet = ({
 
   useKeyboardShortcut({
     handler: (e: KeyboardEvent) => {
-      if (!switchNetworkMenuIsActive() && !getInputIsFocused()) {
+      if (!switchNetworkMenuIsActive() && !inputIsFocused()) {
         const regex = /^[1-9]$/;
         if (regex.test(e.key)) {
           const accountIndex = parseInt(e.key, 10) - 1;

--- a/src/entries/popup/pages/swap/index.tsx
+++ b/src/entries/popup/pages/swap/index.tsx
@@ -71,7 +71,7 @@ import {
   TranslationContext,
   useTranslationContext,
 } from '../../hooks/useTranslationContext';
-import { getActiveElement, getInputIsFocused } from '../../utils/activeElement';
+import { getActiveElement, inputIsFocused } from '../../utils/activeElement';
 
 import { SwapReviewSheet } from './SwapReviewSheet/SwapReviewSheet';
 import { SwapSettings } from './SwapSettings/SwapSettings';
@@ -695,8 +695,8 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
     handler: (e: KeyboardEvent) => {
       if (e.key === shortcuts.swap.FLIP_ASSETS.key) {
         const flippingAfterSearch =
-          getInputIsFocused() && getActiveElement()?.id === SWAP_INPUT_MASK_ID;
-        if (flippingAfterSearch || !getInputIsFocused()) {
+          inputIsFocused() && getActiveElement()?.id === SWAP_INPUT_MASK_ID;
+        if (flippingAfterSearch || !inputIsFocused()) {
           trackShortcut({
             key: shortcuts.swap.FLIP_ASSETS.display,
             type: 'swap.flipAssets',
@@ -708,9 +708,8 @@ export function Swap({ bridge = false }: { bridge?: boolean }) {
       if (e.key === shortcuts.swap.SET_MAX_AMOUNT.key) {
         if (assetToSell) {
           const maxxingAfterSearch =
-            getInputIsFocused() &&
-            getActiveElement()?.id === SWAP_INPUT_MASK_ID;
-          if (maxxingAfterSearch || !getInputIsFocused()) {
+            inputIsFocused() && getActiveElement()?.id === SWAP_INPUT_MASK_ID;
+          if (maxxingAfterSearch || !inputIsFocused()) {
             trackShortcut({
               key: shortcuts.swap.SET_MAX_AMOUNT.display,
               type: 'swap.setMax',

--- a/src/entries/popup/utils/activeElement.ts
+++ b/src/entries/popup/utils/activeElement.ts
@@ -1,17 +1,43 @@
+// ============================================================================
+// General Element Helpers
+// ============================================================================
+
 export const getActiveElement = () => document.activeElement;
-export const getActiveModal = () =>
-  document.querySelector('div[data-is-modally-presented]');
-export const getExplainerSheet = () =>
-  document.querySelector('div[data-is-explainer-sheet]');
-export const getInputIsFocused = () => {
+
+// Checks if an input/textarea is focused (used to prevent shortcuts while typing)
+export const inputIsFocused = () => {
   const tagName = getActiveElement()?.tagName || '';
   return ['INPUT', 'TEXTAREA'].includes(tagName);
 };
+
+// ============================================================================
+// Modal and Sheet Detectors
+// ============================================================================
+
+// Returns the active modal element (BottomSheets, Prompts, DropdownMenus, etc.)
+export const getActiveModal = () =>
+  document.querySelector('div[data-is-modally-presented]');
+
+// Detects any modal with isModal prop (BottomSheets, Prompts, DropdownMenus, etc.)
+// Used by shortcut handlers to block keyboard shortcuts when modals are active
+export const modalIsActive = () => !!getActiveModal();
+
+// ============================================================================
+// Menu Detectors
+// ============================================================================
+
+// Detects Radix UI popper menus (context menus, dropdowns)
 export const radixIsActive = () =>
   !!document.querySelector('div[data-radix-popper-content-wrapper]');
+
+// Detects network switcher menu
 export const switchNetworkMenuIsActive = () =>
   !!document.getElementById('switch-network-menu-selector');
+
+// Detects app connection menu (DApp connection management)
 export const appConnectionMenuIsActive = () =>
   !!document.getElementById('app-connection-menu-selector-open');
+
+// Detects wallet switcher prompt in DApp connection flow
 export const appConnectionSwitchWalletsPromptIsActive = () =>
   !!document.getElementById('app-connection-switch-wallets-prompt');

--- a/src/entries/popup/utils/simulateTab.ts
+++ b/src/entries/popup/utils/simulateTab.ts
@@ -1,11 +1,9 @@
-import { getActiveModal, getExplainerSheet } from './activeElement';
+import { getActiveModal } from './activeElement';
 
 export const simulateTab = (forwards: boolean) => {
   const activeElement = document.activeElement;
   if (activeElement) {
-    const modal = getActiveModal();
-    const explainer = getExplainerSheet();
-    const target = explainer || modal || document;
+    const target = getActiveModal() || document;
 
     const tabbableArray = Array.from(
       target.querySelectorAll('[tabindex]:not([tabindex="-1"])'),


### PR DESCRIPTION
## Summary
- avoid triggering home hotkeys when dapp network switcher is active
- Refactored active element detection - renamed getInputIsFocused() → inputIsFocused(), added modalIsActive()
- Restored switchNetworkMenuIsActive() - prevents wallet switcher shortcuts when network menu is open
- Removed isExplainerSheet prop - replaced with generic modalIsActive() check
- Updated useKeyboardShortcut hook - evaluates conditions dynamically, includes all deps in useEffect
- Improved overlay blocking - CommandK, home shortcuts, and wallet switcher all respect modal/menu state


------
https://chatgpt.com/codex/tasks/task_e_68c053a8fb088325beb125629a56a32b

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of keyboard shortcuts and modal interactions across various components in the application. It introduces new functions for detecting active modals and input focus, while also refining existing logic for better usability.

### Detailed summary
- Changed `isExplainerSheet` prop to be removed from `Box` in `BackupReminder`.
- Updated `getInputIsFocused` to `inputIsFocused` in multiple files.
- Introduced `modalIsActive` function to check for active modals.
- Refined keyboard shortcut conditions to consider modal and input focus states.
- Improved overall clarity and consistency in shortcut handling across components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->