### PR TITLE
feat: add more breadcrumbs to internal builds

### DIFF
--- a/src/core/sentry/index.ts
+++ b/src/core/sentry/index.ts
@@ -11,8 +11,8 @@ import { RainbowError, logger } from '~/logger';
 
 import pkg from '../../../package.json';
 
-const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
-const IS_TESTING = process.env.IS_TESTING === 'true';
+export const INTERNAL_BUILD = process.env.INTERNAL_BUILD === 'true';
+export const IS_TESTING = process.env.IS_TESTING === 'true';
 
 // Common browser lifecycle errors that we want to ignore from Sentry
 // Strings are partially matched; use RegExp for exact matches

--- a/src/entries/background/procedures/popup/index.ts
+++ b/src/entries/background/procedures/popup/index.ts
@@ -1,6 +1,8 @@
 import { os } from '@orpc/server';
 import { RPCHandler } from '@orpc/server/message-port';
+import * as Sentry from '@sentry/react';
 
+import { INTERNAL_BUILD, IS_TESTING } from '~/core/sentry';
 import { RainbowError, logger } from '~/logger';
 
 import { healthRouter } from './health';
@@ -9,7 +11,16 @@ import { stateRouter } from './state';
 import { telemetryRouter } from './telemetry';
 import { walletRouter } from './wallet';
 
-const sentryMiddleware = os.middleware(async ({ next }) => {
+const sentryMiddleware = os.middleware(async ({ next, path }) => {
+  if (INTERNAL_BUILD || IS_TESTING) {
+    Sentry.addBreadcrumb({
+      message: `ORPC: ${path.join('/')}`,
+      data: {
+        path: path.join('/'),
+        timestamp: new Date().toISOString(),
+      },
+    });
+  }
   try {
     return await next();
   } catch (e) {

--- a/src/entries/background/procedures/popup/wallet/wallet.ts
+++ b/src/entries/background/procedures/popup/wallet/wallet.ts
@@ -1,9 +1,21 @@
+import * as Sentry from '@sentry/react';
+
 import { getWallet } from '~/core/keychain';
+import { INTERNAL_BUILD, IS_TESTING } from '~/core/sentry';
 
 import { walletOs } from '../os';
 
 export const walletHandler = walletOs.wallet.handler(
   async ({ input: address }) => {
+    if (INTERNAL_BUILD || IS_TESTING) {
+      Sentry.addBreadcrumb({
+        message: `Wallet address: ${address}`,
+        data: {
+          address,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    }
     return await getWallet(address);
   },
 );


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Exported `INTERNAL_BUILD` and `IS_TESTING` constants from the Sentry module to make them accessible in other parts of the application
- Added Sentry breadcrumbs for ORPC calls in the `sentryMiddleware` to improve debugging capabilities in internal builds and testing environments
- Added Sentry breadcrumbs for wallet address access to track wallet-related operations during development and testing

## What to test

- Verify that Sentry breadcrumbs are properly added for ORPC calls in internal builds and testing environments
- Confirm that wallet address operations are correctly tracked with breadcrumbs
- Ensure that breadcrumbs are only added when `INTERNAL_BUILD` or `IS_TESTING` is true
- Check that the existing error handling in the Sentry middleware still works as expected