### PR TITLE
chore: add Cursor Cloud specific instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,8 @@ Key stores include: `currentSettings`, `wallets`, `transactions`, `assets`, `net
 
 - **Node.js v22.17.0** is required (specified in `.nvmrc`). Load it with `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"`.
 - **Yarn 4.2.2** is provided via corepack (`corepack enable`). The project uses Yarn Berry with `nodeLinker: node-modules`.
-- A `.env` file must exist in the repo root. If missing, copy from `.env.example`. The actual API keys come from the private `browser-extension-env` repo and are not available in cloud environments — the extension will build and load without them but the popup UI will show errors due to missing service keys.
+- A `.env` file must exist in the repo root. If missing, copy from `.env.example` and populate API keys from environment variables. Critical: `SECURE_WALLET_HASH_KEY` (a hex string) is required but absent from `.env.example` — without it the extension throws on init and the popup renders blank.
+- **Chrome for Testing 139** must be installed to match the pinned chromedriver 139 (see `e2e/browsers.json`). The system Chrome 147 does NOT work with `--load-extension`. Install via: `npx @puppeteer/browsers install chrome@139.0.7258.138` then symlink to `/opt/google/chrome/chrome`.
 
 ### Key gotchas
 
@@ -147,5 +148,5 @@ Key stores include: `currentSettings`, `wallets`, `transactions`, `assets`, `net
 - **LavaMoat policy warnings** during `yarn policy` about "dynamic require" in typescript are expected and non-blocking.
 - **`enableScripts: false`** in `.yarnrc.yml` means most dependency lifecycle scripts are disabled. The `lavamoat.allowScripts` section in `package.json` controls which packages are allowed to run scripts (chromedriver and geckodriver are allowed).
 - **Unit tests** (`yarn test --run`) use vitest with happy-dom and MSW mocks — no external services required.
-- **E2E tests** require Chrome, chromedriver, Foundry/Anvil, and an `ALCHEMY_DEV_KEY` env var. Chrome v147 is installed in the cloud VM but chromedriver v139 is pinned in devDependencies — this version mismatch may cause E2E failures.
-- **Husky pre-commit hook** runs `yarn lint-staged`. This is set up by `husky install` (the `prepare` script).
+- **E2E tests** require Chrome for Testing 139, chromedriver 139, Foundry/Anvil, and an `ALCHEMY_DEV_KEY` env var.
+- **Husky pre-commit hook** runs `yarn lint-staged`. Ensure nvm is loaded in the shell so `yarn` is on PATH when committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,3 +131,21 @@ Key stores include: `currentSettings`, `wallets`, `transactions`, `assets`, `net
 - Prefix commits and PR titles with a type such as fix, feat, or chore, for example: fix: resolve login bug.
 - Never modify any CHANGELOG.md files. These are managed automatically.
 - Only modify en-US.json locale files; never adjust other locale JSON files.
+
+## Cursor Cloud specific instructions
+
+### Environment prerequisites
+
+- **Node.js v22.17.0** is required (specified in `.nvmrc`). Load it with `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"`.
+- **Yarn 4.2.2** is provided via corepack (`corepack enable`). The project uses Yarn Berry with `nodeLinker: node-modules`.
+- A `.env` file must exist in the repo root. If missing, copy from `.env.example`. The actual API keys come from the private `browser-extension-env` repo and are not available in cloud environments — the extension will build and load without them but the popup UI will show errors due to missing service keys.
+
+### Key gotchas
+
+- **`yarn dev` requires a prior `yarn build`**: The dev webpack config (`webpack.config.dev.js`) requires `build/manifest.json` to exist. Always run `yarn build` before `yarn dev` the first time.
+- **`yarn setup`** is the canonical setup command. It runs: `yarn install`, `yarn ds:install`, `yarn ds:generate-symbols`, `yarn patch-package`, and `yarn policy`. If `yarn setup` fails with "Couldn't find the node_modules state file", run `yarn install` first, then re-run `yarn setup`.
+- **LavaMoat policy warnings** during `yarn policy` about "dynamic require" in typescript are expected and non-blocking.
+- **`enableScripts: false`** in `.yarnrc.yml` means most dependency lifecycle scripts are disabled. The `lavamoat.allowScripts` section in `package.json` controls which packages are allowed to run scripts (chromedriver and geckodriver are allowed).
+- **Unit tests** (`yarn test --run`) use vitest with happy-dom and MSW mocks — no external services required.
+- **E2E tests** require Chrome, chromedriver, Foundry/Anvil, and an `ALCHEMY_DEV_KEY` env var. Chrome v147 is installed in the cloud VM but chromedriver v139 is pinned in devDependencies — this version mismatch may cause E2E failures.
+- **Husky pre-commit hook** runs `yarn lint-staged`. This is set up by `husky install` (the `prepare` script).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes N/A

## What changed (plus any additional context for devs)

Added a `## Cursor Cloud specific instructions` section to `CLAUDE.md` (which `AGENTS.md` symlinks to) with key development environment gotchas discovered during cloud agent setup:

- Node.js v22.17.0 and Yarn 4.2.2 prerequisites
- `.env` file requirements — including the undocumented `SECURE_WALLET_HASH_KEY` (a hex string required at runtime, absent from `.env.example`)
- Chrome for Testing 139 must be used instead of system Chrome 147 — the `--load-extension` flag silently fails with Chrome 147
- `yarn dev` requiring a prior `yarn build` (due to `webpack.config.dev.js` needing `build/manifest.json`)
- `yarn setup` failure recovery when `node_modules` state file is missing
- LavaMoat policy warnings being expected and non-blocking
- Unit test and E2E test environment requirements
- Husky pre-commit hook needing nvm loaded for `yarn` to be on PATH

## Screen recordings / screenshots

[rainbow_wallet_creation_demo.mp4](https://cursor.com/agents/bc-b453b7a5-f66f-4a9c-a064-1a0b5e36e6a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frainbow_wallet_creation_demo.mp4)
Full wallet creation flow: onboarding → create wallet → set password → ready screen.

[Rainbow wallet onboarding screen](https://cursor.com/agents/bc-b453b7a5-f66f-4a9c-a064-1a0b5e36e6a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopup_working.png)
Extension popup rendering correctly with the onboarding UI.

[Rainbow is ready to use screen](https://cursor.com/agents/bc-b453b7a5-f66f-4a9c-a064-1a0b5e36e6a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_final.png)
Wallet created successfully — "Rainbow is ready to use" with keyboard shortcut displayed.

## What to test

This is a documentation-only change. Verify the content in `CLAUDE.md` is accurate and helpful.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b453b7a5-f66f-4a9c-a064-1a0b5e36e6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b453b7a5-f66f-4a9c-a064-1a0b5e36e6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

