### PR TITLE
fix: only poll 5792 transactions in background

### DIFF
--- a/src/core/state/batches/updateBatchStatus.ts
+++ b/src/core/state/batches/updateBatchStatus.ts
@@ -47,9 +47,15 @@ export async function updateBatchesForMinedTx(
   tx: MinedTxInfo,
 ): Promise<number> {
   const batchKeys = getBatchKeysForNonce(tx.nonce, tx.chainId, tx.sender);
+  if (batchKeys.length === 0) return 0;
+
+  // Fetch the receipt once for all matching batches instead of per-batch
+  const provider = getProvider({ chainId: tx.chainId });
+  const receipt = await fetchReceipt(tx.hash, provider);
+
   await Promise.all(
     batchKeys.map((key) =>
-      updateBatchStatusFromReceipt(key, tx).catch(() => undefined),
+      updateBatchStatusFromReceipt(key, tx, receipt).catch(() => undefined),
     ),
   );
   return batchKeys.length;
@@ -63,12 +69,10 @@ export async function updateBatchesForMinedTx(
 async function updateBatchStatusFromReceipt(
   batchKey: string,
   minedTx: MinedTxInfo,
+  receipt: TransactionReceipt | null,
 ): Promise<void> {
   const batch = useBatchStore.getState().batches[batchKey];
   if (!batch) return;
-
-  const provider = getProvider({ chainId: batch.chainId });
-  const receipt = await fetchReceipt(minedTx.hash, provider);
 
   let newStatus: BatchStatusValue;
   let callReceipt: WalletCallReceipt | undefined;

--- a/src/core/state/transactions/pendingTransactions/watchPendingTransactions.ts
+++ b/src/core/state/transactions/pendingTransactions/watchPendingTransactions.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem';
+import type { Address } from 'viem';
 
 import { fetchTransaction } from '~/core/resources/transactions/transaction';
 import {
@@ -13,7 +13,7 @@ import { useNetworkStore } from '~/core/state/networks/networks';
 import { isPendingTxTimedOut } from '~/core/state/networks/timing';
 import { useStaleBalancesStore } from '~/core/state/staleBalances';
 import { useCustomNetworkTransactionsStore } from '~/core/state/transactions/customNetworkTransactions';
-import {
+import type {
   MinedTransaction,
   RainbowTransaction,
 } from '~/core/types/transactions';
@@ -37,10 +37,10 @@ export interface WatchPendingTransactionsOptions {
  * after React Query cache is updated. Runs in background service worker.
  */
 export async function watchPendingTransactions(
+  pendingTransactions: Record<Address, RainbowTransaction[]>,
   options?: WatchPendingTransactionsOptions,
 ): Promise<void> {
   const { skipTimedOutTxs = false } = options ?? {};
-  const { pendingTransactions } = usePendingTransactionsStore.getState();
   const { currentCurrency } = useCurrentCurrencyStore.getState();
   const { updatePendingTransaction, removePendingTransactionsForAddress } =
     usePendingTransactionsStore.getState();

--- a/src/entries/background/handlers/handleWatchPendingTransactions.test.ts
+++ b/src/entries/background/handlers/handleWatchPendingTransactions.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const address = '0x1234567890abcdef1234567890abcdef12345678';
+  let activePopupPortCount = 0;
+  const regularTx = {
+    chainId: 1,
+    hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    nonce: 1,
+    status: 'pending',
+  };
+  const batchTx = {
+    chainId: 1,
+    hash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    nonce: 2,
+    status: 'pending',
+  };
+  const pendingTransactions = { [address]: [regularTx, batchTx] };
+
+  return {
+    address,
+    batchTx,
+    getBatchKeysForNonce: vi.fn((nonce, chainId, sender) => {
+      return nonce === batchTx.nonce && chainId === 1 && sender === address
+        ? ['batch']
+        : [];
+    }),
+    getMinPollingIntervalForPendingTxs: vi.fn(),
+    pendingTransactions,
+    popupPortLifecycleListeners: new Set<() => void>(),
+    regularTx,
+    setActivePopupPortCount: (count: number) => {
+      activePopupPortCount = count;
+    },
+    usePendingTransactionsStore: {
+      getState: vi.fn(() => ({ pendingTransactions })),
+      persist: {
+        hydrationPromise: vi.fn(() => Promise.resolve()),
+      },
+      subscribe: vi.fn(),
+    },
+    watchPendingTransactions: vi.fn(),
+    get activePopupPortCount() {
+      return activePopupPortCount;
+    },
+  };
+});
+
+vi.mock('~/core/state', () => ({
+  usePendingTransactionsStore: mocks.usePendingTransactionsStore,
+}));
+
+vi.mock('~/core/state/batches/updateBatchStatus', () => ({
+  getBatchKeysForNonce: mocks.getBatchKeysForNonce,
+}));
+
+vi.mock('~/core/state/networks/timing', () => ({
+  getMinPollingIntervalForPendingTxs: mocks.getMinPollingIntervalForPendingTxs,
+}));
+
+vi.mock(
+  '~/core/state/transactions/pendingTransactions/watchPendingTransactions',
+  () => ({
+    watchPendingTransactions: mocks.watchPendingTransactions,
+  }),
+);
+
+vi.mock('../procedures/popup/popupPortManager', () => ({
+  addPopupPortLifecycleListener: vi.fn((listener: () => void) => {
+    mocks.popupPortLifecycleListeners.add(listener);
+    return () => {
+      mocks.popupPortLifecycleListeners.delete(listener);
+    };
+  }),
+  isPopupOpen: vi.fn(() => mocks.activePopupPortCount > 0),
+}));
+
+describe('handleWatchPendingTransactions', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+
+    mocks.setActivePopupPortCount(0);
+    mocks.popupPortLifecycleListeners.clear();
+    mocks.getMinPollingIntervalForPendingTxs.mockReturnValue(1000);
+    mocks.watchPendingTransactions.mockResolvedValue(undefined);
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not mark the initial all-pending poll done after a batch-only cycle', async () => {
+    const { handleWatchPendingTransactions } = await import(
+      './handleWatchPendingTransactions'
+    );
+
+    await handleWatchPendingTransactions();
+    await Promise.resolve();
+
+    // Cold start with popup closed: background should poll only batch txs.
+    expect(mocks.watchPendingTransactions).toHaveBeenNthCalledWith(
+      1,
+      { [mocks.address]: [mocks.batchTx] },
+      { skipTimedOutTxs: false },
+    );
+
+    mocks.setActivePopupPortCount(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // First popup-open cycle should still run the full initial check.
+    expect(mocks.watchPendingTransactions).toHaveBeenNthCalledWith(
+      2,
+      mocks.pendingTransactions,
+      { skipTimedOutTxs: false },
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Later popup-open cycles can skip timed-out txs.
+    expect(mocks.watchPendingTransactions).toHaveBeenNthCalledWith(
+      3,
+      mocks.pendingTransactions,
+      { skipTimedOutTxs: true },
+    );
+  });
+
+  it('reschedules through the popup port lifecycle listener', async () => {
+    const { addPopupPortLifecycleListener } = await import(
+      '../procedures/popup/popupPortManager'
+    );
+    const { handleWatchPendingTransactions } = await import(
+      './handleWatchPendingTransactions'
+    );
+
+    mocks.getMinPollingIntervalForPendingTxs.mockImplementation((txs) =>
+      txs === mocks.pendingTransactions ? 100 : 1000,
+    );
+
+    await handleWatchPendingTransactions();
+
+    expect(addPopupPortLifecycleListener).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+
+    mocks.setActivePopupPortCount(1);
+    expect(mocks.popupPortLifecycleListeners.size).toBe(1);
+    mocks.popupPortLifecycleListeners.forEach((listener) => listener());
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mocks.watchPendingTransactions).toHaveBeenNthCalledWith(
+      2,
+      mocks.pendingTransactions,
+      { skipTimedOutTxs: false },
+    );
+  });
+});

--- a/src/entries/background/handlers/handleWatchPendingTransactions.ts
+++ b/src/entries/background/handlers/handleWatchPendingTransactions.ts
@@ -1,20 +1,62 @@
+import type { Address } from 'viem';
+
 import { usePendingTransactionsStore } from '~/core/state';
+import { getBatchKeysForNonce } from '~/core/state/batches/updateBatchStatus';
 import { getMinPollingIntervalForPendingTxs } from '~/core/state/networks/timing';
 import { watchPendingTransactions } from '~/core/state/transactions/pendingTransactions/watchPendingTransactions';
+import type { RainbowTransaction } from '~/core/types/transactions';
 import { RainbowError, logger } from '~/logger';
+
+import {
+  addPopupPortLifecycleListener,
+  isPopupOpen,
+} from '../procedures/popup/popupPortManager';
 
 let nextPollTimeout: ReturnType<typeof setTimeout> | null = null;
 let nextPollAt = 0;
-let initialPollDone = false;
+let initialAllPendingPollDone = false;
+let initialBatchOnlyPollDone = false;
 let unsubscribe: (() => void) | null = null;
+
+function isBatchTx(tx: RainbowTransaction, address: Address): boolean {
+  return getBatchKeysForNonce(tx.nonce, tx.chainId, address).length > 0;
+}
+
+/**
+ * Returns pending txs that should be polled right now.
+ * - Popup open: all pending txs
+ * - Popup closed: only EIP-5792 batch txs
+ */
+function getPendingTxPollScope(): {
+  pollablePendingTxs: Record<Address, RainbowTransaction[]>;
+  isPollingAllPendingTxs: boolean;
+} {
+  const { pendingTransactions } = usePendingTransactionsStore.getState();
+  const isPollingAllPendingTxs = isPopupOpen();
+
+  if (isPollingAllPendingTxs) {
+    return { pollablePendingTxs: pendingTransactions, isPollingAllPendingTxs };
+  }
+
+  const result: Record<string, RainbowTransaction[]> = {};
+
+  for (const [addr, txs] of Object.entries(pendingTransactions)) {
+    const filtered = txs.filter((tx) => isBatchTx(tx, addr as Address));
+    if (filtered.length > 0) {
+      result[addr] = filtered;
+    }
+  }
+
+  return { pollablePendingTxs: result, isPollingAllPendingTxs };
+}
 
 function scheduleNextPoll(): void {
   if (nextPollTimeout) {
     clearTimeout(nextPollTimeout);
   }
 
-  const { pendingTransactions } = usePendingTransactionsStore.getState();
-  const intervalMs = getMinPollingIntervalForPendingTxs(pendingTransactions);
+  const { pollablePendingTxs } = getPendingTxPollScope();
+  const intervalMs = getMinPollingIntervalForPendingTxs(pollablePendingTxs);
 
   nextPollAt = Date.now() + intervalMs;
 
@@ -32,8 +74,8 @@ function scheduleNextPoll(): void {
 function maybeReschedule(): void {
   if (!nextPollTimeout) return;
 
-  const { pendingTransactions } = usePendingTransactionsStore.getState();
-  const newIntervalMs = getMinPollingIntervalForPendingTxs(pendingTransactions);
+  const { pollablePendingTxs } = getPendingTxPollScope();
+  const newIntervalMs = getMinPollingIntervalForPendingTxs(pollablePendingTxs);
   const remaining = Math.max(0, nextPollAt - Date.now());
 
   if (newIntervalMs < remaining) {
@@ -47,11 +89,20 @@ function maybeReschedule(): void {
 }
 
 async function runPollCycle(): Promise<void> {
-  const skipTimedOutTxs = initialPollDone;
-  initialPollDone = true;
+  const { pollablePendingTxs, isPollingAllPendingTxs } =
+    getPendingTxPollScope();
+  const skipTimedOutTxs = isPollingAllPendingTxs
+    ? initialAllPendingPollDone
+    : initialBatchOnlyPollDone;
+  if (isPollingAllPendingTxs) {
+    initialAllPendingPollDone = true;
+    initialBatchOnlyPollDone = true;
+  } else {
+    initialBatchOnlyPollDone = true;
+  }
 
   try {
-    await watchPendingTransactions({ skipTimedOutTxs });
+    await watchPendingTransactions(pollablePendingTxs, { skipTimedOutTxs });
   } catch (e) {
     logger.error(
       new RainbowError('watchPendingTransactions failed', { cause: e }),
@@ -68,6 +119,8 @@ export async function handleWatchPendingTransactions(): Promise<void> {
       (s) => s.pendingTransactions,
       maybeReschedule,
     );
+
+    addPopupPortLifecycleListener(maybeReschedule);
   }
 
   await usePendingTransactionsStore.persist.hydrationPromise();

--- a/src/entries/background/procedures/popup/popupPortManager.ts
+++ b/src/entries/background/procedures/popup/popupPortManager.ts
@@ -8,13 +8,32 @@ const POPUP_INSTANCE_DATA_EXPIRY = 180000; // 3 minutes
 
 // Track active popup ports
 const activePopupPorts = new Set<chrome.runtime.Port>();
+const popupPortLifecycleListeners = new Set<() => void>();
+
+const notifyPopupPortLifecycleListeners = () => {
+  for (const listener of popupPortLifecycleListeners) {
+    try {
+      listener();
+    } catch (error) {
+      logger.error(
+        new RainbowError('Error notifying popup port lifecycle listener', {
+          cause: error,
+        }),
+      );
+    }
+  }
+};
 
 /**
  * Handles popup port disconnect - sets expiry and checks for immediate lock
  */
 const handlePopupDisconnect = async (port: chrome.runtime.Port) => {
   // Remove from active ports
-  activePopupPorts.delete(port);
+  const didDeletePort = activePopupPorts.delete(port);
+
+  if (didDeletePort) {
+    notifyPopupPortLifecycleListeners();
+  }
 
   // Set expiry timestamp for popup instance data cleanup
   await SessionStorage.set('expiry', Date.now() + POPUP_INSTANCE_DATA_EXPIRY);
@@ -53,6 +72,7 @@ export const registerPopupPort = (port: chrome.runtime.Port) => {
   }
 
   activePopupPorts.add(port);
+  notifyPopupPortLifecycleListeners();
 
   port.onDisconnect.addListener(() => {
     void handlePopupDisconnect(port);
@@ -63,3 +83,19 @@ export const registerPopupPort = (port: chrome.runtime.Port) => {
  * Gets the count of active popup ports
  */
 export const getActivePopupPortCount = () => activePopupPorts.size;
+
+/**
+ * Whether at least one popup port is currently connected
+ */
+export const isPopupOpen = () => getActivePopupPortCount() > 0;
+
+/**
+ * Subscribes to popup port open/close lifecycle changes
+ */
+export const addPopupPortLifecycleListener = (listener: () => void) => {
+  popupPortLifecycleListeners.add(listener);
+
+  return () => {
+    popupPortLifecycleListeners.delete(listener);
+  };
+};


### PR DESCRIPTION
Fixes: https://linear.app/rainbow/issue/BX-2160/investigate-bx-traffic-spike-on-gettransactionbyhash

## Why?

The pending transaction polling moved into the background service worker in `v1.6.3` so `wallet_getCallsStatus` could keep working after the popup closed. That also caused regular pending transactions to be polled continuously in the background, which drove a large increase in `GetTransactionByHash` traffic even though those transactions only need to be refreshed while the popup is open.

This change narrows background polling back to the flows that actually need it. Normal pending transactions continue to get the same responsive polling while the popup is open, and EIP-5792 batch transactions still keep their status up to date after the popup closes.

## Approach

The background watcher now derives the pollable pending transaction set from popup connection state and passes that snapshot into the polling worker. When the popup is open, it polls all pending transactions; when it is closed, it polls only transactions tied to active EIP-5792 batches.

## Testing

See the video I've attached. There I mock 404 for `GetTransactionByHash` so it's visible that in batch flow it does poll in the background. In the non batch flow (revoke.cash) it only call `GetTransactionByHash` after I've opened popup (it stops polling because `ListTransactions` is firing at the same time and it also have updated status for the transaction).[Screen Recording 2026-04-17 at 14.00.24.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/92a0615f-5ac5-4efb-a9ce-0bcc8a0b2e5b.mov" />](https://app.graphite.com/user-attachments/video/92a0615f-5ac5-4efb-a9ce-0bcc8a0b2e5b.mov)

- Submit a regular transaction, (usually the popup is closed automatically before it confirms), then reopen the wallet later and verify that the transaction is still shown as in progress at first but quickly resolves to its actual state because background polling was off.
- Execute a 5792 `wallet_sendCalls` batch (for example, on https://jumper.xyz/), then reopen the wallet later and verify that the transaction has already resolved to its actual state because background polling was on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background polling scope and scheduling based on popup connection state; mistakes could cause pending transactions to stop updating or increase polling frequency unexpectedly. Also optimizes batch status updates by sharing a single receipt fetch across batches, which could affect batch resolution if receipt handling is wrong.
> 
> **Overview**
> Reduces background service-worker RPC load by **polling only EIP-5792 batch-related pending transactions when the popup is closed**, while continuing to poll *all* pending transactions when the popup is open.
> 
> Refactors the polling pipeline so `handleWatchPendingTransactions` computes the pollable pending-tx snapshot (and separate initial-poll state for all-vs-batch-only) and passes it into `watchPendingTransactions`, and adds popup open/close lifecycle notifications to reschedule polling immediately on popup state changes.
> 
> Separately, `updateBatchesForMinedTx` now fetches a transaction receipt once per mined tx and reuses it across all matching batches to avoid redundant receipt RPC calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc11247151a6e028008973a40fe0f80a13b41836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->