### PR TITLE
fix(send): gate in-app and dApp approval on native balance for value + max fee

### DIFF
--- a/src/core/send/nativeSendBalance.test.ts
+++ b/src/core/send/nativeSendBalance.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+
+import { hasEnoughNativeBalanceForSend } from './nativeSendBalance';
+
+test('hasEnoughNativeBalanceForSend is false when balance < value + gas', () => {
+  expect(
+    hasEnoughNativeBalanceForSend({
+      balanceWei: 99n,
+      valueWei: 50n,
+      gasFeeWei: 50n,
+    }),
+  ).toBe(false);
+});
+
+test('hasEnoughNativeBalanceForSend is true when balance equals value + gas', () => {
+  expect(
+    hasEnoughNativeBalanceForSend({
+      balanceWei: 100n,
+      valueWei: 50n,
+      gasFeeWei: 50n,
+    }),
+  ).toBe(true);
+});
+
+test('hasEnoughNativeBalanceForSend is true for gas-only when balance covers gas', () => {
+  expect(
+    hasEnoughNativeBalanceForSend({
+      balanceWei: 21_000_000_000_000n,
+      valueWei: 0n,
+      gasFeeWei: 21_000_000_000_000n,
+    }),
+  ).toBe(true);
+});

--- a/src/core/send/nativeSendBalance.ts
+++ b/src/core/send/nativeSendBalance.ts
@@ -1,0 +1,15 @@
+/**
+ * Whether the account balance (wei) covers native value + max gas fee (wei).
+ * Used by send / dApp approval validation hooks.
+ */
+export function hasEnoughNativeBalanceForSend({
+  balanceWei,
+  valueWei,
+  gasFeeWei,
+}: {
+  balanceWei: bigint;
+  valueWei: bigint;
+  gasFeeWei: bigint;
+}): boolean {
+  return balanceWei >= valueWei + gasFeeWei;
+}

--- a/src/entries/popup/hooks/approveAppRequest/useApproveAppRequestValidations.ts
+++ b/src/entries/popup/hooks/approveAppRequest/useApproveAppRequestValidations.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { Hex } from 'viem';
 
 import { DAppStatus } from '~/core/graphql/__generated__/metadata';
 import { i18n } from '~/core/languages';
