### PR TITLE
fix: edge sourcemap url prefix

### DIFF
--- a/.github/workflows/publish-prod-edge.yml
+++ b/.github/workflows/publish-prod-edge.yml
@@ -59,6 +59,6 @@ jobs:
           finalize: true
           sourcemaps: ./build
           version: ${{ env.release_version }}
-          url_prefix: 'chrome-extension://opfgelmcmbiajamepnmloijbpoleiama'
+          url_prefix: 'chrome-extension://cpojfbodiccabbabgimdeohkkpjfpbnf'
 
           


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- Corrected sourcemap linking for Edge Store uploads

```
TypeError
Failed to fetch (f2c.rainbow.me)
mechanism
onunhandledrejection
handled
false
chrome-extension://cpojfbodiccabbabgimdeohkkpjfpbnf/262.js at line 1:3572745

Unminify Code
In App
chrome-extension://cpojfbodiccabbabgimdeohkkpjfpbnf/popup.js in Zs at line 493:972
```

## Screen recordings / screenshots

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `url_prefix` in the `.github/workflows/publish-prod-edge.yml` file to a new Chrome extension identifier, reflecting a change in the deployment target for the production edge environment.

### Detailed summary
- Updated `url_prefix` from `'chrome-extension://opfgelmcmbiajamepnmloijbpoleiama'` to `'chrome-extension://cpojfbodiccabbabgimdeohkkpjfpbnf'` in the `.github/workflows/publish-prod-edge.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->