### PR TITLE
fix: remote config error

### DIFF
--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "./build/popup.js",
-      "maxSize": "2.4MB"
+      "maxSize": "3MB"
     },
     {
       "path": "./build/contentscript.js",

--- a/src/core/firebase/remoteConfig.ts
+++ b/src/core/firebase/remoteConfig.ts
@@ -8,7 +8,7 @@ import {
   isSupported,
 } from 'firebase/remote-config';
 
-import { RainbowError, logger } from '~/logger';
+import { logger } from '~/logger';
 
 import { useNetworkStore } from '../state/networks/networks';
 import { ChainId } from '../types/chains';
@@ -134,7 +134,7 @@ export const init = async () => {
     }
   } catch (e) {
     logger.info('Using default remote config');
-    logger.error(new RainbowError('error getting remote config', { cause: e }));
+    // most likely blocked by adblockers or dns
   } finally {
     config.status = 'ready';
     if (process.env.IS_DEV === 'true') {


### PR DESCRIPTION
# Remove error logging for remote config failures

## What changed

- Removed the `RainbowError` import from the logger module
- Replaced error logging with a comment indicating that remote config failures are most likely caused by adblockers or DNS blocking
- This change prevents unnecessary error logging for expected failures when retrieving remote configuration

## What to test

- Verify that the application still functions correctly when remote config cannot be retrieved
- Check that no errors are logged to the console when remote config fails to load due to adblockers or DNS blocking
- Ensure that the application falls back to default configuration values as expected

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating configuration settings and refining error handling in the codebase. It increases the `maxSize` limit in the `.bundlewatchrc.json` file and modifies error logging in the `src/core/firebase/remoteConfig.ts` file.

### Detailed summary
- Updated `maxSize` from `"2.4MB"` to `"3MB"` in `.bundlewatchrc.json`.
- Removed the import of `RainbowError` from `~/logger` in `src/core/firebase/remoteConfig.ts`.
- Changed error logging to a comment indicating the issue is likely caused by adblockers or DNS.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->