### PR TITLE
feat: implement duplicate private key import handling

### DIFF
--- a/e2e/parallel/importWalletFlowPkey.test.ts
+++ b/e2e/parallel/importWalletFlowPkey.test.ts
@@ -5,11 +5,18 @@ import {
   beforeAll,
   beforeEach,
   describe,
+  expect,
   it,
 } from 'vitest';
 
 import {
   checkWalletName,
+  delayTime,
+  fillPrivateKey,
+  findElementByIdAndClick,
+  findElementByTestId,
+  findElementByTestIdAndClick,
+  findElementByText,
   getExtensionIdByName,
   getRootUrl,
   importWalletFlow,
@@ -52,6 +59,62 @@ describe('Import wallet with a private key flow', () => {
     );
   });
   it('should display account name', async () => {
+    await checkWalletName(
+      driver,
+      rootURL,
+      TEST_VARIABLES.PRIVATE_KEY_WALLET.ADDRESS,
+    );
+  });
+
+  it('should show toast and navigate to home when importing duplicate private key', async () => {
+    await importWalletFlow(
+      driver,
+      rootURL,
+      TEST_VARIABLES.PRIVATE_KEY_WALLET_2.SECRET,
+      true,
+    );
+
+    await checkWalletName(
+      driver,
+      rootURL,
+      TEST_VARIABLES.PRIVATE_KEY_WALLET_2.ADDRESS,
+    );
+
+    await findElementByIdAndClick({
+      id: 'header-account-name-shuffle',
+      driver,
+    });
+    await findElementByTestIdAndClick({ id: 'add-wallet-button', driver });
+    await findElementByTestIdAndClick({
+      id: 'import-wallets-button',
+      driver,
+    });
+    await findElementByTestIdAndClick({
+      id: 'import-via-pkey-option',
+      driver,
+    });
+
+    await fillPrivateKey(driver, TEST_VARIABLES.PRIVATE_KEY_WALLET.SECRET);
+    await findElementByTestIdAndClick({
+      id: 'import-wallets-button',
+      driver,
+    });
+
+    await delayTime('medium');
+
+    const toastMessage = await findElementByText(
+      driver,
+      'This private key is already imported',
+    );
+    expect(toastMessage).toBeTruthy();
+
+    await delayTime('short');
+    const homeScreen = await findElementByTestId({
+      id: 'home-page-header-right',
+      driver,
+    });
+    expect(homeScreen).toBeTruthy();
+
     await checkWalletName(
       driver,
       rootURL,

--- a/src/core/keychain/KeychainManager.ts
+++ b/src/core/keychain/KeychainManager.ts
@@ -16,7 +16,7 @@ import { persistWalletKeychainTypesFromWallets } from '~/core/state/walletKeycha
 import { RainbowError, logger } from '~/logger';
 
 import { LocalStorage, SessionStorage } from '../storage';
-import { KeychainType } from '../types/keychainTypes';
+import { DuplicateAccountError, KeychainType } from '../types/keychainTypes';
 import { isLowerCaseMatch } from '../utils/strings';
 
 import {
@@ -397,7 +397,7 @@ class KeychainManager {
     const newAccounts = await keychain.getAccounts();
     for (let i = 0; i < newAccounts.length; i++) {
       if (existingAccounts.includes(newAccounts[i])) {
-        throw new Error(`Duplicate account ${newAccounts[i]}`);
+        throw new DuplicateAccountError(newAccounts[i]);
       }
     }
     return;
@@ -415,7 +415,7 @@ class KeychainManager {
           matchingExistingAccount,
         );
         if (existingAccountWallet.type !== KeychainType.ReadOnlyKeychain) {
-          throw new Error(`Duplicate account ${newAccounts[i]}`);
+          throw new DuplicateAccountError(newAccounts[i]);
         }
       }
     }

--- a/src/core/keychain/index.test.ts
+++ b/src/core/keychain/index.test.ts
@@ -14,6 +14,7 @@ import {
 import { mainnet } from 'viem/chains';
 import { beforeAll, expect, test, vi } from 'vitest';
 
+import { DuplicateAccountError } from '~/core/types/keychainTypes';
 import { delay } from '~/test/utils';
 
 import { useConnectedToHardhatStore } from '../state/currentSettings/connectedToHardhat';
@@ -89,6 +90,10 @@ test('[keychain/index] :: should be able to import a wallet using a private key'
   const accounts = await getAccounts();
   expect(accounts.length).toBe(2);
   expect(isAddress(accounts[1])).toBe(true);
+});
+
+test('[keychain/index] :: should reject duplicate private key import', async () => {
+  await expect(importWallet(privateKey)).rejects.toThrow(DuplicateAccountError);
 });
 
 test('[keychain/index] :: should be able to remove an account from a KeyPair keychain...', async () => {

--- a/src/core/keychain/index.ts
+++ b/src/core/keychain/index.ts
@@ -29,7 +29,7 @@ import {
   getAtomicSwapsEnabled,
   getDelegationEnabled,
 } from '../resources/delegations/featureStatus';
-import { KeychainType } from '../types/keychainTypes';
+import { DuplicateAccountError, KeychainType } from '../types/keychainTypes';
 import { EthereumWalletType } from '../types/walletTypes';
 import {
   EthereumWalletSeed,
@@ -38,6 +38,7 @@ import {
   sanitizeTypedData,
 } from '../utils/ethereum';
 import { addHexPrefix } from '../utils/hex';
+import { isLowerCaseMatch } from '../utils/strings';
 
 import { PrivateKey } from './IKeychain';
 import { keychainManager } from './KeychainManager';
@@ -154,6 +155,9 @@ export const importHardwareWallet = async ({
   wallets: Array<{ address: Address; index: number; hdPath?: string }>;
   accountsEnabled: number;
 }) => {
+  if (wallets.length === 0) {
+    throw new Error('No hardware wallet accounts to import');
+  }
   const keychain = await keychainManager.importKeychain({
     vendor,
     type: KeychainType.HardwareWalletKeychain,
@@ -184,11 +188,22 @@ export const importWallet = async (
         privateKey: secret as PrivateKey,
       };
       const newAccount = (await keychainManager.deriveAccounts(opts))[0];
+      const existingAccounts = await keychainManager.getAccounts();
+      const matchingExisting = existingAccounts.find((a) =>
+        isLowerCaseMatch(a, newAccount),
+      );
+      if (matchingExisting) {
+        const existingKeychain =
+          await keychainManager.getKeychain(matchingExisting);
+        if (existingKeychain.type !== KeychainType.ReadOnlyKeychain) {
+          throw new DuplicateAccountError(matchingExisting);
+        }
+      }
 
-      await keychainManager.importKeychain(opts);
-      // returning the derived address instead of the first from the keychain,
-      // because this pk could have been elevated to hd while importing
-      return newAccount;
+      const keychain = await keychainManager.importKeychain(opts);
+      const accounts = await keychain.getAccounts();
+      const resolved = accounts.find((a) => isLowerCaseMatch(a, newAccount));
+      return resolved ?? accounts[0];
     }
     case EthereumWalletType.readOnly: {
       const keychain = await keychainManager.importKeychain({

--- a/src/core/types/keychainTypes.ts
+++ b/src/core/types/keychainTypes.ts
@@ -1,3 +1,5 @@
+import { Address } from 'viem';
+
 export enum KeychainType {
   HdKeychain = 'HdKeychain',
   KeyPairKeychain = 'KeyPairKeychain',
@@ -11,3 +13,19 @@ export type KeychainWallet = {
   imported: boolean;
   vendor?: 'Ledger' | 'Trezor';
 };
+
+/**
+ * Thrown when attempting to import an account that already exists in the vault.
+ */
+export class DuplicateAccountError extends Error {
+  readonly account: Address;
+
+  constructor(account: Address, message?: string) {
+    super(message || `Duplicate account ${account}`);
+    this.name = 'DuplicateAccountError';
+    this.account = account;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DuplicateAccountError);
+    }
+  }
+}

--- a/src/entries/background/contracts/popup/wallet/import.ts
+++ b/src/entries/background/contracts/popup/wallet/import.ts
@@ -3,6 +3,17 @@ import z from 'zod';
 
 import { addressSchema } from '~/core/schemas/address';
 
+export enum ImportWalletError {
+  DUPLICATE_ACCOUNT = 'DUPLICATE_ACCOUNT',
+}
+
+export const importWalletErrors = {
+  [ImportWalletError.DUPLICATE_ACCOUNT]: {
+    data: z.object({ address: addressSchema }),
+  },
+} as const;
+
 export const importContract = oc
   .input(z.object({ seed: z.string() }))
+  .errors(importWalletErrors)
   .output(z.object({ address: addressSchema }));

--- a/src/entries/background/procedures/popup/wallet/import.ts
+++ b/src/entries/background/procedures/popup/wallet/import.ts
@@ -1,11 +1,23 @@
 import { importWallet } from '~/core/keychain';
+import { DuplicateAccountError } from '~/core/types/keychainTypes';
 
 import { walletOs } from '../os';
 
 export const importHandler = walletOs.import.handler(
-  async ({ input: { seed } }) => {
-    const address = await importWallet(seed);
-    // Status is now computed from keychain state, no need to set it explicitly
-    return { address };
+  async ({ input: { seed }, errors }) => {
+    try {
+      const address = await importWallet(seed);
+      return { address };
+    } catch (e) {
+      if (e instanceof DuplicateAccountError) {
+        throw errors.DUPLICATE_ACCOUNT({
+          message: `Duplicate account ${e.account}`,
+          data: {
+            address: e.account,
+          },
+        });
+      }
+      throw e;
+    }
   },
 );

--- a/src/entries/popup/components/ImportWallet/ImportWalletViaPrivateKey.tsx
+++ b/src/entries/popup/components/ImportWallet/ImportWalletViaPrivateKey.tsx
@@ -1,8 +1,9 @@
+import { safe } from '@orpc/client';
 import { motion } from 'framer-motion';
 import { startsWith } from 'lodash';
 import { KeyboardEvent, useCallback, useEffect, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
-import { Address, isAddress } from 'viem';
+import { isAddress } from 'viem';
 
 import { analytics } from '~/analytics';
 import { i18n } from '~/core/languages';
@@ -20,6 +21,7 @@ import {
   Text,
   textStyles,
 } from '~/design-system';
+import { triggerAlert } from '~/design-system/components/Alert/Alert';
 import {
   accentSelectionStyle,
   placeholderStyle,
@@ -28,15 +30,16 @@ import {
   transformScales,
   transitions,
 } from '~/design-system/styles/designTokens';
+import { popupClient } from '~/entries/popup/handlers/background';
 
 import {
   getImportWalletSecrets,
   removeImportWalletSecrets,
   setImportWalletSecrets,
 } from '../../handlers/importWalletSecrets';
-import * as wallet from '../../handlers/wallet';
 import { useRainbowNavigate } from '../../hooks/useRainbowNavigate';
 import { ROUTES } from '../../urls';
+import { triggerToast } from '../Toast/Toast';
 
 const ImportWalletViaPrivateKey = () => {
   const navigate = useRainbowNavigate();
@@ -113,34 +116,61 @@ const ImportWalletViaPrivateKey = () => {
     if (isAddingWallets) return;
     // If it's only one private key, import it directly and go to wallet screen
     if (secrets.length === 1) {
-      if (isValidPrivateKey(secrets[0]) || isAddress(secrets[0])) {
-        try {
-          setIsAddingWallets(true);
-          const address = (await wallet.importWithSecret(
-            secrets[0],
-          )) as Address;
-          setCurrentAddress(address);
-          setIsAddingWallets(false);
+      const secret = secrets[0];
+      const isKeyPairImport = isValidPrivateKey(secret);
+      if (isKeyPairImport || isAddress(secret)) {
+        const goNext = () =>
+          onboarding
+            ? navigate(ROUTES.CREATE_PASSWORD, {
+                state: { backTo: ROUTES.WELCOME },
+              })
+            : navigate(ROUTES.HOME);
+
+        setIsAddingWallets(true);
+        const [error, data, isDefined] = await safe(
+          popupClient.wallet.import({ seed: secret }),
+        );
+
+        if (data) {
+          setCurrentAddress(data.address);
+
+          analytics.track('wallet.added', {
+            type: isKeyPairImport
+              ? KeychainType.KeyPairKeychain
+              : KeychainType.ReadOnlyKeychain,
+          });
+
+          removeImportWalletSecrets();
 
           // workaround for a deeper issue where the keychain status
           // didn't yet updated or synced in the same tick
           setTimeout(() => {
-            if (onboarding)
-              navigate(ROUTES.CREATE_PASSWORD, {
-                state: { backTo: ROUTES.WELCOME },
-              });
-            else navigate(ROUTES.HOME);
+            goNext();
+            setIsAddingWallets(false);
           }, 1);
+          return;
+        }
 
-          analytics.track('wallet.added', {
-            type: KeychainType.ReadOnlyKeychain,
+        setIsAddingWallets(false);
+
+        if (isDefined) {
+          setCurrentAddress(error.data.address);
+          triggerToast({
+            title: i18n.t(
+              isKeyPairImport
+                ? 'import_wallet_via_private_key.duplicate_private_key'
+                : 'import_wallet_via_private_key.duplicate_watched_wallet',
+            ),
           });
-
-          setIsAddingWallets(false);
+          goNext();
           removeImportWalletSecrets();
           return;
-        } catch (e) {
-          //
+        }
+
+        if (error) {
+          triggerAlert({
+            text: i18n.t('import_wallet_via_private_key.import_error'),
+          });
         }
       }
     }

--- a/src/entries/popup/pages/hw/walletList/index.tsx
+++ b/src/entries/popup/pages/hw/walletList/index.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { Address } from 'viem';
+import { Address, getAddress } from 'viem';
 
 import { i18n } from '~/core/languages';
 import { useCurrentAddressStore } from '~/core/state';
+import { useHiddenWalletsStore } from '~/core/state/hiddenWallets';
+import { isLowerCaseMatch } from '~/core/utils/strings';
 import {
   Box,
   Button,
@@ -23,6 +25,7 @@ import { AddressOrEns } from '../../../components/AddressOrEns/AddressorEns';
 import { Checkbox } from '../../../components/Checkbox/Checkbox';
 import { FullScreenContainer } from '../../../components/FullScreen/FullScreenContainer';
 import { Spinner } from '../../../components/Spinner/Spinner';
+import { triggerToast } from '../../../components/Toast/Toast';
 import { WalletAvatar } from '../../../components/WalletAvatar/WalletAvatar';
 import * as wallet from '../../../handlers/wallet';
 import { useRainbowNavigate } from '../../../hooks/useRainbowNavigate';
@@ -71,34 +74,51 @@ const WalletListHW = () => {
     if (isLoading) return;
     if (selectedAccounts === 0) return;
     setIsLoading(true);
-    let defaultAccountChosen = false;
-    // Import all the secrets
-    const filteredAccounts = accountsToImport.filter(
+    const selectedToConnect = accountsToImport.filter(
       (account: { address: Address }) =>
-        !accountsIgnored.includes(account.address) &&
-        !existingWallets.includes(account.address),
+        !accountsIgnored.includes(account.address),
+    );
+    const filteredAccounts = selectedToConnect.filter(
+      (account: { address: Address }) =>
+        !existingWallets.some((ew) => isLowerCaseMatch(ew, account.address)),
     );
 
-    const address = (await wallet.importAccountsFromHW(
-      filteredAccounts,
-      state.accountsEnabled,
-      state.deviceId,
-      state.vendor as Vendor,
-    )) as Address;
-    // Select the first wallet
-    if (!defaultAccountChosen && !accountsIgnored.includes(address)) {
-      defaultAccountChosen = true;
-      setCurrentAddress(address);
-    }
+    try {
+      if (filteredAccounts.length === 0 && selectedToConnect.length > 0) {
+        const canonicalFor = (raw: Address) =>
+          existingWallets.find((ew) => isLowerCaseMatch(ew, raw)) ??
+          getAddress(raw);
+        const { unhideWallet } = useHiddenWalletsStore.getState();
+        for (const { address } of selectedToConnect) {
+          unhideWallet({ address: canonicalFor(address) });
+        }
+        setCurrentAddress(canonicalFor(selectedToConnect[0].address));
+        triggerToast({
+          title: i18n.t('hw.wallet_already_imported'),
+        });
+        navigate(ROUTES.HOME);
+        return;
+      }
 
-    navigate(ROUTES.HW_SUCCESS, {
-      state: {
-        accounts: filteredAccounts.map(
-          (account: { address: Address }) => account.address,
-        ),
-        vendor: state.vendor,
-      },
-    });
+      const address = await wallet.importAccountsFromHW(
+        filteredAccounts,
+        state.accountsEnabled,
+        state.deviceId,
+        state.vendor,
+      );
+      if (!accountsIgnored.includes(address)) setCurrentAddress(address);
+
+      navigate(ROUTES.HW_SUCCESS, {
+        state: {
+          accounts: filteredAccounts.map(
+            (account: { address: Address }) => account.address,
+          ),
+          vendor: state.vendor,
+        },
+      });
+    } finally {
+      setIsLoading(false);
+    }
   }, [
     isLoading,
     selectedAccounts,

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -1095,7 +1095,10 @@
     "title": "Import Your Wallet",
     "explanation": "Enter your 64-character Private Key from Rainbow or any Ethereum wallet.",
     "placeholder": "Paste your Private Key from another wallet",
-    "import_wallet": "Import wallet"
+    "import_wallet": "Import wallet",
+    "duplicate_private_key": "This private key is already imported",
+    "duplicate_watched_wallet": "This watched wallet is already imported",
+    "import_error": "Failed to import wallet. Please try again."
   },
   "import_or_connect": {
     "title": "Restore or Connect",
@@ -1822,6 +1825,7 @@
     "connect_wallets_found": "We’ve found %{count} wallets on your %{vendor} with a balance or activity. Select which to connect.",
     "connect_wallets_not_found": "We didn't find any wallets with activity on this %{vendor} but you can still add these.",
     "connect_wallet": "Connect wallet",
+    "wallet_already_imported": "These hardware wallet accounts are already imported",
     "connect_n_wallets": "Connect %{count} wallets",
     "wallets_found": "%{count} wallets found",
     "add_by_index": "Add by index",


### PR DESCRIPTION
Fixes BX-1922, BX-2126

Trying to add a wallet that is **already** in Rainbow. Whether by **private key** or by **Ledger/Trezor** when every address you pick is already imported, failed or felt broken: unclear feedback, stuck or confusing UI, or attempts to “import” nothing instead of switching to the wallet you already have.

### What changed

- Duplicate imports are now handled end-to-end with clear feedback, switching to the relevant existing account, and navigation that matches user intent instead of opaque failures or invalid empty imports.
- Analytics and safeguards were aligned so successful flows are tracked correctly and the vault cannot be put into an inconsistent state from these cases; tests cover the duplicate-import behavior.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces error handling for duplicate wallet imports, enhances the import functionality, and improves user feedback through notifications. It also adds a new error class and modifies several components to handle these changes effectively.

### Detailed summary
- Added `ImportWalletError` enum and `importWalletErrors` object for error handling.
- Introduced `DuplicateAccountError` class for duplicate wallet imports.
- Updated `importHandler` to catch and throw `DuplicateAccountError`.
- Added tests for duplicate wallet import handling.
- Enhanced user feedback with toast notifications for duplicate imports.
- Modified wallet import logic to check for existing accounts before importing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->