### PR TITLE
fix: react-query undefined

### DIFF
--- a/src/core/keychain/utils.ts
+++ b/src/core/keychain/utils.ts
@@ -56,9 +56,11 @@ export const autoDiscoverAccountsFromIndex = async ({
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    logger.error(new RainbowError(`[aha]: Failed to discover wallets`), {
-      message: error.message,
-    });
+    if (!(error instanceof Error && error.name === 'AbortError'))
+      // abort errors are expected
+      logger.error(new RainbowError(`[aha]: Failed to discover wallets`), {
+        message: error.message,
+      });
     return { accountsEnabled: 1 };
   }
 };

--- a/src/core/resources/transactions/consolidatedTransactions.ts
+++ b/src/core/resources/transactions/consolidatedTransactions.ts
@@ -119,9 +119,15 @@ export async function consolidatedTransactionsQueryFunction({
     };
   } catch (e) {
     // we don't bother with fetching cache and returning stale data here because we probably have previous page data already
-    logger.error(new RainbowError('consolidatedTransactionsQueryFunction: '), {
-      message: e,
-    });
+    if (!(e instanceof Error && e.name === 'AbortError'))
+      // abort errors are expected
+      logger.error(
+        new RainbowError('consolidatedTransactionsQueryFunction: '),
+        {
+          message: e,
+        },
+      );
+
     return { transactions: [] };
   }
 }


### PR DESCRIPTION
# Prevent logging AbortError instances as errors

## What changed

- Added conditional checks to prevent logging `AbortError` instances as errors since these are expected
- Updated error handling in multiple functions to only log errors that aren't abort errors
- Added null coalescing operators to ensure empty objects are used when cached data is undefined

## What to test

- Verify that AbortError instances are no longer logged as errors in the console
- Check that the application still properly handles other types of errors
- Confirm that the application gracefully handles cases where cached data is undefined

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `src/core/keychain/utils.ts`, `src/core/resources/transactions/consolidatedTransactions.ts`, and `src/core/resources/assets/userAssets.ts` files by adding checks for `AbortError` instances before logging errors.

### Detailed summary
- In `src/core/keychain/utils.ts`, added a check for `AbortError` before logging an error.
- In `src/core/resources/transactions/consolidatedTransactions.ts`, added a similar check for `AbortError` before logging.
- In `src/core/resources/assets/userAssets.ts`, modified the fallback for `cachedDataForChain` and added an `AbortError` check before logging errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->