### PR TITLE
chore: gracefully cancel internal publish when no new commits

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -23,7 +23,7 @@ jobs:
           if [[ "$last_commit" == *"Version Bump (Internal)"* ]]; then
             echo "No new commits. Skipping publish."
             gh run cancel ${{ github.run_id }}
-            gh run watch ${{ github.run_id }}
+            sleep 60
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -21,9 +21,12 @@ jobs:
         run: |
           last_commit=$(git log -1 --pretty=%B)
           if [[ "$last_commit" == *"Version Bump (Internal)"* ]]; then
-            echo "No new commits. Canceling publish..."
-            exit 1
+            echo "No new commits. Skipping publish."
+            gh run cancel ${{ github.run_id }}
+            gh run watch ${{ github.run_id }}
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "22.17.0"


### PR DESCRIPTION
## Summary
- When the daily internal publish cron finds no new commits (last commit is a version bump), the workflow now cancels itself gracefully via `gh run cancel` instead of `exit 1`
- Runs show as "cancelled" (neutral) instead of "failed", eliminating false error signals from expected no-op runs

## Test plan
- [ ] Trigger the workflow manually when the latest commit is a "Version Bump (Internal)" commit and verify the run ends as cancelled, not failed
- [ ] Trigger the workflow when there are new commits and verify the publish proceeds normally