### PR TITLE
feat: gate additional Android browsers

### DIFF
--- a/src/entries/popup/hooks/useBrowser.ts
+++ b/src/entries/popup/hooks/useBrowser.ts
@@ -11,8 +11,8 @@ export function getBrowser() {
   if (isArc()) return 'Arc';
   if ('brave' in navigator) return 'Brave';
   if (ua.includes('firefox')) return 'Firefox';
-  if (ua.includes('samsungbrowser')) 'Samsung';
-  if (ua.includes('opera') || ua.includes('OPR')) return 'Opera';
+  if (ua.includes('samsungbrowser')) return 'Samsung';
+  if (ua.includes('opera') || ua.includes('opr')) return 'Opera';
   if (ua.includes('edge')) return 'Edge Legacy';
   if (ua.includes('edg')) return 'Edge';
   if (ua.includes('chrome')) return 'Chrome';

--- a/src/entries/popup/utils/isMobile.test.ts
+++ b/src/entries/popup/utils/isMobile.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isMobile } from './isMobile';
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+    writable: true,
+  });
+};
+
+describe('isMobile', () => {
+  const originalUA = window.navigator.userAgent;
+
+  afterEach(() => {
+    setUserAgent(originalUA);
+  });
+
+  it('returns true for common Android browsers', () => {
+    const uas = [
+      // Chrome for Android
+      'Mozilla/5.0 (Linux; Android 10; SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.0.0 Mobile Safari/537.36',
+      // Firefox for Android
+      'Mozilla/5.0 (Android 10; Mobile; rv:91.0) Gecko/91.0 Firefox/91.0',
+      // Edge for Android
+      'Mozilla/5.0 (Linux; Android 10; Pixel 2 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36 EdgA/109.0.1518.52',
+      // Vivaldi for Android
+      'Mozilla/5.0 (Linux; Android 10; V1921) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile Safari/537.36 Vivaldi/5.7.2867.62',
+      // Yandex Browser for Android
+      'Mozilla/5.0 (Linux; Android 11; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Mobile Safari/537.36 YaBrowser/22.9.0.236.00',
+      // Opera for Android
+      'Mozilla/5.0 (Linux; Android 10; SM-G960F Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36 OPR/63.3.3216.58675',
+    ];
+
+    uas.forEach((ua) => {
+      setUserAgent(ua);
+      expect(isMobile()).toBe(true);
+    });
+  });
+
+  it('returns false for desktop browsers', () => {
+    const desktopChromeUA =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36';
+    setUserAgent(desktopChromeUA);
+    expect(isMobile()).toBe(false);
+  });
+});

--- a/src/entries/popup/utils/isMobile.ts
+++ b/src/entries/popup/utils/isMobile.ts
@@ -1,7 +1,5 @@
 const userAgent = () =>
-  typeof navigator !== 'undefined'
-    ? navigator.userAgent.toLocaleLowerCase()
-    : '';
+  typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
 
 const isAndroid = (ua = userAgent()) => ua.includes('android');
 


### PR DESCRIPTION
## Summary
- restore desktop browser detection and retain unsupported fallthrough
- simplify mobile detection using `toLowerCase` and verify Android user agents

## Testing
- `yarn lint`
- `yarn typecheck`
- `npx vitest run src/entries/popup/utils/isMobile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad6342ac8325a8f61ad7e89f3f8f