### PR TITLE
feat: throw in getKeychain if locked

### DIFF
--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -542,6 +542,9 @@ class KeychainManager {
     if (!this.state.initialized) {
       throw new Error('Keychain manager not initialized');
     }
+    if (!this.state.isUnlocked) {
+      throw new Error('Wallet locked - please unlock to access accounts');
+    }
     for (let i = 0; i < this.state.keychains.length; i++) {
       const keychain = this.state.keychains[i];
       const accounts = await keychain.getAccounts();


### PR DESCRIPTION
# Prevent access to accounts when wallet is locked

## What changed (plus any additional context for devs)

Added a check in the `KeychainManager` to prevent access to accounts when the wallet is locked. Now, if a user attempts to access accounts while the wallet is locked, the system will throw an error message: "Wallet locked - please unlock to access accounts".

## What to test

- Verify that attempting to access accounts when the wallet is locked throws the appropriate error
- Confirm that unlocking the wallet allows proper access to accounts
- Test the error handling flow when a user tries to access accounts in locked state

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the `KeychainManager` by checking if the wallet is unlocked before accessing accounts.

### Detailed summary
- Added a check to see if `this.state.isUnlocked` is false.
- If the wallet is locked, an error is thrown with the message: 'Wallet locked - please unlock to access accounts'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->