### PR TITLE
fix: dont persist orpc

### DIFF
--- a/src/core/react-query/queryClient.ts
+++ b/src/core/react-query/queryClient.ts
@@ -40,9 +40,9 @@ export const persistOptions: Omit<PersistQueryClientOptions, 'queryClient'> = {
     shouldDehydrateQuery: (query) => {
       return Boolean(
         // We want to persist queries that have a `cacheTime` of above zero.
-        query.gcTime !== 0 ||
+        query.gcTime !== 0 &&
           // dont persist orpc queries
-          isOrpcQueryKey(query.queryKey),
+          !isOrpcQueryKey(query.queryKey),
       );
     },
   },


### PR DESCRIPTION
# Fix Query Persistence Logic for ORPC Queries

## What changed

Fixed a logical error in the query persistence condition:
- Changed the logical OR (`||`) to AND (`&&`) to ensure both conditions are met
- Fixed the negation of `isOrpcQueryKey` by changing from `-isOrpcQueryKey` to `!isOrpcQueryKey`

This ensures that:
1. Only queries with a `gcTime` above zero are persisted
2. ORPC queries are properly excluded from persistence

## What to test

- Verify that ORPC queries are no longer being persisted
- Confirm that non-ORPC queries with `gcTime > 0` are still being persisted correctly
- Check that the application's caching behavior works as expected after a refresh

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the logic for persisting queries in the `queryClient.ts` file by changing how `isOrpcQueryKey` is evaluated, ensuring that only non-ORPC queries are persisted when `gcTime` is greater than zero.

### Detailed summary
- Changed the condition for persisting queries:
  - From `-isOrpcQueryKey(query.queryKey)` to `+!isOrpcQueryKey(query.queryKey)` 
- This change ensures that ORPC queries are not persisted.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->