### PR TITLE
feat: set Hyperliquid referrer

### DIFF
--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./build/background.js",
-      "maxSize": "4MB"
+      "maxSize": "4.1MB"
     },
     {
       "path": "./build/popup.js",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@ledgerhq/hw-transport-webhid": "6.30.0",
     "@metamask/browser-passworder": "6.0.0",
     "@metamask/eth-sig-util": "7.0.1",
+    "@nktkas/hyperliquid": "0.32.2",
     "@orpc/client": "1.8.6",
     "@orpc/contract": "1.8.6",
     "@orpc/server": "1.8.6",

--- a/src/core/hyperliquid/referral.ts
+++ b/src/core/hyperliquid/referral.ts
@@ -1,0 +1,166 @@
+import * as hl from '@nktkas/hyperliquid';
+import { AbstractViemLocalAccount } from '@nktkas/hyperliquid/signing';
+import type { Address, TypedDataDefinition } from 'viem';
+
+import { getWallet, signTypedData } from '~/core/keychain';
+import { KeychainType } from '~/core/types/keychainTypes';
+import { wait } from '~/core/utils/time';
+import { logger } from '~/logger';
+
+const HYPERLIQUID_HOSTS = new Set(['app.hyperliquid.xyz']);
+const RAINBOW_REFERRAL_CODE = 'RNBW';
+const HYPERLIQUID_REFERRAL_POLL_INTERVAL_MS = 5000;
+const HYPERLIQUID_REFERRAL_POLL_TIMEOUT_MS = 120000;
+
+type HyperliquidReferralTerminalState =
+  | 'already_referred'
+  | 'success'
+  | 'unsupported_wallet';
+
+type HyperliquidReferralState =
+  | { kind: 'idle' }
+  | { kind: 'processing'; promise: Promise<void> }
+  | { kind: 'terminal'; terminalState: HyperliquidReferralTerminalState };
+
+type HyperliquidReferralAttemptResult = 'done' | 'retry';
+
+const hlTransport = new hl.HttpTransport();
+const infoClient = new hl.InfoClient({
+  transport: hlTransport,
+});
+
+const referralStates = new Map<string, HyperliquidReferralState>();
+
+const getAddressKey = (address: Address) => address.toLowerCase();
+
+const getState = (address: Address): HyperliquidReferralState =>
+  referralStates.get(getAddressKey(address)) ?? { kind: 'idle' };
+
+const setState = (address: Address, state: HyperliquidReferralState) => {
+  referralStates.set(getAddressKey(address), state);
+};
+
+const getAbstractWallet = (address: Address): AbstractViemLocalAccount => ({
+  address,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  signTypedData(params, _options) {
+    return signTypedData({
+      address,
+      message: {
+        type: 'sign_typed_data',
+        data: params as unknown as TypedDataDefinition,
+      },
+    }) as Promise<`0x${string}`>;
+  },
+});
+
+const runAttempt = async (
+  address: Address,
+): Promise<HyperliquidReferralAttemptResult> => {
+  try {
+    const wallet = await getWallet(address);
+    if (
+      !wallet ||
+      wallet.type === KeychainType.ReadOnlyKeychain ||
+      wallet.type === KeychainType.HardwareWalletKeychain
+    ) {
+      setState(address, {
+        kind: 'terminal',
+        terminalState: 'unsupported_wallet',
+      });
+      return 'done';
+    }
+
+    const check = await infoClient.preTransferCheck({
+      user: address,
+      source: address,
+    });
+    if (!check.userExists) {
+      return 'retry';
+    }
+
+    const referral = await infoClient.referral({ user: address });
+    if (referral.referredBy) {
+      setState(address, {
+        kind: 'terminal',
+        terminalState: 'already_referred',
+      });
+      return 'done';
+    }
+
+    const exchangeClient = new hl.ExchangeClient({
+      wallet: getAbstractWallet(address),
+      transport: hlTransport,
+    });
+    await exchangeClient.setReferrer({ code: RAINBOW_REFERRAL_CODE });
+    setState(address, { kind: 'terminal', terminalState: 'success' });
+    return 'done';
+  } catch (error) {
+    logger.warn('Failed to ensure Hyperliquid referral', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return 'retry';
+  }
+};
+
+const runWorkflow = async ({
+  address,
+  poll,
+}: {
+  address: Address;
+  poll: boolean;
+}): Promise<void> => {
+  const maxAttempts = poll
+    ? Math.floor(
+        HYPERLIQUID_REFERRAL_POLL_TIMEOUT_MS /
+          HYPERLIQUID_REFERRAL_POLL_INTERVAL_MS,
+      ) + 1
+    : 1;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // We want this code to run serially
+    // eslint-disable-next-line no-await-in-loop
+    const result = await runAttempt(address);
+    if (result === 'done') {
+      return;
+    }
+
+    if (attempt === maxAttempts - 1) {
+      setState(address, { kind: 'idle' });
+      return;
+    }
+
+    // We want this code to run serially
+    // eslint-disable-next-line no-await-in-loop
+    await wait(HYPERLIQUID_REFERRAL_POLL_INTERVAL_MS);
+  }
+};
+
+export const isHyperliquidHost = (host: string) => HYPERLIQUID_HOSTS.has(host);
+
+export const ensureHyperliquidReferral = async ({
+  address,
+  poll = false,
+}: {
+  address: Address;
+  poll?: boolean;
+}): Promise<void> => {
+  const state = getState(address);
+
+  if (state.kind === 'terminal') return;
+  if (state.kind === 'processing') {
+    const { promise } = state;
+    await promise;
+    if (!poll) {
+      return;
+    }
+  }
+
+  if (getState(address).kind !== 'idle') {
+    return;
+  }
+
+  const promise = runWorkflow({ address, poll });
+  setState(address, { kind: 'processing', promise });
+  await promise;
+};

--- a/src/core/utils/time.ts
+++ b/src/core/utils/time.ts
@@ -2,6 +2,11 @@ import parseMilliseconds from 'parse-ms';
 
 import { i18n } from '../languages';
 
+export const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 const buildLocalizedTimeUnitString = ({
   plural,
   short,

--- a/src/entries/background/dapps/hooks.ts
+++ b/src/entries/background/dapps/hooks.ts
@@ -1,0 +1,91 @@
+import { type Address, getAddress } from 'viem';
+
+import type { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
+import { getDappHost, isValidUrl } from '~/core/utils/connectedApps';
+import { getSigningRequestDisplayDetails } from '~/core/utils/signMessages';
+import { logger } from '~/logger';
+
+import { hyperliquidDappHook } from './hyperliquid';
+import type { DappHook } from './types';
+
+const DAPP_HOOKS: readonly DappHook[] = [hyperliquidDappHook];
+
+const getMatchingDappHooks = (host: string) =>
+  DAPP_HOOKS.filter((hook) => hook.matchesHost(host));
+
+const getRequestAddress = (request: ProviderRequestPayload): Address | null => {
+  switch (request.method) {
+    case 'personal_sign':
+    case 'eth_signTypedData':
+    case 'eth_signTypedData_v3':
+    case 'eth_signTypedData_v4':
+      return getSigningRequestDisplayDetails(request).address;
+    case 'eth_sendTransaction':
+    case 'wallet_sendCalls': {
+      const from = request.params?.[0];
+      if (
+        from &&
+        typeof from === 'object' &&
+        'from' in from &&
+        typeof from.from === 'string'
+      ) {
+        return getAddress(from.from);
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+};
+
+export const runDappSessionAddedHooks = async ({
+  address,
+  host,
+}: {
+  address: Parameters<NonNullable<DappHook['onSessionAdded']>>[0]['address'];
+  host: string;
+}) => {
+  const hooks = getMatchingDappHooks(host);
+  await Promise.all(
+    hooks.map(async (hook) => {
+      try {
+        await hook.onSessionAdded?.({ address, host });
+      } catch (error) {
+        logger.warn('Dapp session hook failed', {
+          error: error instanceof Error ? error.message : String(error),
+          host,
+        });
+      }
+    }),
+  );
+};
+
+export const runApprovedProviderRequestHooks = async (
+  request: ProviderRequestPayload,
+) => {
+  const senderUrl = request.meta?.sender.url || '';
+  const host = (isValidUrl(senderUrl) && getDappHost(senderUrl)) || '';
+  if (!host) {
+    return;
+  }
+
+  const address = getRequestAddress(request);
+  if (!address) {
+    return;
+  }
+
+  const hooks = getMatchingDappHooks(host);
+  await Promise.all(
+    hooks.map(async (hook) => {
+      try {
+        await hook.onApprovedProviderRequest?.({ address, host, request });
+      } catch (error) {
+        logger.warn('Dapp approved request hook failed', {
+          error: error instanceof Error ? error.message : String(error),
+          host,
+          method: request.method,
+        });
+      }
+    }),
+  );
+};

--- a/src/entries/background/dapps/hyperliquid.ts
+++ b/src/entries/background/dapps/hyperliquid.ts
@@ -1,0 +1,32 @@
+import {
+  ensureHyperliquidReferral,
+  isHyperliquidHost,
+} from '~/core/hyperliquid/referral';
+
+import type { DappHook } from './types';
+
+const HYPERLIQUID_RELEVANT_APPROVED_METHODS = new Set([
+  'eth_sendTransaction',
+  'wallet_sendCalls',
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+  'personal_sign',
+]);
+
+const isRelevantHyperliquidApprovedMethod = (method: string) =>
+  HYPERLIQUID_RELEVANT_APPROVED_METHODS.has(method);
+
+export const hyperliquidDappHook: DappHook = {
+  matchesHost: isHyperliquidHost,
+  async onApprovedProviderRequest({ address, request }) {
+    if (!isRelevantHyperliquidApprovedMethod(request.method)) {
+      return;
+    }
+
+    await ensureHyperliquidReferral({ address, poll: true });
+  },
+  async onSessionAdded({ address }) {
+    await ensureHyperliquidReferral({ address });
+  },
+};

--- a/src/entries/background/dapps/types.ts
+++ b/src/entries/background/dapps/types.ts
@@ -1,0 +1,20 @@
+import type { Address } from 'viem';
+
+import type { ProviderRequestPayload } from '~/core/transports/providerRequestTransport';
+
+export type DappHookContext = {
+  address: Address;
+  host: string;
+};
+
+export type DappApprovedProviderRequestContext = DappHookContext & {
+  request: ProviderRequestPayload;
+};
+
+export type DappHook = {
+  matchesHost: (host: string) => boolean;
+  onApprovedProviderRequest?: (
+    context: DappApprovedProviderRequestContext,
+  ) => Promise<void> | void;
+  onSessionAdded?: (context: DappHookContext) => Promise<void> | void;
+};

--- a/src/entries/background/handlers/handleProviderRequest.ts
+++ b/src/entries/background/handlers/handleProviderRequest.ts
@@ -39,6 +39,7 @@ import { getDappHost, isValidUrl } from '~/core/utils/connectedApps';
 import { POPUP_DIMENSIONS } from '~/core/utils/dimensions';
 import { WELCOME_URL, goToNewTab } from '~/core/utils/tabs';
 import { getProvider } from '~/core/viem/clientToProvider';
+import { runApprovedProviderRequestHooks } from '~/entries/background/dapps/hooks';
 import { IN_DAPP_NOTIFICATION_STATUS } from '~/entries/iframe/notification';
 
 const MAX_REQUEST_PER_SECOND = 10;
@@ -162,6 +163,8 @@ const messengerProviderRequest = async (request: ProviderRequestPayload) => {
   if (status === 'REJECTED') {
     throw new UserRejectedRequestError(Error('User rejected the request.'));
   }
+  void runApprovedProviderRequestHooks(request);
+
   return payload as object;
 };
 

--- a/src/entries/background/procedures/popup/state/sessions.ts
+++ b/src/entries/background/procedures/popup/state/sessions.ts
@@ -7,6 +7,7 @@ import { useAppConnectionWalletSwitcherStore } from '~/core/state/appConnectionW
 import { useAppSessionsStore } from '~/core/state/appSessions';
 import { getDappHost, isValidUrl } from '~/core/utils/connectedApps';
 import { toHex } from '~/core/utils/hex';
+import { runDappSessionAddedHooks } from '~/entries/background/dapps/hooks';
 
 const messenger = initializeMessenger({ connect: 'inpage' });
 
@@ -56,6 +57,8 @@ const addSessionHandler = os
     const sessions = useAppSessionsStore
       .getState()
       .addSession({ host, address, chainId, url });
+
+    void runDappSessionAddedHooks({ address, host });
 
     // Forward events to inpage
     messenger.send(`accountsChanged:${host}`, address);

--- a/src/entries/popup/handlers/retry.ts
+++ b/src/entries/popup/handlers/retry.ts
@@ -1,11 +1,7 @@
+import { wait } from '~/core/utils/time';
 import { logger } from '~/logger';
 
 type AllowPromise<T> = T | Promise<T>;
-
-export const wait = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 export async function retry<T>(
   fn: () => AllowPromise<T>,

--- a/src/entries/popup/pendingTransactionCleanup.ts
+++ b/src/entries/popup/pendingTransactionCleanup.ts
@@ -12,8 +12,7 @@ import {
   MinedTransaction,
   RainbowTransaction,
 } from '~/core/types/transactions';
-
-import { wait } from './handlers/retry';
+import { wait } from '~/core/utils/time';
 
 type ConsolidatedPage = { transactions: RainbowTransaction[] };
 

--- a/static/allowlist.json
+++ b/static/allowlist.json
@@ -23,6 +23,7 @@
     "https://*.live.ledger.com",
     "https://nftp.rainbow.me/",
     "https://gateway-arbitrum.network.thegraph.com",
-    "https://ccip-v2.ens.xyz"
+    "https://ccip-v2.ens.xyz",
+    "https://api.hyperliquid.xyz"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,6 +4060,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nktkas/hyperliquid@npm:0.32.2":
+  version: 0.32.2
+  resolution: "@nktkas/hyperliquid@npm:0.32.2"
+  dependencies:
+    "@nktkas/rews": "npm:^2"
+    "@noble/hashes": "npm:^2"
+    valibot: "npm:1.3.1"
+  checksum: 10c0/5b337d5c244deb445e3f150676e23a9fa99f3c20190b473888f1fcce66de4b47f4fad8b37b54ffbe59c01b17ded62aa2768a99e64da9bf3f59a8d12f34ffc949
+  languageName: node
+  linkType: hard
+
+"@nktkas/rews@npm:^2":
+  version: 2.1.1
+  resolution: "@nktkas/rews@npm:2.1.1"
+  checksum: 10c0/5ceaf48d0dd456fd98988238fb6b2a317e8b3b47be5c573f4caa72d2b12dee6374da0f68001d1e1430c684648db19a7198482d54e06c97446f3393caacd98985
+  languageName: node
+  linkType: hard
+
 "@noble/ciphers@npm:^1.3.0":
   version: 1.3.0
   resolution: "@noble/ciphers@npm:1.3.0"
@@ -4151,6 +4169,13 @@ __metadata:
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: 10c0/2482cce3bce6a596626f94ca296e21378e7a5d4c09597cbc46e65ffacc3d64c8df73111f2265444e36a3168208628258bbbaccba2ef24f65f58b2417638a20e7
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^2":
+  version: 2.2.0
+  resolution: "@noble/hashes@npm:2.2.0"
+  checksum: 10c0/cad8630c504d6b9271984f685cd0af9101b40988fc2dfbe17ccdf068a9941f95cc5c9957d89e9ca4b7ca94c15cb35f93510c5d53a09fbcc83ee503b93d0a1034
   languageName: node
   linkType: hard
 
@@ -9517,6 +9542,7 @@ __metadata:
     "@ledgerhq/hw-transport-webhid": "npm:6.30.0"
     "@metamask/browser-passworder": "npm:6.0.0"
     "@metamask/eth-sig-util": "npm:7.0.1"
+    "@nktkas/hyperliquid": "npm:0.32.2"
     "@orpc/client": "npm:1.8.6"
     "@orpc/contract": "npm:1.8.6"
     "@orpc/server": "npm:1.8.6"
@@ -23540,6 +23566,18 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^1.6.0"
   checksum: 10c0/aaa6491ee0505010a818a98bd7abdb30c0136a93eac12106b836e1afb519759ea4da795cceaf7fe871d26ed6cb669e46fd48533d6f8107a23213d723a028f805
+  languageName: node
+  linkType: hard
+
+"valibot@npm:1.3.1":
+  version: 1.3.1
+  resolution: "valibot@npm:1.3.1"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/e20a4097fa726f57530da1e64558af47ddd2303129c77978fe93c522c66cf4c79540ea3af864523589283ea25e347c3d65b8044fa4913376208dde576b9f6382
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/BX-2034/add-referral-code-to-hyperliquid-signups-from-rainbows-bx

## Description

Sets Rainbow as the Hyperliquid referrer when a user connects to or approves relevant requests from `app.hyperliquid.xyz`.

The flow only runs for supported local wallets, skips users who already have a referrer, and retries briefly when Hyperliquid has not created the user yet. This lets referral attribution happen in the background without blocking the approved dapp request.

## Testing

- Connect Rainbow to `app.hyperliquid.xyz` with a fresh supported wallet and confirm the referrer is set to `RNBW`.
- Confirm wallets that already have a Hyperliquid referrer are left unchanged.
- Confirm read-only and hardware wallets do not attempt to sign the referrer request.