### PR TITLE
fix: logger log level env, enabled state, transport selection

### DIFF
--- a/src/core/sentry/index.ts
+++ b/src/core/sentry/index.ts
@@ -12,6 +12,7 @@ import { RainbowError, logger } from '~/logger';
 import pkg from '../../../package.json';
 
 const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
+const IS_TESTING = process.env.IS_TESTING === 'true';
 
 // Common browser lifecycle errors that we want to ignore from Sentry
 // Strings are partially matched; use RegExp for exact matches
@@ -138,7 +139,11 @@ export function initializeSentry(context: 'popup' | 'background') {
         replaysSessionSampleRate: INTERNAL_BUILD ? 1.0 : 0.1, // 10% sampling in prod
         replaysOnErrorSampleRate: 1.0, // 100% sampling in prod
         release: pkg.version,
-        environment: INTERNAL_BUILD ? 'internal' : 'production',
+        environment: IS_TESTING
+          ? 'e2e'
+          : INTERNAL_BUILD
+          ? 'internal'
+          : 'production',
         ignoreErrors: IGNORED_ERRORS,
       });
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -253,7 +253,7 @@ export class Logger {
 export const logger = new Logger();
 
 /**
- * Report to console in dev, Sentry in prod, nothing in test.
+ * Report to console in dev, Sentry in prod, internal build, or e2e
  */
 if (process.env.NODE_ENV === 'production') {
   logger.addTransport(sentryTransport);

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -4,8 +4,6 @@ import format from 'date-fns/format';
 
 import { DebugContext } from './debugContext';
 
-const { LOG_LEVEL, LOG_DEBUG } = process.env;
-
 export enum LogLevel {
   Debug = 'debug',
   Info = 'info',
@@ -177,22 +175,18 @@ export class Logger {
   LogLevel = LogLevel;
   DebugContext = DebugContext;
 
-  enabled: boolean;
   level: LogLevel;
   transports: Transport[] = [];
 
   protected debugContextRegexes: RegExp[] = [];
 
   constructor({
-    enabled = process.env.NODE_ENV !== 'production',
-    level = LOG_LEVEL as LogLevel,
-    debug = LOG_DEBUG || '',
+    level = process.env.LOG_LEVEL as LogLevel,
+    debug = process.env.LOG_DEBUG || '',
   }: {
-    enabled?: boolean;
     level?: LogLevel;
     debug?: string;
   } = {}) {
-    this.enabled = enabled !== false;
     this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
     this.debugContextRegexes = (debug || '').split(',').map((context) => {
       return new RegExp(context.replace(/[^\w:*]/, '').replace(/\*/g, '.*'));
@@ -238,7 +232,6 @@ export class Logger {
     message: string | RainbowError,
     metadata: Metadata = {},
   ) {
-    if (!this.enabled) return;
     if (!enabledLogLevels[this.level].includes(level)) return;
 
     for (const transport of this.transports) {
@@ -262,8 +255,8 @@ export const logger = new Logger();
 /**
  * Report to console in dev, Sentry in prod, nothing in test.
  */
-if (process.env.NODE_ENV === 'development') {
-  logger.addTransport(consoleTransport);
-} else if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production') {
   logger.addTransport(sentryTransport);
+} else {
+  logger.addTransport(consoleTransport);
 }


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Added a new environment flag `IS_TESTING` to identify e2e test environments in Sentry
- Modified Sentry initialization to use 'e2e' as the environment name when `IS_TESTING=true`
- Simplified the Logger class by:
  - Removing the `enabled` property since it's no longer needed
  - Directly accessing environment variables instead of storing them in constants
- Updated logger transport configuration to:
  - Use Sentry transport in production environments
  - Use console transport in all other environments (development, test)

## What to test

- Verify that Sentry correctly identifies the environment as 'e2e' when `IS_TESTING=true`
- Confirm that logs are properly sent to Sentry in production builds
- Check that logs appear in the console during development
- Ensure logging works as expected in all environments (production, internal, e2e)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the Sentry and Logger implementations, particularly focusing on environment configurations and logging behavior based on new environment variables.

### Detailed summary
- Added `IS_TESTING` constant to determine if the environment is for testing.
- Modified the `environment` property in `initializeSentry` to handle `IS_TESTING`.
- Updated `Logger` constructor to use `process.env.LOG_LEVEL` and `process.env.LOG_DEBUG`.
- Adjusted logging behavior to include console transport for testing and internal builds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->