### PR TITLE
fix: skip NFT tests when feature disabled

### DIFF
--- a/e2e/parallel/nftsFlow.test.ts
+++ b/e2e/parallel/nftsFlow.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-await-in-loop */
 import { WebDriver } from 'selenium-webdriver';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import remoteConfig from '~/core/firebase/remoteConfig';
 
 import {
   delayTime,
@@ -17,6 +19,7 @@ import { TEST_VARIABLES } from '../walletVariables';
 
 let rootURL = getRootUrl();
 let driver: WebDriver;
+let skipSuite = false;
 
 const browser = process.env.BROWSER || 'chrome';
 const os = process.env.OS || 'mac';
@@ -30,6 +33,13 @@ describe('Visit NFTs Gallery and Details Pages', () => {
     const extensionId = await getExtensionIdByName(driver, 'Rainbow');
     if (!extensionId) throw new Error('Extension not found');
     rootURL += extensionId;
+    if (remoteConfig.nfts_enabled === false) {
+      skipSuite = true;
+    }
+  });
+  // Vitest provides a test context object via `this`
+  beforeEach(function (this: { skip: () => void }) {
+    if (skipSuite) this.skip();
   });
   afterAll(async () => await driver?.quit());
 

--- a/e2e/parallel/nftsFlow.test.ts
+++ b/e2e/parallel/nftsFlow.test.ts
@@ -10,14 +10,14 @@ import {
   vi,
 } from 'vitest';
 
-import remoteConfig from '~/core/firebase/remoteConfig';
-
-// Mock chrome.notifications for FCM
+// Mock chrome.notifications for FCM - must be before remoteConfig import
 vi.stubGlobal('chrome', {
   notifications: {
     create: vi.fn(),
   },
 });
+
+import remoteConfig from '~/core/firebase/remoteConfig';
 
 import {
   delayTime,

--- a/e2e/parallel/nftsFlow.test.ts
+++ b/e2e/parallel/nftsFlow.test.ts
@@ -1,8 +1,23 @@
 /* eslint-disable no-await-in-loop */
 import { WebDriver } from 'selenium-webdriver';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import remoteConfig from '~/core/firebase/remoteConfig';
+
+// Mock chrome.notifications for FCM
+vi.stubGlobal('chrome', {
+  notifications: {
+    create: vi.fn(),
+  },
+});
 
 import {
   delayTime,

--- a/e2e/parallel/nftsFlow.test.ts
+++ b/e2e/parallel/nftsFlow.test.ts
@@ -1,23 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { WebDriver } from 'selenium-webdriver';
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
-
-// Mock chrome.notifications for FCM - must be before remoteConfig import
-vi.stubGlobal('chrome', {
-  notifications: {
-    create: vi.fn(),
-  },
-});
-
-import remoteConfig from '~/core/firebase/remoteConfig';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
   delayTime,
@@ -32,146 +15,153 @@ import {
 } from '../helpers';
 import { TEST_VARIABLES } from '../walletVariables';
 
+vi.stubGlobal('chrome', {
+  notifications: {
+    create: vi.fn(),
+  },
+});
+
+const remoteConfig = (await import('~/core/firebase/remoteConfig')).default;
+
 let rootURL = getRootUrl();
 let driver: WebDriver;
-let skipSuite = false;
 
 const browser = process.env.BROWSER || 'chrome';
 const os = process.env.OS || 'mac';
 
-describe('Visit NFTs Gallery and Details Pages', () => {
-  beforeAll(async () => {
-    driver = await initDriverWithOptions({
-      browser,
-      os,
+describe.runIf(remoteConfig.nfts_enabled)(
+  'Visit NFTs Gallery and Details Pages',
+  () => {
+    beforeAll(async () => {
+      driver = await initDriverWithOptions({
+        browser,
+        os,
+      });
+      const extensionId = await getExtensionIdByName(driver, 'Rainbow');
+      if (!extensionId) throw new Error('Extension not found');
+      rootURL += extensionId;
     });
-    const extensionId = await getExtensionIdByName(driver, 'Rainbow');
-    if (!extensionId) throw new Error('Extension not found');
-    rootURL += extensionId;
-    if (remoteConfig.nfts_enabled === false) {
-      skipSuite = true;
-    }
-  });
-  // Vitest provides a test context object via `this`
-  beforeEach(function (this: { skip: () => void }) {
-    if (skipSuite) this.skip();
-  });
-  afterAll(async () => await driver?.quit());
+    afterAll(async () => await driver?.quit());
 
-  it('should be able import a wallet via seed', async () => {
-    await importWalletFlow(driver, rootURL, TEST_VARIABLES.EMPTY_WALLET.SECRET);
-  });
-
-  it('should be able to navigate to NFT details', async () => {
-    await goToPopup(driver, rootURL);
-    await findElementByTestIdAndClick({ id: 'bottom-tab-nfts', driver });
-    await delayTime('short');
-    await findElementByTestIdAndClick({
-      id: 'nft-thumbnail-https://lh3.googleusercontent.com/ICZJsSKEfLTquCvn1o-W7wD75EdtCksjf3bMtm2IQsYdw7K8-_de9gGQBXJE09fHy33OtBBrgWqMUAfX2ve6ZsW200JnLrX-m3s=s1000-0',
-      driver,
+    it('should be able import a wallet via seed', async () => {
+      await importWalletFlow(
+        driver,
+        rootURL,
+        TEST_VARIABLES.EMPTY_WALLET.SECRET,
+      );
     });
-    const nftName = await findElementByText(driver, 'Citizen 297');
-    expect(nftName).toBeTruthy();
-  });
 
-  it('should display last sales price', async () => {
-    const lastSalesPrice = await findElementByText(driver, '0.0179');
-    expect(lastSalesPrice).toBeTruthy();
-  });
-
-  it('should display NFT description', async () => {
-    const description = await findElementByText(
-      driver,
-      'Bring your citizen to life',
-    );
-    expect(description).toBeTruthy();
-  });
-
-  it('should display NFT traits', async () => {
-    const bodyTrait = await findElementByText(driver, 'ALPINEMIKI');
-    expect(bodyTrait).toBeTruthy();
-    const materialTrait = await findElementByText(driver, 'ORANGE');
-    expect(materialTrait).toBeTruthy();
-  });
-
-  it('should display token standard', async () => {
-    const tokenStandard = await findElementByText(driver, 'ERC721');
-    expect(tokenStandard).toBeTruthy();
-  });
-
-  it('should display token contract', async () => {
-    const contractAddress = await findElementByText(driver, '0x6171…f23b');
-    expect(contractAddress).toBeTruthy();
-  });
-
-  it('should display contract creator', async () => {
-    const creatorAddress = await findElementByText(driver, 'adworld.eth');
-    expect(creatorAddress).toBeTruthy();
-  });
-
-  it('should display chain', async () => {
-    const networkName = await findElementByText(driver, 'Base');
-    expect(networkName).toBeTruthy();
-  });
-
-  it('should correctly display external link', async () => {
-    const externalLinkButton = await findElementByTestId({
-      id: 'nft-link-button-adworld.game',
-      driver,
+    it('should be able to navigate to NFT details', async () => {
+      await goToPopup(driver, rootURL);
+      await findElementByTestIdAndClick({ id: 'bottom-tab-nfts', driver });
+      await delayTime('short');
+      await findElementByTestIdAndClick({
+        id: 'nft-thumbnail-https://lh3.googleusercontent.com/ICZJsSKEfLTquCvn1o-W7wD75EdtCksjf3bMtm2IQsYdw7K8-_de9gGQBXJE09fHy33OtBBrgWqMUAfX2ve6ZsW200JnLrX-m3s=s1000-0',
+        driver,
+      });
+      const nftName = await findElementByText(driver, 'Citizen 297');
+      expect(nftName).toBeTruthy();
     });
-    expect(externalLinkButton).toBeTruthy();
-  });
 
-  it('should return back to gallery and select another NFT (ENS)', async () => {
-    await findElementByTestIdAndClick({
-      id: 'navbar-button-with-back',
-      driver,
+    it('should display last sales price', async () => {
+      const lastSalesPrice = await findElementByText(driver, '0.0179');
+      expect(lastSalesPrice).toBeTruthy();
     });
-    await delayTime('medium');
-    await findElementByTestIdAndClick({
-      id: 'nft-thumbnail-https://lh3.googleusercontent.com/O_dtxR4ggdzoCNEAZ89s7w5eBiu8rP5TELBQcuFZyIHc-raU2qj48LSkJmEKeN64JaGa7m9X5EFYUreCCJBlx9lXW0rgjrZUL0E=s1000-1',
-      driver,
-    });
-    const ensName = findElementByText(driver, 'testmar27.eth');
-    expect(ensName).toBeTruthy();
-  });
 
-  it('should display ens registration date accurately', async () => {
-    const registeredLabel = await findElementByText(driver, 'Registered on');
-    expect(registeredLabel).toBeTruthy();
-    const registeredDate = await findElementByText(driver, 'Mar 27, 2023');
-    expect(registeredDate).toBeTruthy();
-  });
+    it('should display NFT description', async () => {
+      const description = await findElementByText(
+        driver,
+        'Bring your citizen to life',
+      );
+      expect(description).toBeTruthy();
+    });
 
-  it('should display and format ens expiration date', async () => {
-    const expirationLabel = await findElementByText(driver, 'Expires in');
-    expect(expirationLabel).toBeTruthy();
-    const expirationValue = await findElementByTestId({
-      id: 'ens-expiry-value',
-      driver,
+    it('should display NFT traits', async () => {
+      const bodyTrait = await findElementByText(driver, 'ALPINEMIKI');
+      expect(bodyTrait).toBeTruthy();
+      const materialTrait = await findElementByText(driver, 'ORANGE');
+      expect(materialTrait).toBeTruthy();
     });
-    expect(expirationValue).toBeTruthy();
-    const expirationValueText = await expirationValue.getText();
-    expect(expirationValueText !== 'Invalid Date');
-  });
 
-  it('should be able to change nfts display mode', async () => {
-    await findElementByTestIdAndClick({
-      id: 'navbar-button-with-back',
-      driver,
+    it('should display token standard', async () => {
+      const tokenStandard = await findElementByText(driver, 'ERC721');
+      expect(tokenStandard).toBeTruthy();
     });
-    await findElementByTestIdAndClick({
-      id: 'nfts-displaymode-dropdown',
-      driver,
+
+    it('should display token contract', async () => {
+      const contractAddress = await findElementByText(driver, '0x6171…f23b');
+      expect(contractAddress).toBeTruthy();
     });
-    await findElementByTestIdAndClick({
-      id: 'nfts-displaymode-option-byCollection',
-      driver,
+
+    it('should display contract creator', async () => {
+      const creatorAddress = await findElementByText(driver, 'adworld.eth');
+      expect(creatorAddress).toBeTruthy();
     });
-    const emptyState = await findElementByText(
-      driver,
-      'Your NFTs will appear here!',
-    );
-    expect(emptyState).toBeTruthy();
-  });
-});
+
+    it('should display chain', async () => {
+      const networkName = await findElementByText(driver, 'Base');
+      expect(networkName).toBeTruthy();
+    });
+
+    it('should correctly display external link', async () => {
+      const externalLinkButton = await findElementByTestId({
+        id: 'nft-link-button-adworld.game',
+        driver,
+      });
+      expect(externalLinkButton).toBeTruthy();
+    });
+
+    it('should return back to gallery and select another NFT (ENS)', async () => {
+      await findElementByTestIdAndClick({
+        id: 'navbar-button-with-back',
+        driver,
+      });
+      await delayTime('medium');
+      await findElementByTestIdAndClick({
+        id: 'nft-thumbnail-https://lh3.googleusercontent.com/O_dtxR4ggdzoCNEAZ89s7w5eBiu8rP5TELBQcuFZyIHc-raU2qj48LSkJmEKeN64JaGa7m9X5EFYUreCCJBlx9lXW0rgjrZUL0E=s1000-1',
+        driver,
+      });
+      const ensName = findElementByText(driver, 'testmar27.eth');
+      expect(ensName).toBeTruthy();
+    });
+
+    it('should display ens registration date accurately', async () => {
+      const registeredLabel = await findElementByText(driver, 'Registered on');
+      expect(registeredLabel).toBeTruthy();
+      const registeredDate = await findElementByText(driver, 'Mar 27, 2023');
+      expect(registeredDate).toBeTruthy();
+    });
+
+    it('should display and format ens expiration date', async () => {
+      const expirationLabel = await findElementByText(driver, 'Expires in');
+      expect(expirationLabel).toBeTruthy();
+      const expirationValue = await findElementByTestId({
+        id: 'ens-expiry-value',
+        driver,
+      });
+      expect(expirationValue).toBeTruthy();
+      const expirationValueText = await expirationValue.getText();
+      expect(expirationValueText !== 'Invalid Date');
+    });
+
+    it('should be able to change nfts display mode', async () => {
+      await findElementByTestIdAndClick({
+        id: 'navbar-button-with-back',
+        driver,
+      });
+      await findElementByTestIdAndClick({
+        id: 'nfts-displaymode-dropdown',
+        driver,
+      });
+      await findElementByTestIdAndClick({
+        id: 'nfts-displaymode-option-byCollection',
+        driver,
+      });
+      const emptyState = await findElementByText(
+        driver,
+        'Your NFTs will appear here!',
+      );
+      expect(emptyState).toBeTruthy();
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- rely solely on `remoteConfig.nfts_enabled` to decide whether to skip the NFT e2e suite

## Testing
- `yarn lint && echo 'lint:success'`
- `yarn typecheck && echo 'typecheck:success'`


------
https://chatgpt.com/codex/tasks/task_e_68c1b0ba2a9483259b0fe0d128fc0da5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `nftsFlow.test.ts` file by integrating `vi` for stubbing global variables, modifying the test structure to conditionally run based on `remoteConfig`, and reorganizing tests for better readability and flow.

### Detailed summary
- Added `vi` for global stubbing of `chrome` notifications.
- Modified `describe` to conditionally run based on `remoteConfig.nfts_enabled`.
- Reorganized test cases for better structure and readability.
- Ensured `beforeAll` and `afterAll` hooks are correctly placed. 
- Updated test cases to maintain functionality and clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->