@@ -13,16 +14,18 @@ export const useApproveAppRequestValidations = ({
   session,
   dappStatus,
   signingWithDevice,
+  nativeValueHex,
 }: {
   session: ActiveSession;
   dappStatus?: DAppStatus;
   signingWithDevice?: boolean;
+  nativeValueHex?: Hex;
 }) => {
   const { connectedToHardhat, connectedToHardhatOp } =
     useConnectedToHardhatStore();
 
   const { hasEnough: enoughNativeAssetForGas, isLoading: isGasLoading } =
-    useHasEnoughGas(session);
+    useHasEnoughGas(session, { nativeValueHex });
 
   const buttonLabel = useMemo(() => {
     const activeChainId = chainIdToUse(

--- a/src/entries/popup/hooks/send/useSendValidations.ts
+++ b/src/entries/popup/hooks/send/useSendValidations.ts
@@ -5,6 +5,7 @@ import { Address } from 'viem';
 import { i18n } from '~/core/languages';
 import { selectUserAssetsDictByChain } from '~/core/resources/_selectors/assets';
 import { useUserAssets } from '~/core/resources/assets';
+import { hasEnoughNativeBalanceForSend } from '~/core/send/nativeSendBalance';
 import { useCurrentAddressStore, useCurrentCurrencyStore } from '~/core/state';
 import { ParsedUserAsset } from '~/core/types/assets';
 import { ChainId, chainNameToIdMapping } from '~/core/types/chains';
@@ -13,10 +14,8 @@ import { UniqueAsset } from '~/core/types/nfts';
 import { getChain } from '~/core/utils/chains';
 import { toWei } from '~/core/utils/ethereum';
 import {
-  add,
   convertAmountToRawAmount,
   lessOrEqualThan,
-  lessThan,
 } from '~/core/utils/numbers';
 
 import { useUserNativeAsset } from '../useUserNativeAsset';
@@ -81,16 +80,16 @@ export const useSendValidations = ({
   ]);
 
   const enoughNativeAssetForGas = useMemo(() => {
-    if (asset?.isNativeAsset) {
-      return lessOrEqualThan(
-        add(toWei(assetAmount || '0'), selectedGas?.gasFee?.amount || '0'),
-        toWei(nativeAsset?.balance?.amount || '0'),
-      );
-    }
-    return lessThan(
-      selectedGas?.gasFee?.amount || '0',
-      toWei(nativeAsset?.balance?.amount || '0'),
-    );
+    const balanceWei = BigInt(toWei(nativeAsset?.balance?.amount || '0'));
+    const gasFeeWei = BigInt(selectedGas?.gasFee?.amount || '0');
+    const valueWei = asset?.isNativeAsset
+      ? BigInt(toWei(assetAmount || '0'))
+      : 0n;
+    return hasEnoughNativeBalanceForSend({
+      balanceWei,
+      valueWei,
+      gasFeeWei,
+    });
   }, [
     asset?.isNativeAsset,
     assetAmount,

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionActions.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionActions.tsx
@@ -1,3 +1,5 @@
+import { Hex } from 'viem';
+
 import { DAppStatus } from '~/core/graphql/__generated__/metadata';
 import { i18n } from '~/core/languages';
 import { shortcuts } from '~/core/references/shortcuts';
@@ -17,6 +19,7 @@ export const SendTransactionActions = ({
   loading = false,
   dappStatus,
   signingWithDevice,
+  nativeValueHex,
 }: {
   session: ActiveSession;
   onAcceptRequest: () => void;
@@ -25,9 +28,15 @@ export const SendTransactionActions = ({
   loading: boolean;
   dappStatus?: DAppStatus;
   signingWithDevice: boolean;
+  nativeValueHex?: Hex;
 }) => {
   const { enoughNativeAssetForGas, buttonLabel } =
-    useApproveAppRequestValidations({ session, dappStatus, signingWithDevice });
+    useApproveAppRequestValidations({
+      session,
+      dappStatus,
+      signingWithDevice,
+      nativeValueHex,
+    });
 
   const { trackShortcut } = useKeyboardAnalytics();
   useKeyboardShortcut({

--- a/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { ReactNode, memo, useState } from 'react';
-import { Address } from 'viem';
+import { Address, Hex } from 'viem';
 
 import {
   DAppStatus,
@@ -82,6 +82,8 @@ interface SendTransactionProps {
   }: {
     preventWindowClose?: boolean;
   }) => void;
+  /** Hex wei for tx `value`; aligns insufficient-balance UI with `sendTransaction` preflight. */
+  nativeValueHex?: Hex;
 }
 
 const InfoRow = ({
@@ -734,6 +736,7 @@ export function SendTransactionInfo({
   dappStatusForUi,
   simulationResult,
   onRejectRequest,
+  nativeValueHex,
 }: SendTransactionProps) {
   const dappUrl = request?.meta?.sender?.url || '';
   const { data: dappMetadata } = useDappMetadata({ url: dappUrl });
@@ -748,8 +751,10 @@ export function SendTransactionInfo({
   const statusForUi = dappStatusForUi ?? dappMetadata?.status;
   const isScamDapp = statusForUi === DAppStatus.Scam;
 
-  const { hasEnough: hasEnoughGas, isLoading: isGasLoading } =
-    useHasEnoughGas(activeSession);
+  const { hasEnough: hasEnoughGas, isLoading: isGasLoading } = useHasEnoughGas(
+    activeSession,
+    { nativeValueHex },
+  );
 
   return (
     <Box

--- a/src/entries/popup/pages/messages/SendTransaction/index.tsx
+++ b/src/entries/popup/pages/messages/SendTransaction/index.tsx
@@ -1,6 +1,7 @@
 import { TransactionRequest } from '@ethersproject/abstract-provider';
+import { BigNumber } from '@ethersproject/bignumber';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Address, getAddress } from 'viem';
+import { Address, type Hex, getAddress } from 'viem';
 
 import { analytics } from '~/analytics';
 import { event } from '~/analytics/event';
@@ -120,6 +121,21 @@ export function SendTransaction({
     chainId,
     selectedWallet,
   ]);
+
+  /** Hex wei for tx `value` — included in `useHasEnoughGas` so balance covers value + gas. */
+  const nativeValueHexForBalanceCheck = useMemo((): Hex | undefined => {
+    if (isSendCalls || !transactionRequest) return undefined;
+    const raw = transactionRequest.value;
+    if (raw === undefined || raw === null) return '0x0';
+    try {
+      return BigNumber.from(raw).toHexString() as Hex;
+    } catch (e) {
+      logger.info('SendTransaction: invalid tx value for balance check', {
+        message: (e as Error)?.message,
+      });
+      return '0x0';
+    }
+  }, [isSendCalls, transactionRequest]);
 
   const simulationTransaction = useMemo((): SimulateTransactionInput | null => {
     if (!sendCallsFlowReady || !transactionRequest) return null;
@@ -416,6 +432,7 @@ export function SendTransaction({
         dappStatusForUi={effectiveDappStatus}
         simulationResult={simulationResult}
         onRejectRequest={rejectRequest}
+        nativeValueHex={nativeValueHexForBalanceCheck}
       />
       <Stack space="20px" padding="20px">
         <Bleed vertical="4px">
@@ -459,6 +476,7 @@ export function SendTransaction({
           loading={loading || (isSendCalls && envelopePending)}
           dappStatus={effectiveDappStatus}
           signingWithDevice={isSigningWithDevice}
+          nativeValueHex={nativeValueHexForBalanceCheck}
         />
       </Stack>
     </Box>

--- a/src/entries/popup/pages/messages/useHasEnoughGas.ts
+++ b/src/entries/popup/pages/messages/useHasEnoughGas.ts
@@ -1,14 +1,22 @@
 import { useMemo } from 'react';
+import { Hex, hexToBigInt } from 'viem';
 
+import { hasEnoughNativeBalanceForSend } from '~/core/send/nativeSendBalance';
 import { useGasStore } from '~/core/state';
 import { ActiveSession } from '~/core/state/appSessions';
 import { ChainId } from '~/core/types/chains';
 import { toWei } from '~/core/utils/ethereum';
-import { lessThan } from '~/core/utils/numbers';
 
 import { useUserNativeAsset } from '../../hooks/useUserNativeAsset';
 
-export const useHasEnoughGas = (session: ActiveSession) => {
+/**
+ * @param nativeValueHex — tx `value` (hex wei). When set, balance must cover
+ * value + gas (same as `useSendValidations` / `hasEnoughNativeBalanceForSend`).
+ */
+export const useHasEnoughGas = (
+  session: ActiveSession,
+  options?: { nativeValueHex?: Hex },
+) => {
   const chainId = session?.chainId || ChainId.mainnet;
 
   const { nativeAsset, isLoading: isNativeAssetLoading } = useUserNativeAsset({
@@ -24,14 +32,22 @@ export const useHasEnoughGas = (session: ActiveSession) => {
       return undefined; // Unknown state
     }
 
-    return lessThan(
-      selectedGas?.gasFee?.amount || '0',
-      toWei(nativeAsset?.balance?.amount || '0'),
-    );
+    const balanceWei = BigInt(toWei(nativeAsset?.balance?.amount || '0'));
+    const gasFeeWei = BigInt(selectedGas?.gasFee?.amount || '0');
+    const valueWei = options?.nativeValueHex
+      ? hexToBigInt(options.nativeValueHex)
+      : 0n;
+
+    return hasEnoughNativeBalanceForSend({
+      balanceWei,
+      valueWei,
+      gasFeeWei,
+    });
   }, [
     selectedGas?.gasFee?.amount,
     nativeAsset?.balance?.amount,
     isNativeAssetLoading,
+    options?.nativeValueHex,
   ]);
 
   return {

--- a/static/json/languages/en_US.json
+++ b/static/json/languages/en_US.json
@@ -1395,6 +1395,7 @@
     "error_encountered": "Something went wrong. Please share the issue with our team and we'll get that fixed!",
     "no_wallet_name_set": "No wallet name set",
     "report_error": "Report issue",
+    "insufficient_native_funds_description": "The total amount plus network fee exceeds your balance.",
     "sending_transaction": "Error sending transaction",
     "executing_swap": "Error executing swap"
   },


### PR DESCRIPTION
Users could advance send / approval flows even when they did not hold enough of the chain’s native asset to cover the **transfer and** the worst-case network fee. That showed up most clearly when a dApp proposed a transaction with **native `value`**: the approval path only compared **gas** to balance, so the flow could treat “gas only” as enough and only fail at broadcast, often with a generic error.

## What changed

We now **gate the UI** on the same rule where it matters: **native balance must cover `value` + `selectedGas.gasFee.amount`** (the max fee line from the gas store, including OP-stack L1 security fee where that feed applies). The check is **`bigint`-only**, implemented once in `src/core/send/nativeSendBalance.ts` as `hasEnoughNativeBalanceForSend`.

- **In-app send** — `useSendValidations` uses that helper (native send: amount + gas; ERC-20 send: gas only).
- **DApp `eth_sendTransaction`** — `useHasEnoughGas` takes optional `nativeValueHex` derived from the pending tx (`SendTransaction`) so approval is not gas-only when the tx carries native value.

There is **no** extra balance guard inside `handlers/wallet.sendTransaction`; validation lives in hooks so we don’t duplicate logic at submit.

Fixes BX-2073.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to handle native asset balance checks during transactions, ensuring that the total amount and gas fees do not exceed the user's balance. It adds new functions and updates existing hooks to utilize these checks for better validation.

### Detailed summary
- Added `insufficient_native_funds_description` to `static/json/languages/en_US.json`.
- Implemented `hasEnoughNativeBalanceForSend` function in `src/core/send/nativeSendBalance.ts` for balance validation.
- Updated `useApproveAppRequestValidations` to accept `nativeValueHex`.
- Modified `SendTransactionActions` to pass `nativeValueHex` to validation hooks.
- Enhanced `useSendValidations` to utilize `hasEnoughNativeBalanceForSend`.
- Updated `useHasEnoughGas` to check if the balance covers both value and gas fees.
- Created tests for `hasEnoughNativeBalanceForSend` in `src/core/send/nativeSendBalance.test.ts`.
- Adjusted `SendTransaction` component to compute and pass `nativeValueHexForBalanceCheck`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->