### PR TITLE
fix: Cannot destructure property 'gasPrice' of 'e' as it is undefined

### DIFF
--- a/src/core/raps/utils.ts
+++ b/src/core/raps/utils.ts
@@ -44,7 +44,7 @@ export const overrideWithFastSpeedIfNeeded = ({
   chainId: ChainId;
   gasFeeParamsBySpeed: GasFeeParamsBySpeed | GasFeeLegacyParamsBySpeed;
 }) => {
-  const gasParams = selectedGas.transactionGasParams;
+  const gasParams = selectedGas.transactionGasParams ?? {};
   // approvals should always use fast gas or custom (whatever is faster)
   if (chainId === ChainId.mainnet) {
     const transactionGasParams = gasParams as TransactionGasParams;


### PR DESCRIPTION
# Fix for undefined transactionGasParams in gas fee handling

## What changed (plus any additional context for devs)

Added a null coalescing operator to provide a default empty object when `selectedGas.transactionGasParams` is undefined in the `overrideWithFastSpeedIfNeeded` function. This prevents potential errors when trying to access properties on an undefined value.

## What to test

- Verify that the function works correctly when `selectedGas.transactionGasParams` is undefined
- Ensure that gas fee parameters are properly applied for mainnet transactions
- Check that approval transactions still use fast gas or custom settings as expected

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of `gasParams` by ensuring it defaults to an empty object if `selectedGas.transactionGasParams` is `undefined`, preventing potential runtime errors.

### Detailed summary
- Changed the assignment of `gasParams` from `selectedGas.transactionGasParams` to `selectedGas.transactionGasParams ?? {}` to provide a default value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->