### PR TITLE
fix: gate script-type detection on chrome.runtime.id, not chrome.runtime

### DIFF
--- a/src/core/utils/detectScriptType.ts
+++ b/src/core/utils/detectScriptType.ts
@@ -2,7 +2,11 @@
  * Detects and returns what context the script is in.
  */
 export function detectScriptType() {
-  const hasChromeRuntime = typeof chrome !== 'undefined' && chrome.runtime;
+  // Gate on `chrome.runtime?.id` (only set in this extension's own
+  // contexts) rather than `chrome.runtime`, which other extensions'
+  // externally_connectable can expose to page context. Fixes #1381.
+  const hasChromeRuntime =
+    typeof chrome !== 'undefined' && Boolean(chrome.runtime?.id);
   const hasWindow = typeof window !== 'undefined';
 
   if (hasChromeRuntime && hasWindow) {


### PR DESCRIPTION
Fixes #1381, RK-162, BX-1770

_External contributor — no internal `BX-####` ticket._

## What changed

Gate `detectScriptType`'s "extension context" check on `chrome.runtime?.id` instead of `chrome.runtime` truthiness.

When another installed extension declares [`externally_connectable`](https://developer.chrome.com/docs/extensions/reference/manifest/externally-connectable) (MetaMask, Phantom, etc.), Chrome exposes a `chrome.runtime` stub in page context, which is truth in the current inpage gate, causing it to misidentify as a content script. It then routes through `tabMessenger`, which calls `chrome.runtime.sendMessage` from page context without an `extensionId` [rejected by Chrome](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendMessage).

`chrome.runtime.id` is only populated in the extension's own contexts, so it's the correct gate.

```diff
-  const hasChromeRuntime = typeof chrome !== 'undefined' && chrome.runtime;
+  const hasChromeRuntime =
+    typeof chrome !== 'undefined' && Boolean(chrome.runtime?.id);
```

## Screen recordings / screenshots

Before: with Rainbow + any other wallet extension active, every dapp logs `chrome.runtime.sendMessage() called from a webpage must specify an Extension ID`. After: no error. Happy to record a clip if needed.

## What to test

- Chrome with Rainbow **and** MetaMask (or Phantom) installed, visit any dapp → console clean.
- Clean profile with only Rainbow → unchanged.
- Connect, switch chain, disconnect, send a testnet tx — all still work.
- Firefox build → same.