### PR TITLE
fix: sign data validation

### DIFF
--- a/src/core/utils/ethereum.ts
+++ b/src/core/utils/ethereum.ts
@@ -111,7 +111,7 @@ export const normalizeTransactionResponsePayload = (
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sanitizeTypedData = (data: any) => {
-  if (data.types[data.primaryType].length > 0) {
+  if (data.types?.[data.primaryType]?.length > 0) {
     // Extract all the valid permit types for the primary type
     const permitPrimaryTypes: string[] = data.types[data.primaryType].map(
       (type: { name: string; type: string }) => type.name,


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Added optional chaining to the `sanitizeTypedData` function to safely access nested properties. This prevents potential errors when `data.types` or `data.types[data.primaryType]` is undefined.

## What to test

- Verify that the `sanitizeTypedData` function handles cases where `data.types` is undefined
- Verify that the function handles cases where `data.types[data.primaryType]` is undefined
- Ensure existing functionality works correctly when all properties are defined