### PR TITLE
fix: ensure AnimatedText receives string children

### DIFF
--- a/src/entries/popup/pages/home/Points/PointsOnboardingSheet.tsx
+++ b/src/entries/popup/pages/home/Points/PointsOnboardingSheet.tsx
@@ -243,7 +243,7 @@ const doneRows = [
     weight="semibold"
     color="labelTertiary"
   >
-    {doneRowsText[4]}
+    {doneRowsText[3]}
   </AnimatedText>,
 ];
 


### PR DESCRIPTION
## Summary
- fix the final done row so AnimatedText receives an existing string value
- avoid passing undefined children that triggered the Sentry error on the points onboarding route

## Testing
- yarn lint src/entries/popup/pages/home/Points/PointsOnboardingSheet.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d4c312a708832582dd51bbb868c76c