### PR TITLE
chore: consolidate dependabot security updates into single grouped PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,9 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@rainbow-me/*"
-  - package-ecosystem: "npm"
-    directory: "/src/design-system/docs"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
+    versioning-strategy: lockfile-only
+    groups:
+      all-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@rainbow-me/*"
-        applies-to: version-updates
     versioning-strategy: lockfile-only
     groups:
       all-security:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@rainbow-me/*"
+        applies-to: version-updates
     versioning-strategy: lockfile-only
     groups:
       all-security:


### PR DESCRIPTION
## Summary
- Remove the fully-ignored `design-system/docs` dependabot entry
- Add `versioning-strategy: lockfile-only` so security updates only touch `yarn.lock`, not `package.json` or resolutions
- Add `groups.all-security` with `applies-to: security-updates` to consolidate all security fixes into one auto-rebasing PR
- Version updates remain scoped to `@rainbow-me/*`; security updates cover all deps including devDependencies

## Test plan
- [ ] CI passes on this PR (validates the YAML is well-formed and no regressions)
- [ ] Verify Dependabot picks up the new config and creates grouped security PRs