### PR TITLE
fix: remove gecko_android from manifest to prevent listed android support

### DIFF
--- a/scripts/firefox-manifest.js
+++ b/scripts/firefox-manifest.js
@@ -11,11 +11,6 @@ const manifestFF = {
       id: 'browserextension@rainbow.me',
       strict_min_version: '116.0',
     },
-    // We don't want to allow sideloading on Firefox Android
-    // Don't support version >120 where Add-ons were introduced
-    gecko_android: {
-      strict_max_version: '119.*',
-    },
   },
   host_permissions: [...manifestBase.host_permissions, '<all_urls>'],
 };


### PR DESCRIPTION
Fixes BX-####
Figma link (if any):

## What changed (plus any additional context for devs)
- Firefox Add-on store interprets max version incorrectly when below 120, so we are removing this manifest patch that intended to prevent side loading

## Screen recordings / screenshots
<img width="664" height="156" alt="Screenshot 2025-09-15 at 12 15 57 PM" src="https://github.com/user-attachments/assets/f1ae37d2-de09-4047-9e73-bd6a59863efd" />

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## What to test

<!--

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
