### PR TITLE
fix: rehydrate error

### DIFF
--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -535,6 +535,9 @@ class KeychainManager {
   }
 
   async getKeychain(address: Address) {
+    if (!this.state.initialized) {
+      throw new Error('Keychain manager not initialized');
+    }
     for (let i = 0; i < this.state.keychains.length; i++) {
       const keychain = this.state.keychains[i];
       const accounts = await keychain.getAccounts();


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Added a check in the `getKeychain` method to verify that the KeychainManager is initialized before attempting to retrieve a keychain. This prevents potential errors when trying to access keychains before the manager is properly set up.

## What to test

- Verify that calling `getKeychain` before initialization throws the expected error message
- Ensure that `getKeychain` works correctly after proper initialization
- Check that this doesn't break any existing keychain retrieval functionality

## Screen recordings / screenshots

N/A

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a validation check in the `getKeychain` method of the `KeychainManager` class to ensure that the keychain manager is initialized before proceeding with retrieving keychains.

### Detailed summary
- Added a check to see if `this.state.initialized` is false.
- If not initialized, an error is thrown with the message 'Keychain manager not initialized'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->