### PR TITLE
fix: seed validation in onboarding

### DIFF
--- a/src/entries/popup/components/ImportWallet/ImportWalletViaSeed.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletViaSeed.tsx
@@ -245,11 +245,11 @@ const ImportWalletViaSeed = () => {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && isValid) {
         handleImportWallet();
       }
     },
-    [handleImportWallet],
+    [handleImportWallet, isValid],
   );
 
   const isValidWord = (word: string) => englishWordlist.indexOf(word) > -1;


### PR DESCRIPTION
# Prevent wallet import via Enter key when form is invalid

## What changed

- Modified the `handleKeyDown` function in `ImportWalletViaSeed.tsx` to only trigger wallet import when the Enter key is pressed AND the form is valid
- Added `isValid` to the dependency array of the `useCallback` hook to ensure the callback is updated when validation state changes

## What to test

- Try pressing Enter when the seed phrase is invalid - import should not be triggered
- Try pressing Enter when the seed phrase is valid - import should be triggered
- Verify that other keyboard interactions still work as expected

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `handleKeyDown` function in the `ImportWalletViaSeed` component to ensure that the wallet is only imported when the `Enter` key is pressed and the wallet is valid.

### Detailed summary
- Updated the condition in `handleKeyDown` to check if `isValid` is true before calling `handleImportWallet()`.
- Added `isValid` as a dependency in the `useCallback` hook for `handleKeyDown`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->